### PR TITLE
feat: add generic OTP challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ license, subscription, private contract, or other written permission.
 - Models `User`, `AuthIdentity`, `Credential`, `Verification`, and `Session` separately.
 - Treats email and phone as optional identity attributes, not mandatory user fields.
 - Orchestrates `signIn`, `link`, `unlink`, `mergeAccounts`, verification, and session revocation.
-- Starts and finishes email OTP sign-in through the headless `EmailSender` port.
+- Starts and finishes generic OTP challenges over email or phone through sender ports.
 - Creates local session records after successful sign-in.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Exposes ports for repositories, providers, sender infrastructure, audit logs, and transactions.
@@ -32,8 +32,8 @@ license, subscription, private contract, or other written permission.
 - It does not ship frontend pages or UI components.
 - It does not include Express, Fastify, Nest, Nuxt, or Next handlers in core.
 - It does not generate one mandatory ORM schema.
-- It does not include SMTP, SMS, OAuth, Telegram, or MAX SDK implementations in core.
-- It does not send email by itself; email OTP uses the `EmailSender` port you provide.
+- It does not include SMTP, SMS gateway, OAuth, Telegram, or MAX SDK implementations in core.
+- It does not send messages by itself; OTP delivery uses sender ports you provide.
 - It does not silently merge two existing users by email.
 
 ## Diagrams
