### PR TITLE
feat: add trusted provider policy hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ import {
   EMAIL_OTP_PROVIDER_ID,
   OtpChannel,
   PASSWORD_PROVIDER_ID,
+  ProviderTrustLevel,
   RateLimitAction,
   UniAuthError,
   UniAuthErrorCode,
@@ -175,11 +176,23 @@ create sessions, read environment variables, or mutate global state.
 The service contract is policy-driven:
 
 ```ts
-const { service } = createInMemoryAuthKit({
-  policy: createDefaultAuthPolicy({
-    allowAutoLink: false,
+const policy = {
+  ...createDefaultAuthPolicy({
+    allowAutoLink: true,
     allowMergeAccounts: false,
   }),
+  canAutoLink(context) {
+    return (
+      context.assertion.trust?.level === ProviderTrustLevel.Trusted &&
+      context.existingIdentities.every(
+        (identity) => identity.trust?.level !== ProviderTrustLevel.Untrusted,
+      )
+    )
+  },
+}
+
+const { service } = createInMemoryAuthKit({
+  policy,
 })
 
 const result = await service.signIn({
@@ -188,6 +201,10 @@ const result = await service.signIn({
     providerUserId: 'alice@example.com',
     email: 'alice@example.com',
     emailVerified: true,
+    trust: {
+      level: ProviderTrustLevel.Trusted,
+      signals: ['first-party-email'],
+    },
   },
 })
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,8 @@ validated profile into `ProviderIdentityAssertion`, and leaves authorization URL
 routes, state and nonce validation, redirect URI policy, provider secrets, HTTP clients, and token
 storage outside core. If provider tokens must survive beyond profile fetch, applications should keep
 them in app-owned persistence keyed by local auth/session state, not inside core assertions.
+Applications can additionally attach normalized trust context to assertions so `AuthPolicy` can make
+auto-link, explicit-link, and merge decisions without receiving raw SDK objects.
 
 Delivery happens after the verification record has been created inside `UnitOfWork`. If a sender
 fails, the pending verification stays in storage until normal expiry or adapter cleanup; core does
@@ -117,6 +119,8 @@ Provider adapters should expose `finish()` and return a `ProviderIdentityAsserti
 own provider SDK setup, redirect routes, raw provider payload storage, or application secrets.
 Provider-specific signature validation can live in a small reference adapter when it does not force
 SDK, framework, or storage dependencies into the core package.
+When provider trust matters, adapters should emit a small `trust` object with stable string
+signals instead of leaking provider SDK payloads into core policy hooks.
 
 ## Provider Adapter Layout
 

--- a/docs/oauth-oidc.md
+++ b/docs/oauth-oidc.md
@@ -103,6 +103,25 @@ createOAuthOidcProvider({
 })
 ```
 
+Providers can also attach normalized trust context for downstream policy checks:
+
+```ts
+createOAuthOidcProvider({
+  providerId: 'tenant-oauth',
+  client,
+  mapProfile: ({ provider, profile }) => ({
+    provider,
+    providerUserId: profile.subject,
+    email: profile.email,
+    emailVerified: profile.emailVerified,
+    trust: {
+      level: 'trusted',
+      signals: ['oidc-email-verified', 'tenant-allowlist'],
+    },
+  }),
+})
+```
+
 ## Security Notes
 
 - Validate `state`, `nonce`, redirect URI, and PKCE verifier in application code before or during
@@ -113,3 +132,5 @@ createOAuthOidcProvider({
 - Exact `(provider, providerUserId)` matching still wins. Email, phone, username, and display fields
   are profile hints, not account ownership proof.
 - Auto-link remains controlled by `AuthPolicy`; OAuth/OIDC providers do not silently merge users.
+- `ProviderIdentityAssertion.trust` can carry app-owned trust signals into `AuthPolicy.canAutoLink`,
+  `AuthPolicy.canLinkIdentity`, and `AuthPolicy.canMergeUsers` without exposing provider SDK types.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,31 +67,30 @@
 
 Tracking issues: #33, #34, #35, #36.
 
-## Next Release
-
 ### v0.8 - OAuth / OIDC Layer
 
 - Provider adapter module layout before adding OAuth/OIDC adapters.
 - Generic OAuth/OIDC adapter contract.
-- Trusted provider policy.
 - Provider profile mapping into `ProviderIdentityAssertion`.
-- Optional Better Auth and Auth.js bridge adapters.
 
-Tracking issues: #37, #38, #39, #49.
+Tracking issues: #37, #49.
 
-## Planned
+## Next Release
 
-### v0.9 - Reference Persistence
+### v0.9 - Reference Persistence and OAuth Policy Follow-Up
 
+- Trusted provider policy hooks.
 - Postgres reference storage.
 - SQL schema example.
 - Transactional merge flow.
 - Indexes and constraints.
 - In-memory testing kit decomposition aligned with reference persistence boundaries.
 
-Tracking issues: #40, #41, #42, #47.
+Tracking issues: #38, #40, #41, #42, #47.
 
-### v0.10 - Production Hardening
+## Planned
+
+### v0.10 - Production Hardening and Integration Backlog
 
 - Threat model documentation.
 - Production email and phone normalization design.
@@ -101,10 +100,11 @@ Tracking issues: #40, #41, #42, #47.
 - Audit coverage.
 - Migration docs and example applications.
 - Backend recipes for Express, Fastify, Nest, and Next.
+- Optional Better Auth and Auth.js bridge adapters after the core OAuth/OIDC policy surface settles.
 - Public domain and service contract source-module decomposition.
 - Password auth use-case decomposition.
 
-Tracking issues: #28, #29, #43, #44, #45, #46, #48.
+Tracking issues: #28, #29, #39, #43, #44, #45, #46, #48.
 
 ## Examples Backlog
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,10 +30,13 @@
 ## Policy Matrix
 
 - Auto-link by verified email/phone: denied by default; extension point:
-  `AuthPolicy.canAutoLink`.
+  `AuthPolicy.canAutoLink`. The context includes the incoming assertion trust and the matched
+  existing identities so policy can reject low-trust provider claims.
+- Link provider identity: allowed by default; extension point: `AuthPolicy.canLinkIdentity`.
 - Unlink identity: allowed only when another active identity remains; extension point:
   `AuthPolicy.canUnlinkIdentity`.
-- Merge users: denied by default; extension point: `AuthPolicy.canMergeUsers`.
+- Merge users: denied by default; extension point: `AuthPolicy.canMergeUsers`. The merge context now
+  includes source and target active identities so policy can inspect provider trust and metadata.
 - Re-auth: required for merge by default; extension point: `AuthPolicy.requiresReAuth`.
 
 ## Threats Covered in v0.1
@@ -77,6 +80,13 @@
   runtime without adding a mandatory dependency to core.
 - Password recovery reuses the verification lifecycle and rate-limit port without creating sessions
   during reset.
+
+## Threats Covered in v0.9
+
+- Low-trust provider claims can be denied during auto-link and explicit link policy decisions.
+- Merge policy can inspect active identities on both sides before moving provider-linked accounts.
+- Provider adapters can expose normalized trust context without leaking provider SDK objects into
+  the core policy contract.
 
 ## Out of Scope for Core
 

--- a/src/application/accounts.ts
+++ b/src/application/accounts.ts
@@ -24,6 +24,7 @@ import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
 
 const PolicyDenialReason = {
   IdentityAlreadyLinked: 'identity-already-linked',
+  LinkDenied: 'link-denied',
   UnlinkDenied: 'unlink-denied',
   MergeDenied: 'merge-denied',
 } as const
@@ -51,6 +52,20 @@ export async function link(runtime: AuthServiceRuntime, input: LinkInput): Promi
         metadata: { reason: PolicyDenialReason.IdentityAlreadyLinked },
       })
       throw new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
+    }
+
+    const allowed =
+      (await runtime.policy.canLinkIdentity?.({
+        user,
+        assertion,
+      })) ?? true
+
+    if (!allowed) {
+      await audit(runtime, AuditEventType.PolicyDenied, now, {
+        userId: user.id,
+        metadata: { reason: PolicyDenialReason.LinkDenied, provider: assertion.provider },
+      })
+      throw new UniAuthError(UniAuthErrorCode.PolicyDenied, 'Auth policy denied this action.')
     }
 
     const identity = await createIdentityFromAssertion(runtime, user, assertion, now)
@@ -137,10 +152,15 @@ export async function mergeAccounts(
     const sourceIdentities = (await runtime.repos.identityRepo.listByUserId(sourceUser.id)).filter(
       isActiveIdentity,
     )
+    const targetIdentities = (await runtime.repos.identityRepo.listByUserId(targetUser.id)).filter(
+      isActiveIdentity,
+    )
     const allowed = await runtime.policy.canMergeUsers({
       sourceUser,
       targetUser,
       sourceIdentityCount: sourceIdentities.length,
+      sourceIdentities,
+      targetIdentities,
     })
 
     if (!allowed) {

--- a/src/application/policy.ts
+++ b/src/application/policy.ts
@@ -19,6 +19,11 @@ export interface AutoLinkContext {
   readonly existingIdentities: readonly AuthIdentity[]
 }
 
+export interface LinkIdentityContext {
+  readonly user: User
+  readonly assertion: ProviderIdentityAssertion
+}
+
 export interface UnlinkIdentityContext {
   readonly user: User
   readonly identity: AuthIdentity
@@ -29,6 +34,8 @@ export interface MergeUsersContext {
   readonly sourceUser: User
   readonly targetUser: User
   readonly sourceIdentityCount: number
+  readonly sourceIdentities: readonly AuthIdentity[]
+  readonly targetIdentities: readonly AuthIdentity[]
 }
 
 export interface ReAuthContext {
@@ -40,6 +47,7 @@ export interface ReAuthContext {
 
 export interface AuthPolicy {
   canAutoLink(context: AutoLinkContext): MaybePromise<boolean>
+  canLinkIdentity?(context: LinkIdentityContext): MaybePromise<boolean>
   canUnlinkIdentity(context: UnlinkIdentityContext): MaybePromise<boolean>
   canMergeUsers(context: MergeUsersContext): MaybePromise<boolean>
   requiresReAuth(context: ReAuthContext): MaybePromise<boolean>
@@ -61,6 +69,9 @@ export function createDefaultAuthPolicy(options: DefaultAuthPolicyOptions = {}):
   return {
     canAutoLink(): boolean {
       return options.allowAutoLink === true
+    },
+    canLinkIdentity(): boolean {
+      return true
     },
     canUnlinkIdentity(context): boolean {
       return context.activeIdentityCount > 1

--- a/src/application/sign-in.ts
+++ b/src/application/sign-in.ts
@@ -14,7 +14,9 @@ import {
   type AuthIdentity,
   type AuthResult,
   type FinishInput,
+  ProviderTrustLevel,
   type ProviderIdentityAssertion,
+  type ProviderTrustContext,
   type Session,
   type SignInInput,
   type User,
@@ -216,7 +218,50 @@ export function normalizeAssertion(
         }
       : {}),
     ...optionalProp('displayName', displayName),
+    ...optionalProp('trust', normalizeProviderTrust(assertion.trust)),
     ...optionalProp('metadata', assertion.metadata),
+  }
+}
+
+function normalizeProviderTrust(
+  trust: ProviderIdentityAssertion['trust'],
+): ProviderTrustContext | undefined {
+  if (!trust) {
+    return undefined
+  }
+
+  if (typeof trust.level !== 'string') {
+    throw invalidInput('Provider trust level must be a string.')
+  }
+
+  const level = trust.level.trim() as ProviderTrustLevel
+
+  if (
+    level !== ProviderTrustLevel.Trusted &&
+    level !== ProviderTrustLevel.Neutral &&
+    level !== ProviderTrustLevel.Untrusted
+  ) {
+    throw invalidInput('Provider trust level must be trusted, neutral, or untrusted.')
+  }
+
+  if (trust.signals !== undefined && !Array.isArray(trust.signals)) {
+    throw invalidInput('Provider trust signals must be an array of strings.')
+  }
+
+  const signals = trust.signals
+    ?.map((signal) => {
+      if (typeof signal !== 'string') {
+        throw invalidInput('Provider trust signals must be an array of strings.')
+      }
+
+      return signal.trim()
+    })
+    .filter((signal) => signal.length > 0)
+
+  return {
+    level,
+    ...(signals && signals.length > 0 ? { signals: [...new Set(signals)] } : {}),
+    ...optionalProp('metadata', trust.metadata),
   }
 }
 
@@ -301,6 +346,7 @@ export async function createIdentityFromAssertion(
     ...(assertion.phone
       ? { phone: assertion.phone, phoneVerified: assertion.phoneVerified === true }
       : {}),
+    ...optionalProp('trust', assertion.trust),
     ...optionalProp('metadata', assertion.metadata),
   }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -64,6 +64,20 @@ export const SessionStatus = {
 
 export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus]
 
+export const ProviderTrustLevel = {
+  Trusted: 'trusted',
+  Neutral: 'neutral',
+  Untrusted: 'untrusted',
+} as const
+
+export type ProviderTrustLevel = (typeof ProviderTrustLevel)[keyof typeof ProviderTrustLevel]
+
+export interface ProviderTrustContext {
+  readonly level: ProviderTrustLevel
+  readonly signals?: readonly string[]
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface User {
   readonly id: UserId
   readonly displayName?: string
@@ -85,6 +99,7 @@ export interface AuthIdentity {
   readonly emailVerified?: boolean
   readonly phone?: string
   readonly phoneVerified?: boolean
+  readonly trust?: ProviderTrustContext
   readonly createdAt: Date
   readonly updatedAt: Date
   readonly disabledAt?: Date
@@ -135,6 +150,7 @@ export interface ProviderIdentityAssertion {
   readonly phone?: string
   readonly phoneVerified?: boolean
   readonly displayName?: string
+  readonly trust?: ProviderTrustContext
   readonly metadata?: Record<string, unknown>
 }
 

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -100,6 +100,12 @@ describe('public utility coverage', () => {
       }),
     ).toBe(false)
     expect(
+      defaultPolicy.canLinkIdentity!({
+        user: user(),
+        assertion: assertion(),
+      }),
+    ).toBe(true)
+    expect(
       defaultPolicy.canUnlinkIdentity({
         user: user(),
         identity: identity(),
@@ -118,6 +124,8 @@ describe('public utility coverage', () => {
         sourceUser: user('source'),
         targetUser: user('target'),
         sourceIdentityCount: 1,
+        sourceIdentities: [],
+        targetIdentities: [],
       }),
     ).toBe(false)
     expect(
@@ -162,6 +170,8 @@ describe('public utility coverage', () => {
         sourceUser: user('source'),
         targetUser: user('target'),
         sourceIdentityCount: 1,
+        sourceIdentities: [],
+        targetIdentities: [],
       }),
     ).toBe(true)
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -20,6 +20,7 @@ export function assertion(
     ...(input.phone ? { phone: input.phone } : {}),
     ...(input.phoneVerified !== undefined ? { phoneVerified: input.phoneVerified } : {}),
     ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.trust ? { trust: input.trust } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
   }
 }
@@ -49,6 +50,7 @@ export function identity(input: Partial<AuthIdentity> = {}): AuthIdentity {
     ...(input.emailVerified !== undefined ? { emailVerified: input.emailVerified } : {}),
     ...(input.phone ? { phone: input.phone } : {}),
     ...(input.phoneVerified !== undefined ? { phoneVerified: input.phoneVerified } : {}),
+    ...(input.trust ? { trust: input.trust } : {}),
     ...(input.disabledAt ? { disabledAt: input.disabledAt } : {}),
     ...(input.metadata ? { metadata: input.metadata } : {}),
   }

--- a/test/provider-policy.test.ts
+++ b/test/provider-policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  type AutoLinkContext,
   AuthPolicyAction,
+  type LinkIdentityContext,
+  type MergeUsersContext,
+  ProviderTrustLevel,
   UniAuthErrorCode,
   VerificationPurpose,
   VerificationStatus,
@@ -53,6 +57,64 @@ describe('provider, policy, and verification edge cases', () => {
           assertion: {
             provider: 'email',
           } as Partial<ProviderIdentityAssertion> as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: assertion({
+            provider: 'oauth',
+            providerUserId: 'invalid-trust',
+            trust: {
+              level: 'unsupported' as 'trusted',
+            },
+          }),
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'oauth',
+            providerUserId: 'invalid-trust-level-type',
+            trust: {
+              level: 1,
+            },
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'oauth',
+            providerUserId: 'invalid-trust-signals-type',
+            trust: {
+              level: 'trusted',
+              signals: 'not-an-array',
+            },
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'oauth',
+            providerUserId: 'invalid-trust-type',
+            trust: {
+              level: 'trusted',
+              signals: [123],
+            },
+          } as unknown as ProviderIdentityAssertion,
           now,
         })
         .catch((caught: unknown) => caught),
@@ -188,6 +250,7 @@ describe('provider, policy, and verification edge cases', () => {
     const deniedKit = createInMemoryAuthKit({
       policy: {
         canAutoLink: () => false,
+        canLinkIdentity: () => true,
         canMergeUsers: () => false,
         canUnlinkIdentity: () => false,
         requiresReAuth: () => false,
@@ -212,5 +275,215 @@ describe('provider, policy, and verification edge cases', () => {
         .unlink({ userId: deniedUser.user.id, identityId: deniedIdentity.identity.id, now })
         .catch((caught: unknown) => caught),
     ).toMatchObject({ code: UniAuthErrorCode.PolicyDenied })
+  })
+
+  it('exposes provider trust context to auto-link, link, and merge policy decisions', async () => {
+    const policy = {
+      ...createDefaultAuthPolicy({
+        allowAutoLink: true,
+        allowMergeAccounts: true,
+        requireReAuthFor: [],
+      }),
+      canAutoLink(context: AutoLinkContext) {
+        return (
+          context.assertion.trust?.level === ProviderTrustLevel.Trusted &&
+          context.existingIdentities.every(
+            (identity) => identity.trust?.level === ProviderTrustLevel.Trusted,
+          )
+        )
+      },
+      canLinkIdentity(context: LinkIdentityContext) {
+        return context.assertion.trust?.level !== ProviderTrustLevel.Untrusted
+      },
+      canMergeUsers(context: MergeUsersContext) {
+        const identities = [...context.sourceIdentities, ...context.targetIdentities]
+        return identities.every(
+          (identity) => identity.trust?.level !== ProviderTrustLevel.Untrusted,
+        )
+      },
+    }
+    const { service } = createInMemoryAuthKit({ policy })
+
+    const untrustedUser = await service.signIn({
+      assertion: assertion({
+        provider: 'legacy-oauth',
+        providerUserId: 'legacy-user',
+        email: 'shared@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Untrusted,
+          signals: ['legacy-email-claim'],
+        },
+      }),
+      now,
+    })
+
+    const trustedCandidate = await service.signIn({
+      assertion: assertion({
+        provider: 'trusted-oauth',
+        providerUserId: 'trusted-user',
+        email: 'shared@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+          signals: ['oidc-email-verified'],
+        },
+      }),
+      now,
+    })
+
+    expect(trustedCandidate.user.id).not.toBe(untrustedUser.user.id)
+    expect(untrustedUser.identity.trust?.signals).toEqual(['legacy-email-claim'])
+
+    const trustedPrimary = await service.signIn({
+      assertion: assertion({
+        provider: 'trusted-primary',
+        providerUserId: 'trusted-primary-user',
+        email: 'pair@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+        },
+      }),
+      now,
+    })
+    const trustedAutoLinked = await service.signIn({
+      assertion: assertion({
+        provider: 'trusted-secondary',
+        providerUserId: 'trusted-secondary-user',
+        email: 'pair@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+        },
+      }),
+      now,
+    })
+
+    expect(trustedAutoLinked.user.id).toBe(trustedPrimary.user.id)
+    expect(trustedAutoLinked.isNewIdentity).toBe(true)
+
+    expect(
+      await service
+        .link({
+          userId: trustedPrimary.user.id,
+          assertion: assertion({
+            provider: 'link-oauth',
+            providerUserId: 'link-oauth-user',
+            trust: {
+              level: ProviderTrustLevel.Untrusted,
+            },
+          }),
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.PolicyDenied })
+
+    const mergeTarget = await service.signIn({
+      assertion: assertion({
+        provider: 'merge-target',
+        providerUserId: 'merge-target-user',
+        email: 'merge-target@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+        },
+      }),
+      now,
+    })
+
+    expect(
+      await service
+        .mergeAccounts({
+          sourceUserId: untrustedUser.user.id,
+          targetUserId: mergeTarget.user.id,
+          reAuthenticatedAt: now,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.PolicyDenied })
+  })
+
+  it('keeps exact link behavior ahead of trust policy denial', async () => {
+    const sameUserKit = createInMemoryAuthKit({
+      policy: {
+        ...createDefaultAuthPolicy(),
+        canLinkIdentity: () => false,
+      },
+    })
+    const baseUser = await sameUserKit.service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'base-user',
+        email: 'base@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    const repeated = await sameUserKit.service.link({
+      userId: baseUser.user.id,
+      assertion: assertion({
+        provider: baseUser.identity.provider,
+        providerUserId: baseUser.identity.providerUserId,
+      }),
+      now,
+    })
+
+    expect(repeated.linked).toBe(false)
+
+    const otherUser = await sameUserKit.service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'other-user',
+        email: 'other@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    expect(
+      await sameUserKit.service
+        .link({
+          userId: otherUser.user.id,
+          assertion: assertion({
+            provider: baseUser.identity.provider,
+            providerUserId: baseUser.identity.providerUserId,
+          }),
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.IdentityAlreadyLinked })
+  })
+
+  it('defaults link policy to allow when a legacy custom policy omits the hook', async () => {
+    const compatibilityKit = createInMemoryAuthKit({
+      policy: {
+        canAutoLink: () => false,
+        canMergeUsers: () => false,
+        canUnlinkIdentity: () => true,
+        requiresReAuth: () => false,
+      },
+    })
+    const baseUser = await compatibilityKit.service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'compat-user',
+        email: 'compat@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    const linked = await compatibilityKit.service.link({
+      userId: baseUser.user.id,
+      assertion: assertion({
+        provider: 'compat-oauth',
+        providerUserId: 'compat-oauth-user',
+      }),
+      now,
+    })
+
+    expect(linked.linked).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add provider trust context to assertions and identities
- add trusted-provider policy hooks for link and merge decisions
- document the post-0.8 roadmap and release mapping for OAuth follow-up work

## Testing
- npm run check

Closes #38.
