### PR TITLE
feat: add email OTP sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ license, subscription, private contract, or other written permission.
 - Models `User`, `AuthIdentity`, `Credential`, `Verification`, and `Session` separately.
 - Treats email and phone as optional identity attributes, not mandatory user fields.
 - Orchestrates `signIn`, `link`, `unlink`, `mergeAccounts`, verification, and session revocation.
+- Starts and finishes email OTP sign-in through the headless `EmailSender` port.
 - Creates local session records after successful sign-in.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Exposes ports for repositories, providers, sender infrastructure, audit logs, and transactions.
@@ -31,7 +32,8 @@ license, subscription, private contract, or other written permission.
 - It does not ship frontend pages or UI components.
 - It does not include Express, Fastify, Nest, Nuxt, or Next handlers in core.
 - It does not generate one mandatory ORM schema.
-- It does not include SMTP, SMS, OAuth, Telegram, or MAX SDK implementations in v0.1.
+- It does not include SMTP, SMS, OAuth, Telegram, or MAX SDK implementations in core.
+- It does not send email by itself; email OTP uses the `EmailSender` port you provide.
 - It does not silently merge two existing users by email.
 
 ## Diagrams
@@ -97,7 +99,7 @@ flowchart TB
 Install from GitHub Packages:
 
 ```sh
-npm install @alyldas/uniauth@0.1.0
+npm install @alyldas/uniauth
 ```
 
 Configure the GitHub Packages registry for the package scope:
@@ -116,6 +118,7 @@ Core imports come from the root entry point:
 ```ts
 import {
   DefaultAuthService,
+  EMAIL_OTP_PROVIDER_ID,
   createDefaultAuthPolicy,
   type AuthProvider,
   type AuthService,
@@ -126,7 +129,11 @@ import {
 Testing helpers come from the explicit testing entry point:
 
 ```ts
-import { createInMemoryAuthKit, StaticAuthProvider } from '@alyldas/uniauth/testing'
+import {
+  InMemoryEmailSender,
+  StaticAuthProvider,
+  createInMemoryAuthKit,
+} from '@alyldas/uniauth/testing'
 ```
 
 There are no root side effects. Importing the package does not register providers, touch storage,
@@ -152,10 +159,31 @@ const result = await service.signIn({
 })
 ```
 
+Email OTP sign-in is still headless: `startEmailOtpSignIn` creates a hashed verification secret and
+sends the plain code through the configured `EmailSender`; `finishEmailOtpSignIn` consumes the code
+once and creates a local session.
+
+```ts
+const { service } = createInMemoryAuthKit()
+
+const challenge = await service.startEmailOtpSignIn({
+  email: 'alice@example.com',
+  secret: '123456',
+})
+
+const result = await service.finishEmailOtpSignIn({
+  verificationId: challenge.verificationId,
+  secret: '123456',
+})
+
+console.log(result.identity.provider === EMAIL_OTP_PROVIDER_ID)
+```
+
 ## Entry Points
 
 - `@alyldas/uniauth`: public domain types, service implementation, policy API, ports, errors, and utilities.
-- `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, and test kit.
+- `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, in-memory email
+  sender, and test kit.
 
 ## Attribution
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@ identities, and email/phone are optional identity attributes.
 `DefaultAuthService` owns use-case orchestration:
 
 - `signIn`
+- `startEmailOtpSignIn`
+- `finishEmailOtpSignIn`
 - `link`
 - `unlink`
 - `mergeAccounts`
@@ -23,19 +25,23 @@ identities, and email/phone are optional identity attributes.
 - `createVerification`
 - `consumeVerification`
 
-It delegates authorization decisions to `AuthPolicy` and storage/provider work to ports.
+It delegates authorization decisions to `AuthPolicy` and storage/provider/sender work to ports.
 
 ## Ports
 
 Core defines repository ports, provider registry, sender ports, audit log port, and `UnitOfWork`.
+
+Email OTP sign-in uses the `EmailSender` port. Core creates and hashes the verification secret, but
+the application owns the real SMTP, transactional email, or queue adapter.
 
 `UnitOfWork` is intentionally part of v0.1 so storage adapters can provide real transaction
 boundaries for link, unlink, merge, session, and verification flows.
 
 ## Testing Adapter
 