@@ -119,6 +119,9 @@ Core imports come from the root entry point:
 import {
   DefaultAuthService,
   EMAIL_OTP_PROVIDER_ID,
+  OtpChannel,
+  PHONE_OTP_PROVIDER_ID,
+  VerificationPurpose,
   createDefaultAuthPolicy,
   type AuthProvider,
   type AuthService,
@@ -131,6 +134,7 @@ Testing helpers come from the explicit testing entry point:
 ```ts
 import {
   InMemoryEmailSender,
+  InMemorySmsSender,
   StaticAuthProvider,
   createInMemoryAuthKit,
 } from '@alyldas/uniauth/testing'
@@ -159,31 +163,49 @@ const result = await service.signIn({
 })
 ```
 
-Email OTP sign-in is still headless: `startEmailOtpSignIn` creates a hashed verification secret and
-sends the plain code through the configured `EmailSender`; `finishEmailOtpSignIn` consumes the code
-once and creates a local session.
+OTP sign-in is still headless: `startOtpChallenge` creates a hashed verification secret and sends
+the plain code through the configured sender port; `finishOtpSignIn` consumes the code once and
+creates a local session. Email-specific methods remain as compatibility wrappers.
 
 ```ts
 const { service } = createInMemoryAuthKit()
 
-const challenge = await service.startEmailOtpSignIn({
-  email: 'alice@example.com',
+const challenge = await service.startOtpChallenge({
+  purpose: VerificationPurpose.SignIn,
+  channel: OtpChannel.Phone,
+  target: '+15551234567',
   secret: '123456',
 })
 
-const result = await service.finishEmailOtpSignIn({
+const result = await service.finishOtpSignIn({
   verificationId: challenge.verificationId,
   secret: '123456',
 })
 
-console.log(result.identity.provider === EMAIL_OTP_PROVIDER_ID)
+console.log(result.identity.provider === PHONE_OTP_PROVIDER_ID)
+```
+
+The email wrapper uses the same shared OTP challenge path:
+
+```ts
+const emailChallenge = await service.startEmailOtpSignIn({
+  email: 'alice@example.com',
+  secret: '123456',
+})
+
+const emailResult = await service.finishEmailOtpSignIn({
+  verificationId: emailChallenge.verificationId,
+  secret: '123456',
+})
+
+console.log(emailResult.identity.provider === EMAIL_OTP_PROVIDER_ID)
 ```
 
 ## Entry Points
 
 - `@alyldas/uniauth`: public domain types, service implementation, policy API, ports, errors, and utilities.
 - `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, in-memory email
-  sender, and test kit.
+  and SMS senders, and test kit.
 
 ## Attribution
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,9 @@ identities, and email/phone are optional identity attributes.
 `DefaultAuthService` owns use-case orchestration:
 
 - `signIn`
+- `startOtpChallenge`
+- `finishOtpChallenge`
+- `finishOtpSignIn`
 - `startEmailOtpSignIn`
 - `finishEmailOtpSignIn`
 - `link`
@@ -31,8 +34,10 @@ It delegates authorization decisions to `AuthPolicy` and storage/provider/sender
 
 Core defines repository ports, provider registry, sender ports, audit log port, and `UnitOfWork`.
 
-Email OTP sign-in uses the `EmailSender` port. Core creates and hashes the verification secret, but
-the application owns the real SMTP, transactional email, or queue adapter.
+OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
+creates and hashes the verification secret, tracks the verification lifecycle, and maps successful
+sign-in challenges to local provider identities. The application owns the real SMTP, transactional
+email, SMS gateway, or queue adapter.
 
 `UnitOfWork` is intentionally part of v0.1 so storage adapters can provide real transaction
 boundaries for link, unlink, merge, session, and verification flows.
@@ -40,8 +45,8 @@ boundaries for link, unlink, merge, session, and verification flows.
 ## Testing Adapter
 
 `@alyldas/uniauth/testing` provides an in-memory implementation for tests, demos, and examples. It
-includes an in-memory email sender so OTP flows can be exercised without SMTP. It is not a production
-persistence adapter.
+includes in-memory email and SMS senders so OTP flows can be exercised without SMTP or an SMS
+gateway. It is not a production persistence adapter.
 
 ## Repository Shape
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,33 +16,39 @@
 - Consume-once finish flow that creates a local session.
 - In-memory email sender for tests, demos, and examples.
 
-## v0.3 - Additional Local Auth Methods
+## v0.3 - Generic OTP Challenges
+
+- Shared `startOtpChallenge`, `finishOtpChallenge`, and `finishOtpSignIn` API.
+- Email OTP wrappers backed by the shared challenge lifecycle.
+- Phone OTP sign-in over the `SmsSender` port.
+- In-memory SMS sender for tests, demos, and examples.
+
+## v0.4 - Additional Local Auth Methods
 
 - Email magic link.
-- Phone OTP.
 - Password credential with Argon2id.
 - Rate limit integration ports.
 
-## v0.4 - Messenger Providers
+## v0.5 - Messenger Providers
 
 - Telegram Mini App `initData` contracts and reference implementation.
 - MAX WebApp `initData` contracts and reference implementation.
 
-## v0.5 - OAuth / OIDC Layer
+## v0.6 - OAuth / OIDC Layer
 
 - Generic OAuth/OIDC adapter contract.
 - Trusted provider policy.
 - Provider profile mapping into `ProviderIdentityAssertion`.
 - Optional Better Auth and Auth.js bridge adapters.
 
-## v0.6 - Reference Persistence
+## v0.7 - Reference Persistence
 
 - Postgres reference storage.
 - SQL schema example.
 - Transactional merge flow.
 - Indexes and constraints.
 
-## v0.7 - Production Hardening
+## v0.8 - Production Hardening
 
 - Threat model documentation.
 - Anti-takeover tests.
@@ -54,7 +60,7 @@
 ## Examples Backlog
 
 - Link and unlink flow.
-- Email OTP wiring.
+- OTP wiring.
 - OAuth adapter wiring.
 - Telegram and MAX adapter wiring.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,8 +10,9 @@
 - The last active identity cannot be unlinked under the default policy.
 - Merge is an explicit operation and disabled by default.
 - Verification secrets are stored as hashes.
-- Email OTP start responses are neutral and do not expose whether an account exists.
-- Email OTP finish consumes a sign-in verification once before creating a local session.
+- OTP start responses are neutral and do not expose whether an account exists.
+- OTP finish consumes a sign-in verification once before creating a local session.
+- Phone OTP uses the same verification lifecycle as email OTP.
 - Public errors avoid exposing which user owns an identity.
 
 ## Policy Matrix
@@ -36,6 +37,12 @@
 - Email OTP account enumeration through start-flow responses.
 - Email OTP replay through consumed verification reuse.
 - Email OTP plaintext persistence in verification storage.
+
+## Threats Covered in v0.3
+
+- Divergent email and phone OTP behavior through duplicated flow code.
+- Phone OTP replay through consumed verification reuse.
+- Phone OTP plaintext persistence in verification storage.
 
 ## Out of Scope for Core
 

--- a/examples/basic-node/index.ts
+++ b/examples/basic-node/index.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { createDefaultAuthPolicy } from '../../src'
+import { OtpChannel, VerificationPurpose, createDefaultAuthPolicy } from '../../src'
 import { createInMemoryAuthKit } from '../../src/testing'
 
 export async function runBasicExample(): Promise<void> {
@@ -7,11 +7,13 @@ export async function runBasicExample(): Promise<void> {
     policy: createDefaultAuthPolicy({ allowAutoLink: false }),
   })
 
-  const challenge = await service.startEmailOtpSignIn({
-    email: 'alice@example.com',
+  const challenge = await service.startOtpChallenge({
+    purpose: VerificationPurpose.SignIn,
+    channel: OtpChannel.Email,
+    target: 'alice@example.com',
     secret: '123456',
   })
-  const result = await service.finishEmailOtpSignIn({
+  const result = await service.finishOtpSignIn({
     verificationId: challenge.verificationId,
     secret: '123456',
   })

--- a/scripts/consumer-smoke.mjs
+++ b/scripts/consumer-smoke.mjs
@@ -63,8 +63,11 @@ try {
     join(consumerDir, 'consumer-smoke.mjs'),
     `import {
   EMAIL_OTP_PROVIDER_ID,
+  OtpChannel,
+  PHONE_OTP_PROVIDER_ID,
   SessionStatus,
   UNIAUTH_ATTRIBUTION,
+  VerificationPurpose,
   createDefaultAuthPolicy,
 } from '${packageMetadata.name}'
 import { createInMemoryAuthKit } from '${packageMetadata.name}/testing'
@@ -109,6 +112,25 @@ if (otpResult.identity.provider !== EMAIL_OTP_PROVIDER_ID) {
 
 if (otpResult.session.status !== SessionStatus.Active) {
   throw new Error('Expected an active email OTP session.')
+}
+
+const phoneChallenge = await service.startOtpChallenge({
+  purpose: VerificationPurpose.SignIn,
+  channel: OtpChannel.Phone,
+  target: '+15551234567',
+  secret: '654321',
+})
+const phoneResult = await service.finishOtpSignIn({
+  verificationId: phoneChallenge.verificationId,
+  secret: '654321',
+})
+
+if (phoneResult.identity.provider !== PHONE_OTP_PROVIDER_ID) {
+  throw new Error('Expected the phone OTP provider identity.')
+}
+
+if (phoneResult.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active phone OTP session.')
 }
 `,
   )

--- a/scripts/registry-smoke.mjs
+++ b/scripts/registry-smoke.mjs
@@ -60,7 +60,14 @@ writeFileSync(
 writeFileSync(join(workspace, 'package.json'), '{"private":true,"type":"module"}\n')
 writeFileSync(
   join(workspace, 'registry-smoke.mjs'),
-  `import { EMAIL_OTP_PROVIDER_ID, SessionStatus, UNIAUTH_ATTRIBUTION } from '${packageMetadata.name}'
+  `import {
+  EMAIL_OTP_PROVIDER_ID,
+  OtpChannel,
+  PHONE_OTP_PROVIDER_ID,
+  SessionStatus,
+  UNIAUTH_ATTRIBUTION,
+  VerificationPurpose,
+} from '${packageMetadata.name}'
 import { createInMemoryAuthKit } from '${packageMetadata.name}/testing'
 
 const { service } = createInMemoryAuthKit()
@@ -96,6 +103,25 @@ if (otpResult.identity.provider !== EMAIL_OTP_PROVIDER_ID) {
 
 if (otpResult.session.status !== SessionStatus.Active) {
   throw new Error('Expected an active email OTP session.')
+}
+
+const phoneChallenge = await service.startOtpChallenge({
+  purpose: VerificationPurpose.SignIn,
+  channel: OtpChannel.Phone,
+  target: '+15551234567',
+  secret: '654321',
+})
+const phoneResult = await service.finishOtpSignIn({
+  verificationId: phoneChallenge.verificationId,
+  secret: '654321',
+})
+
+if (phoneResult.identity.provider !== PHONE_OTP_PROVIDER_ID) {
+  throw new Error('Expected the phone OTP provider identity.')
+}
+
+if (phoneResult.session.status !== SessionStatus.Active) {
+  throw new Error('Expected an active phone OTP session.')
 }
 `,
 )

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -13,6 +13,8 @@ interface PackageMetadata {
 interface CoreExports {
   readonly DefaultAuthService: unknown
   readonly EMAIL_OTP_PROVIDER_ID: string
+  readonly OtpChannel: { readonly Email: string; readonly Phone: string }
+  readonly PHONE_OTP_PROVIDER_ID: string
   readonly UNIAUTH_ATTRIBUTION: AttributionExports
   readonly getUniauthAttributionNotice: (options?: {
     readonly productName?: string
@@ -24,6 +26,7 @@ interface CoreExports {
 interface TestingExports {
   readonly createInMemoryAuthKit: unknown
   readonly InMemoryEmailSender: unknown
+  readonly InMemorySmsSender: unknown
   readonly StaticAuthProvider: unknown
 }
 
@@ -59,6 +62,8 @@ describe('package exports', () => {
 
     expect(core.DefaultAuthService).toBeTypeOf('function')
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
+    expect(core.OtpChannel.Phone).toBe('phone')
+    expect(core.PHONE_OTP_PROVIDER_ID).toBe('phone-otp')
     expect(core.createDefaultAuthPolicy).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
     expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
@@ -68,6 +73,7 @@ describe('package exports', () => {
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
     expect(testing.InMemoryEmailSender).toBeTypeOf('function')
+    expect(testing.InMemorySmsSender).toBeTypeOf('function')
     expect(testing.StaticAuthProvider).toBeTypeOf('function')
   })
 
@@ -77,6 +83,8 @@ describe('package exports', () => {
 
     expect(core.DefaultAuthService).toBeTypeOf('function')
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
+    expect(core.OtpChannel).toMatchObject({ Email: 'email', Phone: 'phone' })
+    expect(core.PHONE_OTP_PROVIDER_ID).toBe('phone-otp')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
     expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toMatchObject({
@@ -89,5 +97,6 @@ describe('package exports', () => {
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
     expect(testing.InMemoryEmailSender).toBeTypeOf('function')
+    expect(testing.InMemorySmsSender).toBeTypeOf('function')
   })
 })

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,6 +1,8 @@
 import {
   AuthIdentityStatus,
   EMAIL_OTP_PROVIDER_ID,
+  OtpChannel,
+  PHONE_OTP_PROVIDER_ID,
   SessionStatus,
   type AuditEvent,
   type AuditEventType,
@@ -14,6 +16,8 @@ import {
   type CreateVerificationResult,
   type FinishEmailOtpSignInInput,
   type FinishInput,
+  type FinishOtpChallengeInput,
+  type FinishOtpSignInInput,
   type IdGenerator,
   type IdentityId,
   type LinkInput,
@@ -26,6 +30,8 @@ import {
   type SignInInput,
   type StartEmailOtpSignInInput,
   type StartEmailOtpSignInResult,
+  type StartOtpChallengeInput,
+  type StartOtpChallengeResult,
   type UnlinkInput,
   type User,
   type UserId,
@@ -41,6 +47,7 @@ import type {
   AuthServiceRepositories,
   EmailSender,
   ProviderRegistry,
+  SmsSender,
   UnitOfWork,
 } from '../ports'
 import { createRandomIdGenerator } from '../utils/ids.js'
@@ -51,6 +58,8 @@ import { addSeconds, systemClock } from '../utils/time.js'
 const DEFAULT_SESSION_TTL_SECONDS = 60 * 60 * 24 * 30
 const DEFAULT_VERIFICATION_TTL_SECONDS = 60 * 10
 const DEFAULT_EMAIL_OTP_SUBJECT = 'Your sign-in code'
+const DEFAULT_SMS_OTP_PREFIX = 'Your sign-in code is'
+type SupportedOtpChannel = typeof OtpChannel.Email | typeof OtpChannel.Phone
 
 const immediateUnitOfWork: UnitOfWork = {
   run: (operation) => operation(),
@@ -70,6 +79,7 @@ export interface DefaultAuthServiceOptions extends AuthServiceInfrastructure {
 export class DefaultAuthService implements AuthService {
   private readonly repos: AuthServiceRepositories
   private readonly emailSender: EmailSender | undefined
+  private readonly smsSender: SmsSender | undefined
   private readonly policy: AuthPolicy
   private readonly providerRegistry: ProviderRegistry | undefined
   private readonly transaction: UnitOfWork
@@ -81,6 +91,7 @@ export class DefaultAuthService implements AuthService {
   constructor(options: DefaultAuthServiceOptions) {
     this.repos = options.repos
     this.emailSender = options.emailSender
+    this.smsSender = options.smsSender
     this.policy = options.policy ?? defaultAuthPolicy
     this.providerRegistry = options.providerRegistry
     this.transaction = options.transaction ?? immediateUnitOfWork
@@ -102,80 +113,99 @@ export class DefaultAuthService implements AuthService {
     })
   }
 
-  async startEmailOtpSignIn(input: StartEmailOtpSignInInput): Promise<StartEmailOtpSignInResult> {
-    const email = normalizeEmail(input.email)
-
-    if (!email) {
-      throw invalidInput('Email is required.')
-    }
-
-    if (!this.emailSender) {
-      throw invalidInput('Email sender is required for email OTP sign-in.')
-    }
-
-    const created = await this.createVerification({
-      purpose: VerificationPurpose.SignIn,
-      target: email,
-      secret: input.secret ?? generateOtpSecret(),
-      ...(input.ttlSeconds ? { ttlSeconds: input.ttlSeconds } : {}),
-      ...(input.now ? { now: input.now } : {}),
-      metadata: {
-        ...input.metadata,
-        channel: 'email',
-        provider: EMAIL_OTP_PROVIDER_ID,
-      },
+  async startOtpChallenge(input: StartOtpChallengeInput): Promise<StartOtpChallengeResult> {
+    const now = input.now ?? this.clock.now()
+    const target = this.normalizeOtpTarget(input.channel, input.target)
+    const config = this.otpChannelConfig(input.channel)
+    const created = await this.transaction.run(async () => {
+      return this.createVerificationRecord({
+        purpose: input.purpose,
+        target,
+        secret: input.secret ?? generateOtpSecret(),
+        ...(input.ttlSeconds !== undefined ? { ttlSeconds: input.ttlSeconds } : {}),
+        now,
+        metadata: {
+          ...input.metadata,
+          channel: input.channel,
+          provider: config.provider,
+        },
+      })
     })
 
-    await this.emailSender.sendEmail({
-      to: created.verification.target,
-      subject: DEFAULT_EMAIL_OTP_SUBJECT,
-      text: `Your sign-in code is ${created.secret}.`,
-      metadata: {
-        verificationId: created.verification.id,
-        purpose: created.verification.purpose,
-        delivery: 'email',
-      },
-    })
+    await config.send(created)
 
     return {
       verificationId: created.verification.id,
       expiresAt: created.verification.expiresAt,
-      delivery: 'email',
+      delivery: input.channel,
     }
   }
 
-  async finishEmailOtpSignIn(input: FinishEmailOtpSignInInput): Promise<AuthResult> {
+  async finishOtpChallenge(input: FinishOtpChallengeInput): Promise<Verification> {
     return this.transaction.run(async () => {
       const now = input.now ?? this.clock.now()
-      const verification = await this.repos.verificationRepo.findById(input.verificationId)
-
-      if (!verification) {
-        throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
-      }
-
-      if (verification.purpose !== VerificationPurpose.SignIn) {
-        throw invalidInput('Verification cannot be used for email OTP sign-in.')
-      }
-
-      const consumed = await this.consumeVerificationRecord({
+      const consumed = await this.consumeOtpChallengeRecord({
         verificationId: input.verificationId,
         secret: input.secret,
+        ...(input.purpose ? { purpose: input.purpose } : {}),
+        ...(input.channel ? { channel: input.channel } : {}),
         now,
+        context: 'OTP challenge',
+      })
+
+      return consumed.verification
+    })
+  }
+
+  async finishOtpSignIn(input: FinishOtpSignInInput): Promise<AuthResult> {
+    return this.transaction.run(async () => {
+      const now = input.now ?? this.clock.now()
+      const consumed = await this.consumeOtpChallengeRecord({
+        verificationId: input.verificationId,
+        secret: input.secret,
+        purpose: VerificationPurpose.SignIn,
+        ...(input.channel ? { channel: input.channel } : {}),
+        now,
+        context: 'OTP sign-in',
       })
 
       return this.signInWithAssertion(
-        this.normalizeAssertion({
-          provider: EMAIL_OTP_PROVIDER_ID,
-          providerUserId: consumed.target,
-          email: consumed.target,
-          emailVerified: true,
-        }),
+        this.assertionFromOtpVerification(consumed.verification, consumed.channel),
         {
           now,
           ...(input.sessionExpiresAt ? { sessionExpiresAt: input.sessionExpiresAt } : {}),
           ...(input.metadata ? { metadata: input.metadata } : {}),
         },
       )
+    })
+  }
+
+  async startEmailOtpSignIn(input: StartEmailOtpSignInInput): Promise<StartEmailOtpSignInResult> {
+    const started = await this.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: input.email,
+      ...(input.secret !== undefined ? { secret: input.secret } : {}),
+      ...(input.ttlSeconds !== undefined ? { ttlSeconds: input.ttlSeconds } : {}),
+      ...(input.now ? { now: input.now } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })
+
+    return {
+      verificationId: started.verificationId,
+      expiresAt: started.expiresAt,
+      delivery: OtpChannel.Email,
+    }
+  }
+
+  async finishEmailOtpSignIn(input: FinishEmailOtpSignInInput): Promise<AuthResult> {
+    return this.finishOtpSignIn({
+      verificationId: input.verificationId,
+      secret: input.secret,
+      channel: OtpChannel.Email,
+      ...(input.now ? { now: input.now } : {}),
+      ...(input.sessionExpiresAt ? { sessionExpiresAt: input.sessionExpiresAt } : {}),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
     })
   }
 
@@ -370,30 +400,181 @@ export class DefaultAuthService implements AuthService {
   async createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult> {
     return this.transaction.run(async () => {
       const now = input.now ?? this.clock.now()
-      const secret = input.secret ?? generateSecret()
-      const verification: Verification = {
-        id: this.idGenerator.verificationId(),
-        purpose: input.purpose,
-        target: normalizeTarget(input.target),
-        secretHash: hashSecret(secret),
-        status: VerificationStatus.Pending,
-        createdAt: now,
-        expiresAt: addSeconds(now, input.ttlSeconds ?? this.verificationTtlSeconds),
-        ...(input.metadata ? { metadata: input.metadata } : {}),
-      }
-
-      const created = await this.repos.verificationRepo.create(verification)
-      await this.audit('auth.verification_created', now, {
-        metadata: { verificationId: created.id, purpose: created.purpose },
-      })
-
-      return { verification: created, secret }
+      return this.createVerificationRecord({ ...input, now })
     })
   }
 
   async consumeVerification(input: ConsumeVerificationInput): Promise<Verification> {
     return this.transaction.run(async () => {
       return this.consumeVerificationRecord(input)
+    })
+  }
+
+  private async createVerificationRecord(
+    input: CreateVerificationInput & { readonly now: Date },
+  ): Promise<CreateVerificationResult> {
+    const secret = input.secret ?? generateSecret()
+    const verification: Verification = {
+      id: this.idGenerator.verificationId(),
+      purpose: input.purpose,
+      target: normalizeTarget(input.target),
+      secretHash: hashSecret(secret),
+      status: VerificationStatus.Pending,
+      createdAt: input.now,
+      expiresAt: addSeconds(input.now, input.ttlSeconds ?? this.verificationTtlSeconds),
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    }
+
+    const created = await this.repos.verificationRepo.create(verification)
+    await this.audit('auth.verification_created', input.now, {
+      metadata: { verificationId: created.id, purpose: created.purpose },
+    })
+
+    return { verification: created, secret }
+  }
+
+  private normalizeOtpTarget(channel: OtpChannel, target: string): string {
+    const normalized =
+      channel === OtpChannel.Email
+        ? normalizeEmail(target)
+        : channel === OtpChannel.Phone
+          ? normalizePhone(target)
+          : normalizeTarget(target)
+
+    if (normalized) {
+      return normalized
+    }
+
+    if (channel === OtpChannel.Email) {
+      throw invalidInput('Email is required.')
+    }
+
+    if (channel === OtpChannel.Phone) {
+      throw invalidInput('Phone is required.')
+    }
+
+    throw invalidInput('OTP target is required.')
+  }
+
+  private otpChannelConfig(channel: OtpChannel): {
+    readonly provider: string
+    send(created: CreateVerificationResult): Promise<void>
+  } {
+    if (channel === OtpChannel.Email) {
+      if (!this.emailSender) {
+        throw invalidInput('Email sender is required for email OTP challenges.')
+      }
+
+      const emailSender = this.emailSender
+
+      return {
+        provider: EMAIL_OTP_PROVIDER_ID,
+        send: async (created) => {
+          await emailSender.sendEmail({
+            to: created.verification.target,
+            subject: DEFAULT_EMAIL_OTP_SUBJECT,
+            text: `Your sign-in code is ${created.secret}.`,
+            metadata: {
+              verificationId: created.verification.id,
+              purpose: created.verification.purpose,
+              delivery: OtpChannel.Email,
+            },
+          })
+        },
+      }
+    }
+
+    if (channel === OtpChannel.Phone) {
+      if (!this.smsSender) {
+        throw invalidInput('SMS sender is required for phone OTP challenges.')
+      }
+
+      const smsSender = this.smsSender
+
+      return {
+        provider: PHONE_OTP_PROVIDER_ID,
+        send: async (created) => {
+          await smsSender.sendSms({
+            to: created.verification.target,
+            text: `${DEFAULT_SMS_OTP_PREFIX} ${created.secret}.`,
+            metadata: {
+              verificationId: created.verification.id,
+              purpose: created.verification.purpose,
+              delivery: OtpChannel.Phone,
+            },
+          })
+        },
+      }
+    }
+
+    throw invalidInput('OTP channel is not supported.')
+  }
+
+  private async consumeOtpChallengeRecord(input: {
+    readonly verificationId: Verification['id']
+    readonly secret: string
+    readonly purpose?: VerificationPurpose
+    readonly channel?: OtpChannel
+    readonly now: Date
+    readonly context: string
+  }): Promise<{ readonly verification: Verification; readonly channel: SupportedOtpChannel }> {
+    const verification = await this.repos.verificationRepo.findById(input.verificationId)
+
+    if (!verification) {
+      throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+    }
+
+    if (input.purpose && verification.purpose !== input.purpose) {
+      throw invalidInput(`Verification cannot be used for ${input.context}.`)
+    }
+
+    const channel = this.otpChannelFromVerification(verification)
+
+    if (!channel) {
+      throw invalidInput(`Verification cannot be used for ${input.context}.`)
+    }
+
+    if (input.channel && channel !== input.channel) {
+      throw invalidInput(`Verification cannot be used for ${input.context}.`)
+    }
+
+    const consumed = await this.consumeVerificationRecord({
+      verificationId: input.verificationId,
+      secret: input.secret,
+      now: input.now,
+    })
+
+    return { verification: consumed, channel }
+  }
+
+  private otpChannelFromVerification(verification: Verification): SupportedOtpChannel | undefined {
+    const channel = verification.metadata?.channel
+
+    if (channel === OtpChannel.Email || channel === OtpChannel.Phone) {
+      return channel
+    }
+
+    return undefined
+  }
+
+  private assertionFromOtpVerification(
+    verification: Verification,
+    channel: SupportedOtpChannel,
+  ): ProviderIdentityAssertion {
+    if (channel === OtpChannel.Email) {
+      return this.normalizeAssertion({
+        provider: EMAIL_OTP_PROVIDER_ID,
+        providerUserId: verification.target,
+        email: verification.target,
+        emailVerified: true,
+      })
+    }
+
+    return this.normalizeAssertion({
+      provider: PHONE_OTP_PROVIDER_ID,
+      providerUserId: verification.target,
+      phone: verification.target,
+      phoneVerified: true,
     })
   }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -12,6 +12,7 @@ export type AuditEventId = Brand<string, 'AuditEventId'>
 export type AuthIdentityProvider = string
 
 export const EMAIL_OTP_PROVIDER_ID = 'email-otp'
+export const PHONE_OTP_PROVIDER_ID = 'phone-otp'
 
 export type ExtensibleString<Literal extends string> = Literal | (string & Record<never, never>)
 
@@ -47,6 +48,13 @@ export const VerificationStatus = {
 } as const
 
 export type VerificationStatus = (typeof VerificationStatus)[keyof typeof VerificationStatus]
+
+export const OtpChannel = {
+  Email: 'email',
+  Phone: 'phone',
+} as const
+
+export type OtpChannel = ExtensibleString<(typeof OtpChannel)[keyof typeof OtpChannel]>
 
 export const SessionStatus = {
   Active: 'active',
@@ -253,6 +261,39 @@ export interface ConsumeVerificationInput {
   readonly now?: Date
 }
 
+export interface StartOtpChallengeInput {
+  readonly purpose: VerificationPurpose
+  readonly channel: OtpChannel
+  readonly target: string
+  readonly secret?: string
+  readonly ttlSeconds?: number
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface StartOtpChallengeResult {
+  readonly verificationId: VerificationId
+  readonly expiresAt: Date
+  readonly delivery: OtpChannel
+}
+
+export interface FinishOtpChallengeInput {
+  readonly verificationId: VerificationId
+  readonly secret: string
+  readonly purpose?: VerificationPurpose
+  readonly channel?: OtpChannel
+  readonly now?: Date
+}
+
+export interface FinishOtpSignInInput {
+  readonly verificationId: VerificationId
+  readonly secret: string
+  readonly channel?: OtpChannel
+  readonly now?: Date
+  readonly sessionExpiresAt?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface StartEmailOtpSignInInput {
   readonly email: string
   readonly secret?: string
@@ -290,6 +331,9 @@ export interface IdGenerator {
 
 export interface AuthService {
   signIn(input: SignInInput): Promise<AuthResult>
+  startOtpChallenge(input: StartOtpChallengeInput): Promise<StartOtpChallengeResult>
+  finishOtpChallenge(input: FinishOtpChallengeInput): Promise<Verification>
+  finishOtpSignIn(input: FinishOtpSignInInput): Promise<AuthResult>
   startEmailOtpSignIn(input: StartEmailOtpSignInInput): Promise<StartEmailOtpSignInResult>
   finishEmailOtpSignIn(input: FinishEmailOtpSignInInput): Promise<AuthResult>
   link(input: LinkInput): Promise<LinkResult>

--- a/src/testing/in-memory.ts
+++ b/src/testing/in-memory.ts
@@ -24,6 +24,7 @@ import type {
   EmailSender,
   IdentityRepo,
   SessionRepo,
+  SmsSender,
   UnitOfWork,
   UserRepo,
   VerificationRepo,
@@ -235,6 +236,24 @@ export class InMemoryEmailSender implements EmailSender {
   }
 }
 
+export interface InMemorySmsMessage {
+  readonly to: string
+  readonly text: string
+  readonly metadata?: Record<string, unknown>
+}
+
+export class InMemorySmsSender implements SmsSender {
+  private readonly messages: InMemorySmsMessage[] = []
+
+  async sendSms(input: InMemorySmsMessage): Promise<void> {
+    this.messages.push(input)
+  }
+
+  listMessages(): readonly InMemorySmsMessage[] {
+    return [...this.messages]
+  }
+}
+
 export interface CreateInMemoryAuthKitOptions {
   readonly policy?: AuthPolicy
   readonly clock?: Clock
@@ -248,15 +267,18 @@ export function createInMemoryAuthKit(options: CreateInMemoryAuthKitOptions = {}
   readonly store: InMemoryAuthStore
   readonly providerRegistry: InMemoryProviderRegistry
   readonly emailSender: InMemoryEmailSender
+  readonly smsSender: InMemorySmsSender
   readonly idGenerator: IdGenerator
 } {
   const store = new InMemoryAuthStore()
   const providerRegistry = new InMemoryProviderRegistry()
   const emailSender = new InMemoryEmailSender()
+  const smsSender = new InMemorySmsSender()
   const idGenerator = options.idGenerator ?? createSequentialIdGenerator()
   const serviceOptions: DefaultAuthServiceOptions = {
     repos: store,
     emailSender,
+    smsSender,
     providerRegistry,
     transaction: store,
     idGenerator,
@@ -273,6 +295,7 @@ export function createInMemoryAuthKit(options: CreateInMemoryAuthKitOptions = {}
     store,
     providerRegistry,
     emailSender,
+    smsSender,
     idGenerator,
   }
 }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import {
   DefaultAuthService,
   EMAIL_OTP_PROVIDER_ID,
+  OtpChannel,
+  PHONE_OTP_PROVIDER_ID,
   createDefaultAuthPolicy,
   getUniauthAttributionNotice,
   isUniauthError,
@@ -264,7 +266,7 @@ describe('DefaultAuthService', () => {
       status: VerificationStatus.Pending,
       metadata: {
         requestId: 'req-1',
-        channel: 'email',
+        channel: OtpChannel.Email,
         provider: EMAIL_OTP_PROVIDER_ID,
       },
     })
@@ -331,6 +333,93 @@ describe('DefaultAuthService', () => {
     expect(generatedFinished.session.expiresAt).toEqual(addSeconds(now, 60))
   })
 
+  it('reuses generic OTP challenges for email and phone sign-in channels', async () => {
+    const { emailSender, service, smsSender, store } = createInMemoryAuthKit()
+
+    const emailLinkChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.Link,
+      channel: OtpChannel.Email,
+      target: ' Link@Example.com ',
+      secret: '111111',
+      now,
+    })
+    const consumedEmailLink = await service.finishOtpChallenge({
+      verificationId: emailLinkChallenge.verificationId,
+      secret: '111111',
+      purpose: VerificationPurpose.Link,
+      channel: OtpChannel.Email,
+      now,
+    })
+
+    expect(emailLinkChallenge.delivery).toBe(OtpChannel.Email)
+    expect(consumedEmailLink.status).toBe(VerificationStatus.Consumed)
+    expect(emailSender.listMessages()[0]).toMatchObject({
+      to: 'link@example.com',
+      text: 'Your sign-in code is 111111.',
+    })
+
+    const clockFallbackChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.Link,
+      channel: OtpChannel.Email,
+      target: 'clock@example.com',
+      secret: '222222',
+    })
+    const clockFallbackConsumed = await service.finishOtpChallenge({
+      verificationId: clockFallbackChallenge.verificationId,
+      secret: '222222',
+      purpose: VerificationPurpose.Link,
+      channel: OtpChannel.Email,
+    })
+
+    expect(clockFallbackConsumed.status).toBe(VerificationStatus.Consumed)
+
+    const phoneChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Phone,
+      target: ' +1 (555) 123-4567 ',
+      secret: '654321',
+      metadata: { requestId: 'req-phone' },
+      now,
+    })
+
+    expect(phoneChallenge).toEqual({
+      verificationId: phoneChallenge.verificationId,
+      expiresAt: new Date('2026-01-01T00:10:00.000Z'),
+      delivery: OtpChannel.Phone,
+    })
+    expect(smsSender.listMessages()[0]).toMatchObject({
+      to: '+15551234567',
+      text: 'Your sign-in code is 654321.',
+      metadata: {
+        verificationId: phoneChallenge.verificationId,
+        purpose: VerificationPurpose.SignIn,
+        delivery: OtpChannel.Phone,
+      },
+    })
+    expect(store.listVerifications()[2]).toMatchObject({
+      id: phoneChallenge.verificationId,
+      target: '+15551234567',
+      metadata: {
+        requestId: 'req-phone',
+        channel: OtpChannel.Phone,
+        provider: PHONE_OTP_PROVIDER_ID,
+      },
+    })
+
+    const phoneResult = await service.finishOtpSignIn({
+      verificationId: phoneChallenge.verificationId,
+      secret: '654321',
+      metadata: { flow: 'phone-otp' },
+      now,
+    })
+
+    expect(phoneResult.identity.provider).toBe(PHONE_OTP_PROVIDER_ID)
+    expect(phoneResult.identity.providerUserId).toBe('+15551234567')
+    expect(phoneResult.identity.phone).toBe('+15551234567')
+    expect(phoneResult.identity.phoneVerified).toBe(true)
+    expect(phoneResult.session.status).toBe(SessionStatus.Active)
+  })
+
   it('rejects invalid email OTP sign-in starts and wrong verification purposes', async () => {
     const serviceWithoutEmailSender = new DefaultAuthService({
       repos: new InMemoryAuthStore(),
@@ -373,6 +462,91 @@ describe('DefaultAuthService', () => {
 
     expect(wrongPurpose).toMatchObject({ code: UniauthErrorCode.InvalidInput })
     expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
+  })
+
+  it('rejects invalid generic OTP challenge usage without consuming secrets', async () => {
+    const serviceWithoutSmsSender = new DefaultAuthService({
+      repos: new InMemoryAuthStore(),
+    })
+
+    expect(
+      await serviceWithoutSmsSender
+        .startOtpChallenge({
+          purpose: VerificationPurpose.SignIn,
+          channel: OtpChannel.Phone,
+          target: '+15551234567',
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutSmsSender
+        .startOtpChallenge({
+          purpose: VerificationPurpose.SignIn,
+          channel: 'push',
+          target: 'alice',
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutSmsSender
+        .startOtpChallenge({
+          purpose: VerificationPurpose.SignIn,
+          channel: 'push',
+          target: '   ',
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutSmsSender
+        .startOtpChallenge({
+          purpose: VerificationPurpose.SignIn,
+          channel: OtpChannel.Phone,
+          target: '   ',
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+
+    const { service, store } = createInMemoryAuthKit()
+    const challenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'alice@example.com',
+      secret: '123456',
+      now,
+    })
+    const wrongChannel = await service
+      .finishOtpChallenge({
+        verificationId: challenge.verificationId,
+        secret: '123456',
+        purpose: VerificationPurpose.SignIn,
+        channel: OtpChannel.Phone,
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(wrongChannel).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
+
+    const rawVerification = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'raw@example.com',
+      secret: '123456',
+      now,
+    })
+    const notOtpChallenge = await service
+      .finishOtpChallenge({
+        verificationId: rawVerification.verification.id,
+        secret: '123456',
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(notOtpChallenge).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(store.listVerifications()[1]?.status).toBe(VerificationStatus.Pending)
   })
 
   it('requires explicit merge policy and moves identities only through mergeAccounts', async () => {


### PR DESCRIPTION
## Summary

- add generic OTP challenge APIs for start, consume, and sign-in completion
- keep email OTP sign-in methods as compatibility wrappers over the shared flow
- add phone OTP sign-in through the SmsSender port and in-memory SMS sender
- update docs, example, smoke tests, consumer smoke, and security/roadmap notes

## Validation

- npm run check
- npm run check:compose
