### PR TITLE
docs: add README Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,64 @@ license, subscription, private contract, or other written permission.
 - It does not include SMTP, SMS, OAuth, Telegram, or MAX SDK implementations in v0.1.
 - It does not silently merge two existing users by email.
 
+## Diagrams
+
+```mermaid
+flowchart LR
+  Provider["AuthProvider<br/>external assertion"] --> Registry["ProviderRegistry<br/>SDK-free lookup"]
+  Registry --> Service["AuthService<br/>signIn / link / unlink / merge"]
+  Policy["AuthPolicy<br/>auto-link / merge / re-auth"] --> Service
+  Service --> Repos["Repositories<br/>users / identities / sessions / verifications"]
+  Service --> Audit["AuditLog<br/>security events"]
+  Service --> Senders["Sender ports<br/>email / SMS"]
+  Testing["@alyldas/uniauth/testing<br/>in-memory kit"] --> Service
+```
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Provider as AuthProvider
+  participant Service as AuthService
+  participant Policy as AuthPolicy
+  participant Store as Repositories
+  participant Audit
+
+  App->>Provider: finish provider flow
+  Provider-->>App: ProviderIdentityAssertion
+  App->>Service: signIn(assertion)
+  Service->>Store: find exact (provider, providerUserId)
+  alt identity exists
+    Store-->>Service: existing user and identity
+  else new provider identity
+    Service->>Policy: canAutoLink(assertion, candidates)
+    Policy-->>Service: allow or deny
+    Service->>Store: create user or link identity
+  end
+  Service->>Store: create local session
+  Service->>Audit: auth.session_created
+  Service-->>App: neutral AuthResult
+```
+
+```mermaid
+flowchart TB
+  Exact["Exact provider identity wins<br/>(provider, providerUserId)"]:::safe
+  Merge["No silent merge<br/>email/profile hints are not ownership"]:::danger
+  PolicyGate["Auto-link only through explicit policy"]:::warn
+  LastIdentity["Cannot unlink the last active sign-in method"]:::safe
+  Secrets["Verification secrets are stored as hashes"]:::safe
+  Neutral["Public responses stay neutral"]:::safe
+
+  Exact --> PolicyGate
+  Merge --> PolicyGate
+  PolicyGate --> LastIdentity
+  PolicyGate --> Secrets
+  Secrets --> Neutral
+
+  classDef safe fill:#ecfdf5,stroke:#059669,color:#064e3b
+  classDef warn fill:#fffbeb,stroke:#d97706,color:#78350f
+  classDef danger fill:#fef2f2,stroke:#dc2626,color:#7f1d1d
+```
+
 ## Install
 
 Install from GitHub Packages:

--- a/docs/badges/ci.svg
+++ b/docs/badges/ci.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="76" height="20" role="img" aria-labelledby="ci-badge-title">
-  <title id="ci-badge-title">CI planned</title>
-  <rect width="76" height="20" fill="#555"/>
-  <rect x="24" width="52" height="20" fill="#0a7f42"/>
-  <text x="12" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">CI</text>
-  <text x="50" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">planned</text>
-</svg>

--- a/docs/badges/license.svg
+++ b/docs/badges/license.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="142" height="20" role="img" aria-labelledby="license-badge-title">
-  <title id="license-badge-title">license PolyForm Strict</title>
-  <rect width="142" height="20" fill="#555"/>
-  <rect x="48" width="94" height="20" fill="#4b5563"/>
-  <text x="24" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">license</text>
-  <text x="95" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">PolyForm Strict</text>
-</svg>

--- a/docs/badges/registry.svg
+++ b/docs/badges/registry.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20" role="img" aria-labelledby="registry-badge-title">
-  <title id="registry-badge-title">registry GitHub Packages</title>
-  <rect width="150" height="20" fill="#555"/>
-  <rect x="50" width="100" height="20" fill="#111827"/>
-  <text x="25" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">registry</text>
-  <text x="100" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">GitHub Packages</text>
-</svg>

--- a/docs/badges/typescript.svg
+++ b/docs/badges/typescript.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="110" height="20" role="img" aria-labelledby="typescript-badge-title">
-  <title id="typescript-badge-title">TypeScript strict</title>
-  <rect width="110" height="20" fill="#555"/>
-  <rect x="70" width="40" height="20" fill="#3178c6"/>
-  <text x="35" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">TypeScript</text>
-  <text x="90" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">strict</text>
-</svg>

--- a/docs/badges/version.svg
+++ b/docs/badges/version.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="92" height="20" role="img" aria-labelledby="version-badge-title">
-  <title id="version-badge-title">version 0.1.0</title>
-  <rect width="92" height="20" fill="#555"/>
-  <rect x="50" width="42" height="20" fill="#2563eb"/>
-  <text x="25" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">version</text>
-  <text x="71" y="14" fill="#fff" font-family="Verdana, sans-serif" font-size="11" text-anchor="middle">0.1.0</text>
-</svg>


### PR DESCRIPTION
## Summary
- add Mermaid diagrams for architecture, sign-in flow, and security invariants
- remove obsolete local SVG badge assets now that README uses live badges

## Checks
- npm run check