-`@alyldas/uniauth/testing` provides an in-memory implementation for tests, demos, and examples. It is
-not a production persistence adapter.
+`@alyldas/uniauth/testing` provides an in-memory implementation for tests, demos, and examples. It
+includes an in-memory email sender so OTP flows can be exercised without SMTP. It is not a production
+persistence adapter.
 
 ## Repository Shape
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,34 +8,41 @@
 - Security tests for account takeover and linking invariants.
 - Package exports, CI, `npm run check`, and `npm pack --dry-run`.
 
-## v0.2 - Local Auth Methods
+## v0.2 - Email OTP Sign-In
+
+- Email OTP sign-in over the `EmailSender` port.
+- Neutral start-flow response.
+- Hashed OTP verification secrets.
+- Consume-once finish flow that creates a local session.
+- In-memory email sender for tests, demos, and examples.
+
+## v0.3 - Additional Local Auth Methods
 
 - Email magic link.
-- Email OTP.
 - Phone OTP.
 - Password credential with Argon2id.
 - Rate limit integration ports.
 
-## v0.3 - Messenger Providers
+## v0.4 - Messenger Providers
 
 - Telegram Mini App `initData` contracts and reference implementation.
 - MAX WebApp `initData` contracts and reference implementation.
 
-## v0.4 - OAuth / OIDC Layer
+## v0.5 - OAuth / OIDC Layer
 
 - Generic OAuth/OIDC adapter contract.
 - Trusted provider policy.
 - Provider profile mapping into `ProviderIdentityAssertion`.
 - Optional Better Auth and Auth.js bridge adapters.
 
-## v0.5 - Reference Persistence
+## v0.6 - Reference Persistence
 
 - Postgres reference storage.
 - SQL schema example.
 - Transactional merge flow.
 - Indexes and constraints.
 
-## v0.6 - Production Hardening
+## v0.7 - Production Hardening
 
 - Threat model documentation.
 - Anti-takeover tests.

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,6 +10,8 @@
 - The last active identity cannot be unlinked under the default policy.
 - Merge is an explicit operation and disabled by default.
 - Verification secrets are stored as hashes.
+- Email OTP start responses are neutral and do not expose whether an account exists.
+- Email OTP finish consumes a sign-in verification once before creating a local session.
 - Public errors avoid exposing which user owns an identity.
 
 ## Policy Matrix
@@ -28,6 +30,12 @@
 - Losing the last usable sign-in method.
 - Verification token persistence in plaintext.
 - Provider identity reuse across users.
+
+## Threats Covered in v0.2
+
+- Email OTP account enumeration through start-flow responses.
+- Email OTP replay through consumed verification reuse.
+- Email OTP plaintext persistence in verification storage.
 
 ## Out of Scope for Core
 

--- a/examples/basic-node/index.ts
+++ b/examples/basic-node/index.ts
@@ -7,14 +7,13 @@ export async function runBasicExample(): Promise<void> {
     policy: createDefaultAuthPolicy({ allowAutoLink: false }),
   })
 
