### PR TITLE
feat: add UniAuth-cased API names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Uniauth
+# UniAuth
 
 [![CI](https://github.com/alyldas/uniauth/actions/workflows/ci.yml/badge.svg)](https://github.com/alyldas/uniauth/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/github/package-json/v/alyldas/uniauth?label=version)](package.json)
@@ -121,8 +121,11 @@ import {
   EMAIL_OTP_PROVIDER_ID,
   OtpChannel,
   PHONE_OTP_PROVIDER_ID,
+  UniAuthError,
+  UniAuthErrorCode,
   VerificationPurpose,
   createDefaultAuthPolicy,
+  isUniAuthError,
   type AuthProvider,
   type AuthService,
   type ProviderIdentityAssertion,
@@ -162,6 +165,21 @@ const result = await service.signIn({
   },
 })
 ```
+
+Public error helpers use the `UniAuth` brand casing:
+
+```ts
+try {
+  await service.signIn({})
+} catch (error) {
+  if (isUniAuthError(error) && error.code === UniAuthErrorCode.InvalidInput) {
+    throw new UniAuthError(UniAuthErrorCode.InvalidInput, error.message)
+  }
+}
+```
+
+The previous `UniauthError`, `UniauthErrorCode`, and `isUniauthError` exports remain as deprecated
+compatibility aliases.
 
 OTP sign-in is still headless: `startOtpChallenge` creates a hashed verification secret and sends
 the plain code through the configured sender port; `finishOtpSignIn` consumes the code once and
@@ -213,14 +231,16 @@ The root entry point exposes attribution metadata and a pure helper for About, L
 acknowledgements screens:
 
 ```ts
-import { UNIAUTH_ATTRIBUTION, getUniauthAttributionNotice } from '@alyldas/uniauth'
+import { UNIAUTH_ATTRIBUTION, getUniAuthAttributionNotice } from '@alyldas/uniauth'
 
 const metadata = UNIAUTH_ATTRIBUTION
-const notice = getUniauthAttributionNotice({ productName: 'Example App' })
+const notice = getUniAuthAttributionNotice({ productName: 'Example App' })
 ```
 
 The helper does not send telemetry, read environment variables, touch storage, or expose anything
 automatically.
+
+The previous `getUniauthAttributionNotice` export remains as a deprecated compatibility alias.
 
 For commercial licensing, paid subscription terms, written agreements, or attribution questions,
 contact `alyldas@ya.ru`.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -14,11 +14,13 @@ See [LICENSE](../LICENSE), [NOTICE](../NOTICE), and [COMMERCIAL.md](../COMMERCIA
 Notices, or acknowledgements screens:
 
 ```ts
-import { UNIAUTH_ATTRIBUTION, getUniauthAttributionNotice } from '@alyldas/uniauth'
+import { UNIAUTH_ATTRIBUTION, getUniAuthAttributionNotice } from '@alyldas/uniauth'
 
 const metadata = UNIAUTH_ATTRIBUTION
-const notice = getUniauthAttributionNotice({ productName: 'Example App' })
+const notice = getUniAuthAttributionNotice({ productName: 'Example App' })
 ```
+
+The previous `getUniauthAttributionNotice` export remains as a deprecated compatibility alias.
 
 The helper is pure. It does not send telemetry, read environment variables, touch storage, or expose
 anything automatically.

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -15,12 +15,31 @@ interface CoreExports {
   readonly EMAIL_OTP_PROVIDER_ID: string
   readonly OtpChannel: { readonly Email: string; readonly Phone: string }
   readonly PHONE_OTP_PROVIDER_ID: string
+  readonly UniAuthError: new (
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ) => Error
+  readonly UniAuthErrorCode: { readonly InvalidInput: string }
   readonly UNIAUTH_ATTRIBUTION: AttributionExports
+  readonly getUniAuthAttributionNotice: (options?: {
+    readonly productName?: string
+    readonly includeLicense?: boolean
+    readonly includeContact?: boolean
+  }) => string
   readonly getUniauthAttributionNotice: (options?: {
     readonly productName?: string
     readonly includeLicense?: boolean
     readonly includeContact?: boolean
   }) => string
+  readonly isUniAuthError: (error: unknown) => boolean
+  readonly isUniauthError: (error: unknown) => boolean
+  readonly UniauthError: new (
+    code: string,
+    message: string,
+    details?: Record<string, unknown>,
+  ) => Error
+  readonly UniauthErrorCode: { readonly InvalidInput: string }
 }
 
 interface TestingExports {
@@ -64,11 +83,17 @@ describe('package exports', () => {
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
     expect(core.OtpChannel.Phone).toBe('phone')
     expect(core.PHONE_OTP_PROVIDER_ID).toBe('phone-otp')
+    expect(core.UniAuthError).toBeTypeOf('function')
+    expect(core.UniAuthErrorCode.InvalidInput).toBe('invalid_input')
+    expect(
+      core.isUniAuthError(new core.UniAuthError(core.UniAuthErrorCode.InvalidInput, 'x')),
+    ).toBe(true)
     expect(core.createDefaultAuthPolicy).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
-    expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
+    expect(core.getUniAuthAttributionNotice).toBeTypeOf('function')
+    expect(core.getUniauthAttributionNotice).toBe(core.getUniAuthAttributionNotice)
     expect(core.UNIAUTH_ATTRIBUTION.license).toBe(packageLicense)
-    expect(core.getUniauthAttributionNotice({ productName: 'Smoke App' })).toContain(
+    expect(core.getUniAuthAttributionNotice({ productName: 'Smoke App' })).toContain(
       `Smoke App uses ${packageMetadata.name}.`,
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
@@ -85,14 +110,18 @@ describe('package exports', () => {
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
     expect(core.OtpChannel).toMatchObject({ Email: 'email', Phone: 'phone' })
     expect(core.PHONE_OTP_PROVIDER_ID).toBe('phone-otp')
+    expect(core.UniAuthError).toBeTypeOf('function')
+    expect(core.UniauthError).toBe(core.UniAuthError)
+    expect(core.UniauthErrorCode).toBe(core.UniAuthErrorCode)
+    expect(core.isUniauthError).toBe(core.isUniAuthError)
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
-    expect(core.getUniauthAttributionNotice).toBeTypeOf('function')
+    expect(core.getUniAuthAttributionNotice).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toMatchObject({
       contactEmail: packageMetadata.author.email,
       license: packageLicense,
       packageName: packageMetadata.name,
     })
-    expect(core.getUniauthAttributionNotice({ includeContact: false })).not.toContain(
+    expect(core.getUniAuthAttributionNotice({ includeContact: false })).not.toContain(
       'Licensing contact',
     )
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -39,7 +39,7 @@ import {
   VerificationPurpose,
   VerificationStatus,
 } from '../domain/types.js'
-import { UniauthError, UniauthErrorCode, invalidInput } from '../errors'
+import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors'
 import type { AuthPolicy, AuthPolicyAction } from './policy.js'
 import { defaultAuthPolicy } from './policy.js'
 import type {
@@ -231,7 +231,7 @@ export class DefaultAuthService implements AuthService {
           identityId: exactIdentity.id,
           metadata: { reason: 'identity-already-linked' },
         })
-        throw new UniauthError(UniauthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
+        throw new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
       }
 
       const identity = await this.createIdentityFromAssertion(user, assertion, now)
@@ -254,7 +254,7 @@ export class DefaultAuthService implements AuthService {
       const identity = await this.getActiveIdentity(input.identityId)
 
       if (identity.userId !== user.id) {
-        throw new UniauthError(UniauthErrorCode.IdentityNotFound, 'Identity was not found.')
+        throw new UniAuthError(UniAuthErrorCode.IdentityNotFound, 'Identity was not found.')
       }
 
       const activeIdentities = (await this.repos.identityRepo.listByUserId(user.id)).filter(
@@ -274,13 +274,13 @@ export class DefaultAuthService implements AuthService {
         })
         const code =
           activeIdentities.length <= 1
-            ? UniauthErrorCode.LastIdentity
-            : UniauthErrorCode.PolicyDenied
+            ? UniAuthErrorCode.LastIdentity
+            : UniAuthErrorCode.PolicyDenied
         const message =
           activeIdentities.length <= 1
             ? 'Cannot unlink the last active identity.'
             : 'Auth policy denied this action.'
-        throw new UniauthError(code, message)
+        throw new UniAuthError(code, message)
       }
 
       await this.repos.identityRepo.update(identity.id, {
@@ -322,7 +322,7 @@ export class DefaultAuthService implements AuthService {
           userId: targetUser.id,
           metadata: { reason: 'merge-denied', sourceUserId: sourceUser.id },
         })
-        throw new UniauthError(UniauthErrorCode.PolicyDenied, 'Auth policy denied this action.')
+        throw new UniAuthError(UniAuthErrorCode.PolicyDenied, 'Auth policy denied this action.')
       }
 
       const movedIdentityIds: IdentityId[] = []
@@ -370,7 +370,7 @@ export class DefaultAuthService implements AuthService {
       const session = await this.repos.sessionRepo.findById(sessionId)
 
       if (!session) {
-        throw new UniauthError(UniauthErrorCode.SessionNotFound, 'Session was not found.')
+        throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
       }
 
       await this.repos.sessionRepo.update(session.id, {
@@ -521,7 +521,7 @@ export class DefaultAuthService implements AuthService {
     const verification = await this.repos.verificationRepo.findById(input.verificationId)
 
     if (!verification) {
-      throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+      throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
     }
 
     if (input.purpose && verification.purpose !== input.purpose) {
@@ -675,23 +675,23 @@ export class DefaultAuthService implements AuthService {
     const verification = await this.repos.verificationRepo.findById(input.verificationId)
 
     if (!verification) {
-      throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+      throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
     }
 
     if (verification.status === VerificationStatus.Consumed) {
-      throw new UniauthError(
-        UniauthErrorCode.VerificationConsumed,
+      throw new UniAuthError(
+        UniAuthErrorCode.VerificationConsumed,
         'Verification has already been consumed.',
       )
     }
 
     if (verification.expiresAt.getTime() <= now.getTime()) {
-      throw new UniauthError(UniauthErrorCode.VerificationExpired, 'Verification has expired.')
+      throw new UniAuthError(UniAuthErrorCode.VerificationExpired, 'Verification has expired.')
     }
 
     if (!verifySecret(input.secret, verification.secretHash)) {
-      throw new UniauthError(
-        UniauthErrorCode.VerificationInvalidSecret,
+      throw new UniAuthError(
+        UniAuthErrorCode.VerificationInvalidSecret,
         'Verification secret is invalid.',
       )
     }
@@ -721,13 +721,13 @@ export class DefaultAuthService implements AuthService {
     }
 
     if (!this.providerRegistry) {
-      throw new UniauthError(UniauthErrorCode.ProviderNotFound, 'Auth provider was not found.')
+      throw new UniAuthError(UniAuthErrorCode.ProviderNotFound, 'Auth provider was not found.')
     }
 
     const provider = await this.providerRegistry.get(input.provider)
 
     if (!provider) {
-      throw new UniauthError(UniauthErrorCode.ProviderNotFound, 'Auth provider was not found.')
+      throw new UniAuthError(UniAuthErrorCode.ProviderNotFound, 'Auth provider was not found.')
     }
 
     return this.normalizeAssertion(await provider.finish(input.finishInput))
@@ -886,7 +886,7 @@ export class DefaultAuthService implements AuthService {
         userId,
         metadata: { reason: 're-auth-required', action },
       })
-      throw new UniauthError(UniauthErrorCode.ReAuthRequired, 'Recent authentication is required.')
+      throw new UniAuthError(UniAuthErrorCode.ReAuthRequired, 'Recent authentication is required.')
     }
   }
 
@@ -894,7 +894,7 @@ export class DefaultAuthService implements AuthService {
     const user = await this.repos.userRepo.findById(userId)
 
     if (!user || user.disabledAt) {
-      throw new UniauthError(UniauthErrorCode.UserNotFound, 'User was not found.')
+      throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
     }
 
     return user
@@ -904,7 +904,7 @@ export class DefaultAuthService implements AuthService {
     const identity = await this.repos.identityRepo.findById(identityId)
 
     if (!identity || !this.isActiveIdentity(identity)) {
-      throw new UniauthError(UniauthErrorCode.IdentityNotFound, 'Identity was not found.')
+      throw new UniAuthError(UniAuthErrorCode.IdentityNotFound, 'Identity was not found.')
     }
 
     return identity

--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -23,7 +23,7 @@ function normalizeRepositoryUrl(url: string): string {
   return url.replace(/^git\+/, '').replace(/\.git$/, '')
 }
 
-export interface UniauthAttributionDetails {
+export interface UniAuthAttributionDetails {
   readonly packageName: string
   readonly displayName: string
   readonly author: string
@@ -34,7 +34,7 @@ export interface UniauthAttributionDetails {
   readonly contactEmail: string
 }
 
-export interface UniauthAttributionNoticeOptions {
+export interface UniAuthAttributionNoticeOptions {
   readonly productName?: string
   readonly includeLicense?: boolean
   readonly includeContact?: boolean
@@ -53,9 +53,9 @@ export const UNIAUTH_ATTRIBUTION = {
   notice: `This product uses ${packageMetadata.name}.`,
   repositoryUrl: normalizeRepositoryUrl(packageMetadata.repository.url),
   contactEmail: packageMetadata.author.email,
-} as const satisfies UniauthAttributionDetails
+} as const satisfies UniAuthAttributionDetails
 
-export function getUniauthAttributionNotice(options: UniauthAttributionNoticeOptions = {}): string {
+export function getUniAuthAttributionNotice(options: UniAuthAttributionNoticeOptions = {}): string {
   const productName = options.productName?.trim()
   const subject = productName ? `${productName} uses` : 'This product uses'
   const parts = [`${subject} ${UNIAUTH_ATTRIBUTION.packageName}.`, UNIAUTH_ATTRIBUTION.copyright]
@@ -70,3 +70,13 @@ export function getUniauthAttributionNotice(options: UniauthAttributionNoticeOpt
 
   return parts.join(' ')
 }
+
+/** @deprecated Use `UniAuthAttributionDetails` instead. */
+export type UniauthAttributionDetails = UniAuthAttributionDetails
+
+/** @deprecated Use `UniAuthAttributionNoticeOptions` instead. */
+export type UniauthAttributionNoticeOptions = UniAuthAttributionNoticeOptions
+
+/** @deprecated Use `getUniAuthAttributionNotice` instead. */
+export const getUniauthAttributionNotice: typeof getUniAuthAttributionNotice =
+  getUniAuthAttributionNotice

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,4 +1,4 @@
-export const UniauthErrorCode = {
+export const UniAuthErrorCode = {
   InvalidInput: 'invalid_input',
   ProviderNotFound: 'provider_not_found',
   UserNotFound: 'user_not_found',
@@ -14,15 +14,15 @@ export const UniauthErrorCode = {
   VerificationInvalidSecret: 'verification_invalid_secret',
 } as const
 
-export type UniauthErrorCode = (typeof UniauthErrorCode)[keyof typeof UniauthErrorCode]
+export type UniAuthErrorCode = (typeof UniAuthErrorCode)[keyof typeof UniAuthErrorCode]
 
-export class UniauthError extends Error {
-  readonly code: UniauthErrorCode
+export class UniAuthError extends Error {
+  readonly code: UniAuthErrorCode
   readonly details?: Record<string, unknown>
 
-  constructor(code: UniauthErrorCode, message: string, details?: Record<string, unknown>) {
+  constructor(code: UniAuthErrorCode, message: string, details?: Record<string, unknown>) {
     super(message)
-    this.name = 'UniauthError'
+    this.name = 'UniAuthError'
     this.code = code
     if (details) {
       this.details = details
@@ -30,10 +30,25 @@ export class UniauthError extends Error {
   }
 }
 
-export function isUniauthError(error: unknown): error is UniauthError {
-  return error instanceof UniauthError
+export function isUniAuthError(error: unknown): error is UniAuthError {
+  return error instanceof UniAuthError
 }
 
-export function invalidInput(message = 'Invalid auth input.'): UniauthError {
-  return new UniauthError(UniauthErrorCode.InvalidInput, message)
+export function invalidInput(message = 'Invalid auth input.'): UniAuthError {
+  return new UniAuthError(UniAuthErrorCode.InvalidInput, message)
 }
+
+/** @deprecated Use `UniAuthErrorCode` instead. */
+export const UniauthErrorCode = UniAuthErrorCode
+
+/** @deprecated Use `UniAuthErrorCode` instead. */
+export type UniauthErrorCode = UniAuthErrorCode
+
+/** @deprecated Use `UniAuthError` instead. */
+export const UniauthError = UniAuthError
+
+/** @deprecated Use `UniAuthError` instead. */
+export type UniauthError = UniAuthError
+
+/** @deprecated Use `isUniAuthError` instead. */
+export const isUniauthError: typeof isUniAuthError = isUniAuthError

--- a/src/testing/in-memory.ts
+++ b/src/testing/in-memory.ts
@@ -16,7 +16,7 @@ import {
   type User,
   type Verification,
 } from '../domain/types.js'
-import { UniauthError, UniauthErrorCode } from '../errors'
+import { UniAuthError, UniAuthErrorCode } from '../errors'
 import type {
   AuditLogRepo,
   AuthServiceRepositories,
@@ -52,7 +52,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existing = this.users.get(id)
 
       if (!existing) {
-        throw new UniauthError(UniauthErrorCode.UserNotFound, 'User was not found.')
+        throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
       }
 
       const updated: User = { ...existing, ...patch }
@@ -91,7 +91,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const key = this.identityKey(identity.provider, identity.providerUserId)
 
       if (this.identityKeys.has(key)) {
-        throw new UniauthError(UniauthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
+        throw new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
       }
 
       this.identities.set(identity.id, identity)
@@ -102,7 +102,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existing = this.identities.get(id)
 
       if (!existing) {
-        throw new UniauthError(UniauthErrorCode.IdentityNotFound, 'Identity was not found.')
+        throw new UniAuthError(UniAuthErrorCode.IdentityNotFound, 'Identity was not found.')
       }
 
       const updated: AuthIdentity = { ...existing, ...patch }
@@ -111,7 +111,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existingIdentityId = this.identityKeys.get(newKey)
 
       if (newKey !== oldKey && existingIdentityId) {
-        throw new UniauthError(UniauthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
+        throw new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
       }
 
       this.identityKeys.delete(oldKey)
@@ -133,7 +133,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existing = this.credentials.get(id)
 
       if (!existing) {
-        throw new UniauthError(UniauthErrorCode.InvalidInput, 'Credential was not found.')
+        throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Credential was not found.')
       }
 
       const updated: Credential = { ...existing, ...patch }
@@ -152,7 +152,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existing = this.verifications.get(id)
 
       if (!existing) {
-        throw new UniauthError(UniauthErrorCode.VerificationNotFound, 'Verification was not found.')
+        throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
       }
 
       const updated: Verification = { ...existing, ...patch }
@@ -173,7 +173,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const existing = this.sessions.get(id)
 
       if (!existing) {
-        throw new UniauthError(UniauthErrorCode.SessionNotFound, 'Session was not found.')
+        throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
       }
 
       const updated: Session = { ...existing, ...patch }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -6,11 +6,11 @@ import {
   OtpChannel,
   PHONE_OTP_PROVIDER_ID,
   createDefaultAuthPolicy,
-  getUniauthAttributionNotice,
-  isUniauthError,
+  getUniAuthAttributionNotice,
+  isUniAuthError,
   SessionStatus,
   UNIAUTH_ATTRIBUTION,
-  UniauthErrorCode,
+  UniAuthErrorCode,
   VerificationPurpose,
   VerificationStatus,
   addSeconds,
@@ -56,11 +56,11 @@ describe('DefaultAuthService', () => {
     expect(UNIAUTH_ATTRIBUTION.packageName).toBe(packageMetadata.name)
     expect(UNIAUTH_ATTRIBUTION.contactEmail).toBe(packageMetadata.author.email)
     expect(UNIAUTH_ATTRIBUTION.license).toBe(packageLicense)
-    expect(getUniauthAttributionNotice()).toBe(
+    expect(getUniAuthAttributionNotice()).toBe(
       `This product uses ${packageMetadata.name}. ${UNIAUTH_ATTRIBUTION.copyright} License: ${packageLicense}. Licensing contact: ${packageMetadata.author.email}.`,
     )
     expect(
-      getUniauthAttributionNotice({
+      getUniAuthAttributionNotice({
         includeContact: false,
         includeLicense: false,
         productName: 'Example App',
@@ -142,7 +142,7 @@ describe('DefaultAuthService', () => {
       .unlink({ userId: result.user.id, identityId: result.identity.id, now })
       .catch((caught: unknown) => caught)
 
-    expect(error).toMatchObject({ code: UniauthErrorCode.LastIdentity })
+    expect(error).toMatchObject({ code: UniAuthErrorCode.LastIdentity })
   })
 
   it('rejects linking an identity already attached to another user without leaking ownership', async () => {
@@ -169,13 +169,13 @@ describe('DefaultAuthService', () => {
       })
       .catch((caught: unknown) => caught)
 
-    expect(isUniauthError(error)).toBe(true)
+    expect(isUniAuthError(error)).toBe(true)
 
-    if (!isUniauthError(error)) {
-      throw new Error('Expected a UniauthError.')
+    if (!isUniAuthError(error)) {
+      throw new Error('Expected a UniAuthError.')
     }
 
-    expect(error.code).toBe(UniauthErrorCode.IdentityAlreadyLinked)
+    expect(error.code).toBe(UniAuthErrorCode.IdentityAlreadyLinked)
     expect(error.message).not.toContain('another user')
     expect(error.message).not.toContain('account')
   })
@@ -205,7 +205,7 @@ describe('DefaultAuthService', () => {
       .catch((caught: unknown) => caught)
 
     expect(invalidSecretError).toMatchObject({
-      code: UniauthErrorCode.VerificationInvalidSecret,
+      code: UniAuthErrorCode.VerificationInvalidSecret,
     })
 
     const consumed = await service.consumeVerification({
@@ -224,7 +224,7 @@ describe('DefaultAuthService', () => {
       .catch((caught: unknown) => caught)
 
     expect(consumedAgainError).toMatchObject({
-      code: UniauthErrorCode.VerificationConsumed,
+      code: UniAuthErrorCode.VerificationConsumed,
     })
   })
 
@@ -282,7 +282,7 @@ describe('DefaultAuthService', () => {
       .catch((caught: unknown) => caught)
 
     expect(wrongSecret).toMatchObject({
-      code: UniauthErrorCode.VerificationInvalidSecret,
+      code: UniAuthErrorCode.VerificationInvalidSecret,
     })
     expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
 
@@ -309,7 +309,7 @@ describe('DefaultAuthService', () => {
       .catch((caught: unknown) => caught)
 
     expect(consumedAgain).toMatchObject({
-      code: UniauthErrorCode.VerificationConsumed,
+      code: UniAuthErrorCode.VerificationConsumed,
     })
 
     const generated = await service.startEmailOtpSignIn({
@@ -429,12 +429,12 @@ describe('DefaultAuthService', () => {
       await serviceWithoutEmailSender
         .startEmailOtpSignIn({ email: 'alice@example.com', now })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(
       await serviceWithoutEmailSender
         .startEmailOtpSignIn({ email: '   ', now })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(
       await serviceWithoutEmailSender
         .finishEmailOtpSignIn({
@@ -443,7 +443,7 @@ describe('DefaultAuthService', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.VerificationNotFound })
+    ).toMatchObject({ code: UniAuthErrorCode.VerificationNotFound })
 
     const { service, store } = createInMemoryAuthKit()
     const linkVerification = await service.createVerification({
@@ -460,7 +460,7 @@ describe('DefaultAuthService', () => {
       })
       .catch((caught: unknown) => caught)
 
-    expect(wrongPurpose).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(wrongPurpose).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
   })
 
@@ -478,7 +478,7 @@ describe('DefaultAuthService', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(
       await serviceWithoutSmsSender
         .startOtpChallenge({
@@ -488,7 +488,7 @@ describe('DefaultAuthService', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(
       await serviceWithoutSmsSender
         .startOtpChallenge({
@@ -498,7 +498,7 @@ describe('DefaultAuthService', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(
       await serviceWithoutSmsSender
         .startOtpChallenge({
@@ -508,7 +508,7 @@ describe('DefaultAuthService', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
 
     const { service, store } = createInMemoryAuthKit()
     const challenge = await service.startOtpChallenge({
@@ -528,7 +528,7 @@ describe('DefaultAuthService', () => {
       })
       .catch((caught: unknown) => caught)
 
-    expect(wrongChannel).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(wrongChannel).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(store.listVerifications()[0]?.status).toBe(VerificationStatus.Pending)
 
     const rawVerification = await service.createVerification({
@@ -545,7 +545,7 @@ describe('DefaultAuthService', () => {
       })
       .catch((caught: unknown) => caught)
 
-    expect(notOtpChallenge).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    expect(notOtpChallenge).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(store.listVerifications()[1]?.status).toBe(VerificationStatus.Pending)
   })
 
@@ -569,7 +569,7 @@ describe('DefaultAuthService', () => {
       })
       .catch((caught: unknown) => caught)
 
-    expect(deniedMergeError).toMatchObject({ code: UniauthErrorCode.PolicyDenied })
+    expect(deniedMergeError).toMatchObject({ code: UniAuthErrorCode.PolicyDenied })
 
     const allowedKit = createInMemoryAuthKit({
       policy: createDefaultAuthPolicy({ allowMergeAccounts: true, requireReAuthFor: [] }),

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -4,10 +4,11 @@ import {
   CredentialType,
   DefaultAuthService,
   SessionStatus,
-  UniauthError,
-  UniauthErrorCode,
+  UniAuthError,
+  UniAuthErrorCode,
   VerificationPurpose,
   VerificationStatus,
+  getUniauthAttributionNotice,
   addSeconds,
   asAuditEventId,
   asCredentialId,
@@ -23,12 +24,15 @@ import {
   generateSecret,
   hashSecret,
   invalidInput,
+  isUniAuthError,
   isUniauthError,
   normalizeEmail,
   normalizePhone,
   normalizeTarget,
   systemClock,
   verifySecret,
+  UniauthError,
+  UniauthErrorCode,
   type AuthIdentity,
   type Credential,
   type ProviderIdentityAssertion,
@@ -209,11 +213,20 @@ describe('coverage support paths', () => {
       }),
     ).toBe(true)
 
-    const error = new UniauthError(UniauthErrorCode.InvalidInput, 'Invalid.', { field: 'email' })
+    const error = new UniAuthError(UniAuthErrorCode.InvalidInput, 'Invalid.', { field: 'email' })
+    const deprecatedAliasError = new UniauthError(
+      UniauthErrorCode.InvalidInput,
+      'Deprecated alias.',
+    )
 
     expect(error.details).toEqual({ field: 'email' })
-    expect(isUniauthError(error)).toBe(true)
-    expect(isUniauthError(new Error('nope'))).toBe(false)
+    expect(error.name).toBe('UniAuthError')
+    expect(isUniAuthError(error)).toBe(true)
+    expect(isUniAuthError(new Error('nope'))).toBe(false)
+    expect(isUniauthError(deprecatedAliasError)).toBe(true)
+    expect(getUniauthAttributionNotice({ includeContact: false })).not.toContain(
+      'Licensing contact',
+    )
     expect(invalidInput().message).toBe('Invalid auth input.')
   })
 
@@ -230,7 +243,7 @@ describe('coverage support paths', () => {
         .update(asUserId('missing'), { displayName: 'Missing' })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.UserNotFound,
+      code: UniAuthErrorCode.UserNotFound,
     })
 
     const emailIdentity = await store.identityRepo.create(
@@ -262,7 +275,7 @@ describe('coverage support paths', () => {
     expect(
       await store.identityRepo.create(emailIdentity).catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.IdentityAlreadyLinked,
+      code: UniAuthErrorCode.IdentityAlreadyLinked,
     })
     expect(
       await store.identityRepo
@@ -271,13 +284,13 @@ describe('coverage support paths', () => {
           providerUserId: emailIdentity.providerUserId,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.IdentityAlreadyLinked })
+    ).toMatchObject({ code: UniAuthErrorCode.IdentityAlreadyLinked })
     expect(
       await store.identityRepo
         .update(asIdentityId('missing'), {})
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.IdentityNotFound,
+      code: UniAuthErrorCode.IdentityNotFound,
     })
     expect(
       await store.identityRepo.update(secondIdentity.id, { providerUserId: 'oauth-alice-2' }),
@@ -306,7 +319,7 @@ describe('coverage support paths', () => {
         .update(asCredentialId('missing'), {})
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.InvalidInput,
+      code: UniAuthErrorCode.InvalidInput,
     })
 
     const verification: Verification = {
@@ -332,7 +345,7 @@ describe('coverage support paths', () => {
         .update(asVerificationId('missing'), {})
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.VerificationNotFound,
+      code: UniAuthErrorCode.VerificationNotFound,
     })
 
     const session: Session = {
@@ -355,7 +368,7 @@ describe('coverage support paths', () => {
     expect(
       await store.sessionRepo.update(asSessionId('missing'), {}).catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.SessionNotFound,
+      code: UniAuthErrorCode.SessionNotFound,
     })
 
     await store.auditLogRepo.append({
@@ -425,7 +438,7 @@ describe('coverage support paths', () => {
     expect(
       await defaultService.revokeSession(asSessionId('missing')).catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.SessionNotFound,
+      code: UniAuthErrorCode.SessionNotFound,
     })
 
     expect(
@@ -477,7 +490,7 @@ describe('coverage support paths', () => {
         .unlink({ userId: first.user.id, identityId: linked.identity.id, now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.IdentityNotFound,
+      code: UniAuthErrorCode.IdentityNotFound,
     })
 
     const second = await defaultService.signIn({
@@ -495,7 +508,7 @@ describe('coverage support paths', () => {
         .unlink({ userId: second.user.id, identityId: first.identity.id, now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.IdentityNotFound,
+      code: UniAuthErrorCode.IdentityNotFound,
     })
     expect(
       await defaultService
@@ -505,13 +518,13 @@ describe('coverage support paths', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
 
     await defaultStore.userRepo.update(second.user.id, { disabledAt: now })
     expect(
       await defaultService.getUserIdentities(second.user.id).catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.UserNotFound,
+      code: UniAuthErrorCode.UserNotFound,
     })
   })
 
@@ -523,12 +536,12 @@ describe('coverage support paths', () => {
         .signIn({ provider: 'missing', finishInput: {}, now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.ProviderNotFound,
+      code: UniAuthErrorCode.ProviderNotFound,
     })
     expect(
       await noRegistryService.signIn({ now }).catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.InvalidInput,
+      code: UniAuthErrorCode.InvalidInput,
     })
     expect(
       await noRegistryService
@@ -537,7 +550,7 @@ describe('coverage support paths', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.InvalidInput })
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
 
     const kit = createInMemoryAuthKit({
       policy: createDefaultAuthPolicy({
@@ -564,7 +577,7 @@ describe('coverage support paths', () => {
         .signIn({ provider: 'missing', finishInput: {}, now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.ProviderNotFound,
+      code: UniAuthErrorCode.ProviderNotFound,
     })
 
     const phoneUser = await kit.service.signIn({
@@ -597,7 +610,7 @@ describe('coverage support paths', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.ReAuthRequired })
+    ).toMatchObject({ code: UniAuthErrorCode.ReAuthRequired })
 
     const passkey = await kit.service.link({
       userId: phoneUser.user.id,
@@ -618,7 +631,7 @@ describe('coverage support paths', () => {
           now,
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.ReAuthRequired })
+    ).toMatchObject({ code: UniAuthErrorCode.ReAuthRequired })
 
     const verification = await kit.service.createVerification({
       purpose: VerificationPurpose.ReAuth,
@@ -649,7 +662,7 @@ describe('coverage support paths', () => {
         .consumeVerification({ verificationId: asVerificationId('missing'), secret: 'x', now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
-      code: UniauthErrorCode.VerificationNotFound,
+      code: UniAuthErrorCode.VerificationNotFound,
     })
     expect(
       await kit.service
@@ -659,7 +672,7 @@ describe('coverage support paths', () => {
           now: addSeconds(now, 5),
         })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.VerificationExpired })
+    ).toMatchObject({ code: UniAuthErrorCode.VerificationExpired })
 
     const deniedKit = createInMemoryAuthKit({
       policy: {
@@ -687,7 +700,7 @@ describe('coverage support paths', () => {
       await deniedKit.service
         .unlink({ userId: deniedUser.user.id, identityId: deniedIdentity.identity.id, now })
         .catch((caught: unknown) => caught),
-    ).toMatchObject({ code: UniauthErrorCode.PolicyDenied })
+    ).toMatchObject({ code: UniAuthErrorCode.PolicyDenied })
 
     const malformedKit = createInMemoryAuthKit({
       policy: createDefaultAuthPolicy({ allowAutoLink: true }),


### PR DESCRIPTION
## Summary

- add UniAuthError, UniAuthErrorCode, isUniAuthError, and getUniAuthAttributionNotice as the canonical public names
- keep Uniauth* names as deprecated compatibility aliases
- keep UNIAUTH_ATTRIBUTION unchanged
- update docs, tests, and export smoke coverage

## Validation

- npm run check
- npm run check:compose
