### PR TITLE
ci: limit push checks to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- limit the CI workflow's `push` trigger to `main`
- keep `pull_request` checks for PR validation
- reduce duplicate CI runs for PR branch pushes and synchronizations

## Validation

- `npm run check`
- `git diff --check`

## Notes

This should leave PRs with the pull request CI run only, while merged commits still get a main-branch push CI run.