### PR TITLE
fix: add registry smoke release verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ This repository keeps package source and documentation in git. Do not commit gen
 `npm run test:consumer` creates a temporary external npm project, installs the packed tarball, and
 imports `@alyldas/uniauth` plus `@alyldas/uniauth/testing` by package name.
 
+`npm run test:registry` creates a temporary external npm project and installs the published package
+from GitHub Packages. It requires `NODE_AUTH_TOKEN`, `GITHUB_TOKEN`, or an authenticated `gh` CLI
+session with `read:packages`.
+
 To keep generated `dist` and `coverage` output inside a Node 22 Alpine container, run:
 
 ```sh
@@ -228,7 +232,14 @@ smoke tests, and `npm pack --dry-run`.
 
 The release workflow follows the same Release Please model as `theme-mode`: pushes to `main` update
 a release PR, and merging that PR creates the `v*` tag, GitHub release notes, and GitHub Packages
-publish. Configure `RELEASE_PLEASE_TOKEN` as a repository secret before enabling releases.
+publish. This repository uses the `RELEASE_PLEASE_TOKEN` secret for release PR automation and
+`GITHUB_TOKEN` for package publishing.
+
+After a release is published, verify the registry package:
+
+```sh
+npm run test:registry
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test": "vitest run test/*.test.ts",
     "test:consumer": "node scripts/consumer-smoke.mjs",
     "test:exports": "npm run build && vitest run smoke/exports.test.ts",
+    "test:registry": "node scripts/registry-smoke.mjs",
     "typecheck": "tsc -p tsconfig.typecheck.json"
   },
   "keywords": [

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -1,0 +1,102 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const packageMetadata = require('../package.json')
+const registryUrl = 'https://npm.pkg.github.com'
+const packageSpec = `${packageMetadata.name}@${packageMetadata.version}`
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...options.env },
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  })
+
+  if (result.status !== 0) {
+    const suffix = options.cwd ? ` in ${options.cwd}` : ''
+    throw new Error(`Command failed${suffix}: ${command} ${args.join(' ')}`)
+  }
+}
+
+function resolveAuthToken() {
+  if (process.env.NODE_AUTH_TOKEN) {
+    return process.env.NODE_AUTH_TOKEN
+  }
+
+  if (process.env.GITHUB_TOKEN) {
+    return process.env.GITHUB_TOKEN
+  }
+
+  const result = spawnSync('gh', ['auth', 'token'], {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+
+  const token = result.stdout.trim()
+
+  if (result.status === 0 && token) {
+    return token
+  }
+
+  throw new Error(
+    'GitHub Packages registry smoke requires NODE_AUTH_TOKEN, GITHUB_TOKEN, or authenticated gh CLI.',
+  )
+}
+
+const workspace = mkdtempSync(join(tmpdir(), 'uniauth-registry-smoke-'))
+const token = resolveAuthToken()
+
+writeFileSync(
+  join(workspace, '.npmrc'),
+  `@alyldas:registry=${registryUrl}\n//npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}\n`,
+)
+writeFileSync(join(workspace, 'package.json'), '{"private":true,"type":"module"}\n')
+writeFileSync(
+  join(workspace, 'registry-smoke.mjs'),
+  `import { SessionStatus, UNIAUTH_ATTRIBUTION } from '${packageMetadata.name}'
+import { createInMemoryAuthKit } from '${packageMetadata.name}/testing'
+
+const { service } = createInMemoryAuthKit()
+const result = await service.signIn({
+  assertion: {
+    provider: 'registry-smoke',
+    providerUserId: 'alice',
+    email: 'alice@example.com',
+    emailVerified: true,
+  },
+})
+
+if (UNIAUTH_ATTRIBUTION.packageName !== '${packageMetadata.name}') {
+  throw new Error('Unexpected package attribution.')
+}
+
+if (result.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active local session.')
+}
+`,
+)
+
+try {
+  run('npm', ['install', packageSpec, '--no-audit', '--no-fund'], {
+    cwd: workspace,
+    env: {
+      NODE_AUTH_TOKEN: token,
+      NPM_CONFIG_USERCONFIG: join(workspace, '.npmrc'),
+    },
+  })
+  run(process.execPath, ['registry-smoke.mjs'], { cwd: workspace })
+  console.log(`GitHub Packages registry smoke passed for ${packageSpec}.`)
+} finally {
+  if (process.env.UNIAUTH_KEEP_REGISTRY_SMOKE === '1') {
+    console.log(`Registry smoke workspace kept at ${workspace}.`)
+  } else {
+    rmSync(workspace, { force: true, recursive: true })
+  }
+}


### PR DESCRIPTION
## Summary
- add a manual GitHub Packages registry smoke script
- document post-release registry verification
- keep the new registry smoke out of the default local/CI gate because it requires network and package-read auth

## Checks
- npm run test:registry
- npm run check