### PR TITLE
chore: align Node runtime dependency policy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,8 @@ coverage
 # Husky runtime files are local git-hook plumbing, not package inputs.
 .husky/_
 
-# Git metadata and CI config are not needed for the package check image.
+# Git metadata is not needed for the package check image.
 .git
-.github
 
 # Local editor state.
 .idea

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         dependency-type: 'development'
         patterns:
           - '*'
+    # Keep Node runtime types on the minimum supported Node.js major.
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,3 +10,4 @@
 - [ ] Security-sensitive behavior is tested, or this change does not affect security behavior.
 - [ ] Release metadata is not edited manually unless this is a Release Please PR (`package.json`, `package-lock.json`, `CHANGELOG.md`).
 - [ ] Merge method and changelog impact follow the policy in `CONTRIBUTING.md`.
+- [ ] Runtime or dependency major updates match the supported Node.js target in `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ npm run check
 ```
 
 This matches the CI class of checks for the package: format check, lint, typecheck, 100% coverage,
-export smoke tests, and `npm pack --dry-run`.
+export smoke tests, package lint, package type-resolution checks, and `npm pack --dry-run`.
 
 ## Commit Messages
 
@@ -52,6 +52,18 @@ Release Please owns these files in its release PR:
 
 After changes land on `main`, Release Please opens or updates the release PR. Merge that release PR
 to let the release workflow create the `v*` tag, GitHub release notes, and GitHub Packages publish.
+
+## Dependency Policy
+
+Runtime-facing dependency updates must match the supported runtime contract. The package currently
+supports Node.js 22 and newer, and CI verifies the minimum supported runtime in `node:22-alpine`.
+
+Keep `@types/node` on the minimum supported Node.js major line. Do not merge major `@types/node`
+updates until `engines.node`, Docker, CI, examples, and docs intentionally move to the same minimum
+Node.js major.
+
+Dependabot may update regular development tooling within its configured groups. Review major updates
+as compatibility work, not routine maintenance.
 
 ## Changelog Policy
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ local npm config or CI secrets; do not commit tokens.
 
 ## Runtime Contract
 
+The package targets modern ESM TypeScript consumers on Node.js 22 or newer.
+
 Core imports come from the root entry point:
 
 ```ts
@@ -355,6 +357,10 @@ Release Please owns these files in its release PR:
 - `CHANGELOG.md`: release section and compare links.
 
 Only bypass that rule for an intentional manual release process.
+
+Follow the changelog and merge policy in [CONTRIBUTING.md](CONTRIBUTING.md): regular feature and API
+PRs should preserve useful Conventional Commits, while Release Please PRs can stay single release
+commits.
 
 After a release is published, verify the package page and GitHub Packages artifact manually against
 the generated release notes and local `npm pack --dry-run` output.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,8 +31,6 @@
 - Attribution metadata and About/Legal notice helper.
 - PolyForm Strict public license metadata and commercial contact docs.
 
-## Next Release
-
 ### v0.5 - Internal Orchestration and Package Hygiene
 
 - Decomposed `DefaultAuthService` into focused application use-case modules.
@@ -47,14 +45,19 @@
   ESM consumer type resolution.
 - Published package files restricted to public entry points, public declaration dependencies, docs,
   examples, and license files.
+- Changelog and merge policy documented for the Release Please workflow.
 
-## Planned
+## Next Release
 
-### v0.6 - Additional Local Auth Methods
+### v0.6 - Local Auth Hardening
 
 - Email magic link.
 - Password credential with Argon2id.
 - Rate limit integration ports.
+- Shared verification lifecycle tests for magic link, OTP, and password recovery.
+- Public docs for choosing local auth flows without leaking account state.
+
+## Planned
 
 ### v0.7 - Messenger Providers
 


### PR DESCRIPTION
## Summary

- block semver-major `@types/node` Dependabot updates while Node 22 is the minimum supported runtime
- document that runtime-facing dependency majors must move together with `engines.node`, Docker, CI, examples, and docs
- add the dependency-major reminder to the pull request checklist
- keep the roadmap/release notes aligned with the post-0.5 maintenance path

## Validation

- `npm run check`
- `npm run check:docker`
- `git diff --check`

## Release impact

No public auth API changes. This is repository/package hygiene and should not force a 0.5.1 release by itself.