-  const result = await service.signIn({
-    assertion: {
-      provider: 'email-otp',
-      providerUserId: 'alice@example.com',
-      email: 'alice@example.com',
-      emailVerified: true,
-      displayName: 'Alice',
-    },
+  const challenge = await service.startEmailOtpSignIn({
+    email: 'alice@example.com',
+    secret: '123456',
+  })
+  const result = await service.finishEmailOtpSignIn({
+    verificationId: challenge.verificationId,
+    secret: '123456',
   })
 
   console.log({

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -62,6 +62,7 @@ try {
   writeFileSync(
     join(consumerDir, 'consumer-smoke.mjs'),
     `import {
+  EMAIL_OTP_PROVIDER_ID,
   SessionStatus,
   UNIAUTH_ATTRIBUTION,
   createDefaultAuthPolicy,
@@ -91,6 +92,23 @@ if (result.session.status !== SessionStatus.Active) {
 
 if (!result.isNewUser || !result.isNewIdentity) {
   throw new Error('Expected a new consumer-smoke user and identity.')
+}
+
+const challenge = await service.startEmailOtpSignIn({
+  email: 'otp@example.com',
+  secret: '123456',
+})
+const otpResult = await service.finishEmailOtpSignIn({
+  verificationId: challenge.verificationId,
+  secret: '123456',
+})
+
+if (otpResult.identity.provider !== EMAIL_OTP_PROVIDER_ID) {
+  throw new Error('Expected the email OTP provider identity.')
+}
+
+if (otpResult.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active email OTP session.')
 }
 `,
   )

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -60,7 +60,7 @@ writeFileSync(
 writeFileSync(join(workspace, 'package.json'), '{"private":true,"type":"module"}\n')
 writeFileSync(
   join(workspace, 'registry-smoke.mjs'),
-  `import { SessionStatus, UNIAUTH_ATTRIBUTION } from '${packageMetadata.name}'
+  `import { EMAIL_OTP_PROVIDER_ID, SessionStatus, UNIAUTH_ATTRIBUTION } from '${packageMetadata.name}'
 import { createInMemoryAuthKit } from '${packageMetadata.name}/testing'
 
 const { service } = createInMemoryAuthKit()
@@ -79,6 +79,23 @@ if (UNIAUTH_ATTRIBUTION.packageName !== '${packageMetadata.name}') {
 
 if (result.session.status !== SessionStatus.Active) {
   throw new Error('Expected an active local session.')
+}
+
+const challenge = await service.startEmailOtpSignIn({
+  email: 'otp@example.com',
+  secret: '123456',
+})
+const otpResult = await service.finishEmailOtpSignIn({
+  verificationId: challenge.verificationId,
+  secret: '123456',
+})
+
+if (otpResult.identity.provider !== EMAIL_OTP_PROVIDER_ID) {
+  throw new Error('Expected the email OTP provider identity.')
+}
+
+if (otpResult.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active email OTP session.')
 }
 `,
 )

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -12,6 +12,7 @@ interface PackageMetadata {
 
 interface CoreExports {
   readonly DefaultAuthService: unknown
+  readonly EMAIL_OTP_PROVIDER_ID: string
   readonly UNIAUTH_ATTRIBUTION: AttributionExports
   readonly getUniauthAttributionNotice: (options?: {
     readonly productName?: string
@@ -22,6 +23,7 @@ interface CoreExports {
 
 interface TestingExports {
   readonly createInMemoryAuthKit: unknown
+  readonly InMemoryEmailSender: unknown
   readonly StaticAuthProvider: unknown
 }
 
@@ -56,6 +58,7 @@ describe('package exports', () => {
     const testing = await import('../dist/testing')
 
     expect(core.DefaultAuthService).toBeTypeOf('function')
+    expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
     expect(core.createDefaultAuthPolicy).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
     expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
@@ -64,6 +67,7 @@ describe('package exports', () => {
       `Smoke App uses ${packageMetadata.name}.`,
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
+    expect(testing.InMemoryEmailSender).toBeTypeOf('function')
     expect(testing.StaticAuthProvider).toBeTypeOf('function')
   })
 
@@ -72,6 +76,7 @@ describe('package exports', () => {
     const testing = require('../dist/testing/index.cjs') as TestingExports
 
     expect(core.DefaultAuthService).toBeTypeOf('function')
+    expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
     expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toMatchObject({
@@ -83,5 +88,6 @@ describe('package exports', () => {
       'Licensing contact',
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
+    expect(testing.InMemoryEmailSender).toBeTypeOf('function')
   })
 })

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,5 +1,6 @@
 import {
   AuthIdentityStatus,
+  EMAIL_OTP_PROVIDER_ID,
   SessionStatus,
   type AuditEvent,
   type AuditEventType,
@@ -11,6 +12,7 @@ import {
   type CreateSessionInput,
   type CreateVerificationInput,
   type CreateVerificationResult,
+  type FinishEmailOtpSignInInput,
   type FinishInput,
   type IdGenerator,
   type IdentityId,
@@ -22,10 +24,13 @@ import {
   type Session,
   type SessionId,
   type SignInInput,
+  type StartEmailOtpSignInInput,
+  type StartEmailOtpSignInResult,
   type UnlinkInput,
   type User,
   type UserId,
   type Verification,
+  VerificationPurpose,
   VerificationStatus,
 } from '../domain/types.js'
 import { UniauthError, UniauthErrorCode, invalidInput } from '../errors'
@@ -34,16 +39,18 @@ import { defaultAuthPolicy } from './policy.js'
 import type {
   AuthServiceInfrastructure,
   AuthServiceRepositories,
+  EmailSender,
   ProviderRegistry,
   UnitOfWork,
 } from '../ports'
 import { createRandomIdGenerator } from '../utils/ids.js'
 import { normalizeEmail, normalizePhone, normalizeTarget } from '../utils/normalization.js'
-import { generateSecret, hashSecret, verifySecret } from '../utils/secrets.js'
+import { generateOtpSecret, generateSecret, hashSecret, verifySecret } from '../utils/secrets.js'
 import { addSeconds, systemClock } from '../utils/time.js'
 
 const DEFAULT_SESSION_TTL_SECONDS = 60 * 60 * 24 * 30
 const DEFAULT_VERIFICATION_TTL_SECONDS = 60 * 10
+const DEFAULT_EMAIL_OTP_SUBJECT = 'Your sign-in code'
 
 const immediateUnitOfWork: UnitOfWork = {
   run: (operation) => operation(),
@@ -62,6 +69,7 @@ export interface DefaultAuthServiceOptions extends AuthServiceInfrastructure {
 
 export class DefaultAuthService implements AuthService {
   private readonly repos: AuthServiceRepositories
+  private readonly emailSender: EmailSender | undefined
   private readonly policy: AuthPolicy
   private readonly providerRegistry: ProviderRegistry | undefined
   private readonly transaction: UnitOfWork
@@ -72,6 +80,7 @@ export class DefaultAuthService implements AuthService {
 
   constructor(options: DefaultAuthServiceOptions) {
     this.repos = options.repos
+    this.emailSender = options.emailSender
     this.policy = options.policy ?? defaultAuthPolicy
     this.providerRegistry = options.providerRegistry
     this.transaction = options.transaction ?? immediateUnitOfWork
@@ -85,88 +94,88 @@ export class DefaultAuthService implements AuthService {
     return this.transaction.run(async () => {
       const now = input.now ?? this.clock.now()
       const assertion = await this.resolveAssertion(input)
-      const exactIdentity = await this.repos.identityRepo.findByProviderUserId(
-        assertion.provider,
-        assertion.providerUserId,
-      )
-
-      if (exactIdentity && this.isActiveIdentity(exactIdentity)) {
-        const user = await this.getActiveUser(exactIdentity.userId)
-        const session = await this.createSessionRecord({
-          userId: user.id,
-          now,
-          ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
-          ...(input.metadata ? { metadata: input.metadata } : {}),
-        })
-        await this.audit('auth.sign_in', now, {
-          userId: user.id,
-          identityId: exactIdentity.id,
-          sessionId: session.id,
-          metadata: { mode: 'exact' },
-        })
-
-        return {
-          user,
-          identity: exactIdentity,
-          session,
-          isNewUser: false,
-          isNewIdentity: false,
-        }
-      }
-
-      const autoLinkTarget = await this.findAutoLinkTarget(assertion)
-
-      if (autoLinkTarget) {
-        const identity = await this.createIdentityFromAssertion(autoLinkTarget, assertion, now)
-        const session = await this.createSessionRecord({
-          userId: autoLinkTarget.id,
-          now,
-          ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
-          ...(input.metadata ? { metadata: input.metadata } : {}),
-        })
-        await this.audit('auth.identity_linked', now, {
-          userId: autoLinkTarget.id,
-          identityId: identity.id,
-          metadata: { mode: 'auto-link' },
-        })
-        await this.audit('auth.sign_in', now, {
-          userId: autoLinkTarget.id,
-          identityId: identity.id,
-          sessionId: session.id,
-          metadata: { mode: 'auto-link' },
-        })
-
-        return {
-          user: autoLinkTarget,
-          identity,
-          session,
-          isNewUser: false,
-          isNewIdentity: true,
-        }
-      }
-
-      const user = await this.createUserFromAssertion(assertion, now)
-      const identity = await this.createIdentityFromAssertion(user, assertion, now)
-      const session = await this.createSessionRecord({
-        userId: user.id,
+      return this.signInWithAssertion(assertion, {
         now,
-        ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
+        ...(input.sessionExpiresAt ? { sessionExpiresAt: input.sessionExpiresAt } : {}),
         ...(input.metadata ? { metadata: input.metadata } : {}),
       })
-      await this.audit('auth.sign_in', now, {
-        userId: user.id,
-        identityId: identity.id,
-        sessionId: session.id,
-        metadata: { mode: 'new-user' },
+    })
+  }
+
+  async startEmailOtpSignIn(input: StartEmailOtpSignInInput): Promise<StartEmailOtpSignInResult> {
+    const email = normalizeEmail(input.email)
+
+    if (!email) {
+      throw invalidInput('Email is required.')
+    }
+
+    if (!this.emailSender) {
+      throw invalidInput('Email sender is required for email OTP sign-in.')
+    }
+
+    const created = await this.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: email,
+      secret: input.secret ?? generateOtpSecret(),
+      ...(input.ttlSeconds ? { ttlSeconds: input.ttlSeconds } : {}),
+      ...(input.now ? { now: input.now } : {}),
+      metadata: {
+        ...input.metadata,
+        channel: 'email',
+        provider: EMAIL_OTP_PROVIDER_ID,
+      },
+    })
+
+    await this.emailSender.sendEmail({
+      to: created.verification.target,
+      subject: DEFAULT_EMAIL_OTP_SUBJECT,
+      text: `Your sign-in code is ${created.secret}.`,
+      metadata: {
+        verificationId: created.verification.id,
+        purpose: created.verification.purpose,
+        delivery: 'email',
+      },
+    })
+
+    return {
+      verificationId: created.verification.id,
+      expiresAt: created.verification.expiresAt,
+      delivery: 'email',
+    }
+  }
+
+  async finishEmailOtpSignIn(input: FinishEmailOtpSignInInput): Promise<AuthResult> {
+    return this.transaction.run(async () => {
+      const now = input.now ?? this.clock.now()
+      const verification = await this.repos.verificationRepo.findById(input.verificationId)
+
+      if (!verification) {
+        throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+      }
+
+      if (verification.purpose !== VerificationPurpose.SignIn) {
+        throw invalidInput('Verification cannot be used for email OTP sign-in.')
+      }
+
+      const consumed = await this.consumeVerificationRecord({
+        verificationId: input.verificationId,
+        secret: input.secret,
+        now,
       })
 
-      return {
-        user,
-        identity,
-        session,
-        isNewUser: true,
-        isNewIdentity: true,
-      }
+      return this.signInWithAssertion(
+        this.normalizeAssertion({
+          provider: EMAIL_OTP_PROVIDER_ID,
+          providerUserId: consumed.target,
+          email: consumed.target,
+          emailVerified: true,
+        }),
+        {
+          now,
+          ...(input.sessionExpiresAt ? { sessionExpiresAt: input.sessionExpiresAt } : {}),
+          ...(input.metadata ? { metadata: input.metadata } : {}),
+        },
+      )
     })
   }
 
@@ -384,41 +393,137 @@ export class DefaultAuthService implements AuthService {
 
   async consumeVerification(input: ConsumeVerificationInput): Promise<Verification> {
     return this.transaction.run(async () => {
-      const now = input.now ?? this.clock.now()
-      const verification = await this.repos.verificationRepo.findById(input.verificationId)
-
-      if (!verification) {
-        throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
-      }
-
-      if (verification.status === VerificationStatus.Consumed) {
-        throw new UniauthError(
-          UniauthErrorCode.VerificationConsumed,
-          'Verification has already been consumed.',
-        )
-      }
-
-      if (verification.expiresAt.getTime() <= now.getTime()) {
-        throw new UniauthError(UniauthErrorCode.VerificationExpired, 'Verification has expired.')
-      }
-
-      if (!verifySecret(input.secret, verification.secretHash)) {
-        throw new UniauthError(
-          UniauthErrorCode.VerificationInvalidSecret,
-          'Verification secret is invalid.',
-        )
-      }
-
-      const consumed = await this.repos.verificationRepo.update(verification.id, {
-        status: VerificationStatus.Consumed,
-        consumedAt: now,
-      })
-      await this.audit('auth.verification_consumed', now, {
-        metadata: { verificationId: consumed.id, purpose: consumed.purpose },
-      })
-
-      return consumed
+      return this.consumeVerificationRecord(input)
     })
+  }
+
+  private async signInWithAssertion(
+    assertion: ProviderIdentityAssertion,
+    input: {
+      readonly now: Date
+      readonly sessionExpiresAt?: Date
+      readonly metadata?: Record<string, unknown>
+    },
+  ): Promise<AuthResult> {
+    const exactIdentity = await this.repos.identityRepo.findByProviderUserId(
+      assertion.provider,
+      assertion.providerUserId,
+    )
+
+    if (exactIdentity && this.isActiveIdentity(exactIdentity)) {
+      const user = await this.getActiveUser(exactIdentity.userId)
+      const session = await this.createSessionRecord({
+        userId: user.id,
+        now: input.now,
+        ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      })
+      await this.audit('auth.sign_in', input.now, {
+        userId: user.id,
+        identityId: exactIdentity.id,
+        sessionId: session.id,
+        metadata: { mode: 'exact' },
+      })
+
+      return {
+        user,
+        identity: exactIdentity,
+        session,
+        isNewUser: false,
+        isNewIdentity: false,
+      }
+    }
+
+    const autoLinkTarget = await this.findAutoLinkTarget(assertion)
+
+    if (autoLinkTarget) {
+      const identity = await this.createIdentityFromAssertion(autoLinkTarget, assertion, input.now)
+      const session = await this.createSessionRecord({
+        userId: autoLinkTarget.id,
+        now: input.now,
+        ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      })
+      await this.audit('auth.identity_linked', input.now, {
+        userId: autoLinkTarget.id,
+        identityId: identity.id,
+        metadata: { mode: 'auto-link' },
+      })
+      await this.audit('auth.sign_in', input.now, {
+        userId: autoLinkTarget.id,
+        identityId: identity.id,
+        sessionId: session.id,
+        metadata: { mode: 'auto-link' },
+      })
+
+      return {
+        user: autoLinkTarget,
+        identity,
+        session,
+        isNewUser: false,
+        isNewIdentity: true,
+      }
+    }
+
+    const user = await this.createUserFromAssertion(assertion, input.now)
+    const identity = await this.createIdentityFromAssertion(user, assertion, input.now)
+    const session = await this.createSessionRecord({
+      userId: user.id,
+      now: input.now,
+      ...(input.sessionExpiresAt ? { expiresAt: input.sessionExpiresAt } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })
+    await this.audit('auth.sign_in', input.now, {
+      userId: user.id,
+      identityId: identity.id,
+      sessionId: session.id,
+      metadata: { mode: 'new-user' },
+    })
+
+    return {
+      user,
+      identity,
+      session,
+      isNewUser: true,
+      isNewIdentity: true,
+    }
+  }
+
+  private async consumeVerificationRecord(input: ConsumeVerificationInput): Promise<Verification> {
+    const now = input.now ?? this.clock.now()
+    const verification = await this.repos.verificationRepo.findById(input.verificationId)
+
+    if (!verification) {
+      throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+    }
+
+    if (verification.status === VerificationStatus.Consumed) {
+      throw new UniauthError(
+        UniauthErrorCode.VerificationConsumed,
+        'Verification has already been consumed.',
+      )
+    }
+
+    if (verification.expiresAt.getTime() <= now.getTime()) {
+      throw new UniauthError(UniauthErrorCode.VerificationExpired, 'Verification has expired.')
+    }
+
+    if (!verifySecret(input.secret, verification.secretHash)) {
+      throw new UniauthError(
+        UniauthErrorCode.VerificationInvalidSecret,
+        'Verification secret is invalid.',
+      )
+    }
+
+    const consumed = await this.repos.verificationRepo.update(verification.id, {
+      status: VerificationStatus.Consumed,
+      consumedAt: now,
+    })
+    await this.audit('auth.verification_consumed', now, {
+      metadata: { verificationId: consumed.id, purpose: consumed.purpose },
+    })
+
+    return consumed
   }
 
   private async resolveAssertion(input: {

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -11,6 +11,8 @@ export type AuditEventId = Brand<string, 'AuditEventId'>
 
 export type AuthIdentityProvider = string
 
+export const EMAIL_OTP_PROVIDER_ID = 'email-otp'
+
 export type ExtensibleString<Literal extends string> = Literal | (string & Record<never, never>)
 
 export const AuthIdentityStatus = {
@@ -251,6 +253,28 @@ export interface ConsumeVerificationInput {
   readonly now?: Date
 }
 
+export interface StartEmailOtpSignInInput {
+  readonly email: string
+  readonly secret?: string
+  readonly ttlSeconds?: number
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface StartEmailOtpSignInResult {
+  readonly verificationId: VerificationId
+  readonly expiresAt: Date
+  readonly delivery: 'email'
+}
+
+export interface FinishEmailOtpSignInInput {
+  readonly verificationId: VerificationId
+  readonly secret: string
+  readonly now?: Date
+  readonly sessionExpiresAt?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface Clock {
   now(): Date
 }
@@ -266,6 +290,8 @@ export interface IdGenerator {
 
 export interface AuthService {
   signIn(input: SignInInput): Promise<AuthResult>
+  startEmailOtpSignIn(input: StartEmailOtpSignInInput): Promise<StartEmailOtpSignInResult>
+  finishEmailOtpSignIn(input: FinishEmailOtpSignInInput): Promise<AuthResult>
   link(input: LinkInput): Promise<LinkResult>
   unlink(input: UnlinkInput): Promise<void>
   mergeAccounts(input: MergeAccountsInput): Promise<MergeResult>

--- a/src/testing/in-memory.ts
+++ b/src/testing/in-memory.ts
@@ -21,6 +21,7 @@ import type {
   AuditLogRepo,
   AuthServiceRepositories,
   CredentialRepo,
+  EmailSender,
   IdentityRepo,
   SessionRepo,
   UnitOfWork,
@@ -215,6 +216,25 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   }
 }
 
+export interface InMemoryEmailMessage {
+  readonly to: string
+  readonly subject: string
+  readonly text: string
+  readonly metadata?: Record<string, unknown>
+}
+
+export class InMemoryEmailSender implements EmailSender {
+  private readonly messages: InMemoryEmailMessage[] = []
+
+  async sendEmail(input: InMemoryEmailMessage): Promise<void> {
+    this.messages.push(input)
+  }
+
+  listMessages(): readonly InMemoryEmailMessage[] {
+    return [...this.messages]
+  }
+}
+
 export interface CreateInMemoryAuthKitOptions {
   readonly policy?: AuthPolicy
   readonly clock?: Clock
@@ -227,13 +247,16 @@ export function createInMemoryAuthKit(options: CreateInMemoryAuthKitOptions = {}
   readonly service: DefaultAuthService
   readonly store: InMemoryAuthStore
   readonly providerRegistry: InMemoryProviderRegistry
+  readonly emailSender: InMemoryEmailSender
   readonly idGenerator: IdGenerator
 } {
   const store = new InMemoryAuthStore()
   const providerRegistry = new InMemoryProviderRegistry()
+  const emailSender = new InMemoryEmailSender()
   const idGenerator = options.idGenerator ?? createSequentialIdGenerator()
   const serviceOptions: DefaultAuthServiceOptions = {
     repos: store,
+    emailSender,
     providerRegistry,
     transaction: store,
     idGenerator,
@@ -249,6 +272,7 @@ export function createInMemoryAuthKit(options: CreateInMemoryAuthKitOptions = {}
     service: createAuthService(serviceOptions),
     store,
     providerRegistry,
+    emailSender,
     idGenerator,
   }
 }

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,9 +1,13 @@
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto'
 
 const SECRET_HASH_PREFIX = 'sha256:'
 
 export function generateSecret(byteLength = 32): string {
   return randomBytes(byteLength).toString('base64url')
+}
+
+export function generateOtpSecret(length = 6): string {
+  return Array.from({ length }, () => randomInt(10).toString()).join('')
 }
 
 export function hashSecret(secret: string): string {

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,6 +1,8 @@
 import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
 import {
+  DefaultAuthService,
+  EMAIL_OTP_PROVIDER_ID,
   createDefaultAuthPolicy,
   getUniauthAttributionNotice,
   isUniauthError,
@@ -9,9 +11,11 @@ import {
   UniauthErrorCode,
   VerificationPurpose,
   VerificationStatus,
+  addSeconds,
+  asVerificationId,
   type ProviderIdentityAssertion,
 } from '../src'
-import { createInMemoryAuthKit, StaticAuthProvider } from '../src/testing'
+import { InMemoryAuthStore, createInMemoryAuthKit, StaticAuthProvider } from '../src/testing'
 
 interface PackageMetadata {
   readonly name: string
@@ -220,6 +224,155 @@ describe('DefaultAuthService', () => {
     expect(consumedAgainError).toMatchObject({
       code: UniauthErrorCode.VerificationConsumed,
     })
+  })
+
+  it('starts and finishes email OTP sign-in without exposing account state', async () => {
+    const { emailSender, service, store } = createInMemoryAuthKit()
+
+    const started = await service.startEmailOtpSignIn({
+      email: ' Alice@Example.com ',
+      secret: '123456',
+      metadata: { requestId: 'req-1' },
+      now,
+    })
+
+    expect(started).toEqual({
+      verificationId: started.verificationId,
+      expiresAt: new Date('2026-01-01T00:10:00.000Z'),
+      delivery: 'email',
+    })
+    expect(started).not.toHaveProperty('isNewUser')
+    expect(started).not.toHaveProperty('user')
+
+    const [message] = emailSender.listMessages()
+    const [storedVerification] = store.listVerifications()
+
+    expect(message).toMatchObject({
+      to: 'alice@example.com',
+      subject: 'Your sign-in code',
+      text: 'Your sign-in code is 123456.',
+    })
+    expect(message?.metadata).toMatchObject({
+      verificationId: started.verificationId,
+      purpose: VerificationPurpose.SignIn,
+      delivery: 'email',
+    })
+    expect(storedVerification).toMatchObject({
+      id: started.verificationId,
+      purpose: VerificationPurpose.SignIn,
+      target: 'alice@example.com',
+      status: VerificationStatus.Pending,
+      metadata: {
+        requestId: 'req-1',
+        channel: 'email',
+        provider: EMAIL_OTP_PROVIDER_ID,
+      },
+    })
+    expect(storedVerification?.secretHash).not.toBe('123456')
+    expect(storedVerification?.secretHash).toMatch(/^sha256:/)
+
+    const wrongSecret = await service
+      .finishEmailOtpSignIn({
+        verificationId: started.verificationId,
+        secret: '000000',
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(wrongSecret).toMatchObject({
+      code: UniauthErrorCode.VerificationInvalidSecret,
+    })
+    expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
+
+    const finished = await service.finishEmailOtpSignIn({
+      verificationId: started.verificationId,
+      secret: '123456',
+      metadata: { flow: 'otp' },
+      now,
+    })
+
+    expect(finished.isNewUser).toBe(true)
+    expect(finished.identity.provider).toBe(EMAIL_OTP_PROVIDER_ID)
+    expect(finished.identity.providerUserId).toBe('alice@example.com')
+    expect(finished.identity.email).toBe('alice@example.com')
+    expect(finished.session.status).toBe(SessionStatus.Active)
+    expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Consumed)
+
+    const consumedAgain = await service
+      .finishEmailOtpSignIn({
+        verificationId: started.verificationId,
+        secret: '123456',
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(consumedAgain).toMatchObject({
+      code: UniauthErrorCode.VerificationConsumed,
+    })
+
+    const generated = await service.startEmailOtpSignIn({
+      email: 'bob@example.com',
+      ttlSeconds: 30,
+    })
+    const generatedMessage = emailSender.listMessages()[1]
+    const generatedSecret = generatedMessage?.text.match(/\d{6}/)?.[0]
+
+    if (!generatedSecret) {
+      throw new Error('Expected generated OTP secret in the email message.')
+    }
+
+    const generatedFinished = await service.finishEmailOtpSignIn({
+      verificationId: generated.verificationId,
+      secret: generatedSecret,
+      sessionExpiresAt: addSeconds(now, 60),
+    })
+
+    expect(generated.delivery).toBe('email')
+    expect(generatedFinished.session.expiresAt).toEqual(addSeconds(now, 60))
+  })
+
+  it('rejects invalid email OTP sign-in starts and wrong verification purposes', async () => {
+    const serviceWithoutEmailSender = new DefaultAuthService({
+      repos: new InMemoryAuthStore(),
+    })
+
+    expect(
+      await serviceWithoutEmailSender
+        .startEmailOtpSignIn({ email: 'alice@example.com', now })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutEmailSender
+        .startEmailOtpSignIn({ email: '   ', now })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutEmailSender
+        .finishEmailOtpSignIn({
+          verificationId: asVerificationId('missing'),
+          secret: '123456',
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.VerificationNotFound })
+
+    const { service, store } = createInMemoryAuthKit()
+    const linkVerification = await service.createVerification({
+      purpose: VerificationPurpose.Link,
+      target: 'alice@example.com',
+      secret: '123456',
+      now,
+    })
+    const wrongPurpose = await service
+      .finishEmailOtpSignIn({
+        verificationId: linkVerification.verification.id,
+        secret: '123456',
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(wrongPurpose).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
   })
 
   it('requires explicit merge policy and moves identities only through mergeAccounts', async () => {

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -17,6 +17,7 @@ import {
   asVerificationId,
   createAuthService,
   createDefaultAuthPolicy,
+  generateOtpSecret,
   createRandomIdGenerator,
   createSequentialIdGenerator,
   generateSecret,
@@ -113,9 +114,11 @@ describe('coverage support paths', () => {
     expect(normalizeTarget(' +1 (555) 123-4567 ')).toBe('+15551234567')
 
     const generatedSecret = generateSecret(8)
+    const generatedOtpSecret = generateOtpSecret()
     const secretHash = hashSecret('secret')
 
     expect(generatedSecret).toBeTypeOf('string')
+    expect(generatedOtpSecret).toMatch(/^\d{6}$/)
     expect(verifySecret('secret', secretHash)).toBe(true)
     expect(verifySecret('secret', 'plaintext')).toBe(false)
     expect(verifySecret('secret', 'sha256:short')).toBe(false)


### PR DESCRIPTION
## Summary

- add neutral email OTP sign-in start and finish flows
- expose EMAIL_OTP_PROVIDER_ID and in-memory email sender support
- update docs, example, export smoke, consumer smoke, and coverage tests for v0.2

## Validation

- npm run check
- npm run check:compose
