### PR TITLE
chore: prepare initial release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Run Release Please
         id: release

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,6 @@ coverage
 
 # Lockfile formatting is managed by npm.
 package-lock.json
+
+# Release Please owns generated changelog formatting.
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- keep Release Please generated changelog formatting out of Prettier checks
- opt the Release Please workflow into Node 24 JavaScript actions execution
- this PR will be squash-merged with a Release-As footer so Release Please regenerates the first release PR as v0.1.0

## Checks
- npm run check