### PR TITLE
chore: add consumer smoke gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,11 @@ This repository keeps package source and documentation in git. Do not commit gen
 - `node_modules`
 - `*.tgz`
 
-`dist` is created by `npm run build`, `npm run test:exports`, `npm run pack:dry`, and
-`npm run prepare`.
+`dist` is created by `npm run build`, `npm run test:exports`, `npm run test:consumer`,
+`npm run pack:dry`, and `npm run prepare`.
+
+`npm run test:consumer` creates a temporary external npm project, installs the packed tarball, and
+imports `@alyldas/uniauth` plus `@alyldas/uniauth/testing` by package name.
 
 To keep generated `dist` and `coverage` output inside a Node 22 Alpine container, run:
 
@@ -220,8 +223,8 @@ Run the package gate before publishing:
 npm run check
 ```
 
-The gate runs formatting, ESLint, typecheck, 100% coverage, export smoke tests, and
-`npm pack --dry-run`.
+The gate runs formatting, ESLint, typecheck, 100% coverage, export smoke tests, consumer install
+smoke tests, and `npm pack --dry-run`.
 
 The release workflow follows the same Release Please model as `theme-mode`: pushes to `main` update
 a release PR, and merging that PR creates the `v*` tag, GitHub release notes, and GitHub Packages

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
-    "check": "npm run format:check && npm run lint && npm run typecheck && npm run coverage && npm run test:exports && npm run pack:dry",
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run coverage && npm run test:exports && npm run test:consumer && npm run pack:dry",
     "check:compose": "docker compose run --rm --build check",
     "check:docker": "docker build --target check -t alyldas-uniauth-check .",
     "coverage": "vitest run test/*.test.ts --coverage",
@@ -62,6 +62,7 @@
     "pack:dry": "npm pack --dry-run",
     "prepare": "npm run build && npm run hooks:install",
     "test": "vitest run test/*.test.ts",
+    "test:consumer": "node scripts/consumer-smoke.mjs",
     "test:exports": "npm run build && vitest run smoke/exports.test.ts",
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -1,0 +1,107 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const require = createRequire(import.meta.url)
+const packageMetadata = require('../package.json')
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)))
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+    stdio: options.capture ? 'pipe' : 'inherit',
+  })
+
+  if (result.status !== 0) {
+    const suffix = options.cwd ? ` in ${options.cwd}` : ''
+    throw new Error(`Command failed${suffix}: ${command} ${args.join(' ')}`)
+  }
+
+  return result.stdout ?? ''
+}
+
+function parseNpmPackJson(output) {
+  const jsonStart = output.lastIndexOf('\n[')
+  const jsonText = (jsonStart >= 0 ? output.slice(jsonStart + 1) : output).trim()
+
+  return JSON.parse(jsonText)
+}
+
+const workspace = mkdtempSync(join(tmpdir(), 'uniauth-consumer-smoke-'))
+
+try {
+  const packOutput = run('npm', ['pack', '--pack-destination', workspace, '--json'], {
+    capture: true,
+  })
+  const [packed] = parseNpmPackJson(packOutput)
+
+  if (!packed?.filename) {
+    throw new Error('npm pack did not return a tarball filename.')
+  }
+
+  const packageFile = join(workspace, packed.filename)
+  const consumerDir = join(workspace, 'consumer')
+  mkdirSync(consumerDir)
+  writeFileSync(
+    join(consumerDir, 'package.json'),
+    `${JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        dependencies: {},
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  writeFileSync(
+    join(consumerDir, 'consumer-smoke.mjs'),
+    `import {
+  SessionStatus,
+  UNIAUTH_ATTRIBUTION,
+  createDefaultAuthPolicy,
+} from '${packageMetadata.name}'
+import { createInMemoryAuthKit } from '${packageMetadata.name}/testing'
+
+if (UNIAUTH_ATTRIBUTION.packageName !== '${packageMetadata.name}') {
+  throw new Error('Unexpected package attribution.')
+}
+
+const { service } = createInMemoryAuthKit({
+  policy: createDefaultAuthPolicy({ allowAutoLink: false }),
+})
+
+const result = await service.signIn({
+  assertion: {
+    provider: 'consumer-smoke',
+    providerUserId: 'alice',
+    email: 'alice@example.com',
+    emailVerified: true,
+  },
+})
+
+if (result.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active local session.')
+}
+
+if (!result.isNewUser || !result.isNewIdentity) {
+  throw new Error('Expected a new consumer-smoke user and identity.')
+}
+`,
+  )
+
+  run('npm', ['install', '--no-audit', '--no-fund', packageFile], { cwd: consumerDir })
+  run(process.execPath, ['consumer-smoke.mjs'], { cwd: consumerDir })
+  console.log(`Consumer smoke passed for ${packageMetadata.name}@${packageMetadata.version}.`)
+} finally {
+  if (process.env.UNIAUTH_KEEP_CONSUMER_SMOKE === '1') {
+    console.log(`Consumer smoke workspace kept at ${workspace}.`)
+  } else {
+    rmSync(workspace, { force: true, recursive: true })
+  }
+}


### PR DESCRIPTION
## Summary
- add a consumer smoke script that packs the library, installs it into a temporary external npm project, and imports both public entry points by package name
- include the consumer smoke in npm run check
- document the new release gate behavior

## Checks
- npm run check
- npm run check:compose