### PR TITLE
feat: add Postgres reference persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ license, subscription, private contract, or other written permission.
 - Exposes ports for repositories, providers, sender infrastructure, rate limits, password hashing,
   audit logs, and transactions.
 - Ships an in-memory testing implementation through `@alyldas/uniauth/testing`.
+- Ships a reference Postgres persistence adapter through `@alyldas/uniauth/postgres`.
 
 ## What It Does Not Do
 
@@ -170,6 +171,16 @@ import {
 } from '@alyldas/uniauth/testing'
 ```
 
+Reference persistence helpers come from the Postgres entry point:
+
+```ts
+import {
+  POSTGRES_AUTH_SCHEMA_SQL,
+  applyPostgresAuthSchema,
+  createPostgresAuthStore,
+} from '@alyldas/uniauth/postgres'
+```
+
 There are no root side effects. Importing the package does not register providers, touch storage,
 create sessions, read environment variables, or mutate global state.
 
@@ -214,6 +225,9 @@ launch data. See [Messenger providers](docs/messenger-providers.md).
 
 OAuth/OIDC providers use an SDK-free client contract for authorization-code finish flows. See
 [OAuth / OIDC providers](docs/oauth-oidc.md).
+
+Reference Postgres persistence lives in a separate subpath so the core API stays ORM-free and does
+not take a hard runtime dependency on `pg`. See [Postgres persistence](docs/postgres.md).
 
 Public error helpers use the `UniAuth` brand casing:
 
@@ -398,6 +412,7 @@ persist raw provider profiles.
 ## Entry Points
 
 - `@alyldas/uniauth`: public domain types, service implementation, policy API, ports, errors, and utilities.
+- `@alyldas/uniauth/postgres`: reference Postgres repositories, schema helper, and transaction wiring.
 - `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, in-memory email
   and SMS senders, and test kit.
 
@@ -431,6 +446,7 @@ contact `alyldas@ya.ru`.
 - [Local auth flows](docs/local-auth.md)
 - [Messenger providers](docs/messenger-providers.md)
 - [OAuth / OIDC providers](docs/oauth-oidc.md)
+- [Postgres persistence](docs/postgres.md)
 - [Comparison](docs/comparison.md)
 - [Licensing and attribution](docs/licensing.md)
 - [Roadmap](docs/roadmap.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,13 @@ includes in-memory email and SMS senders, a rate limiter, and a deterministic pa
 local auth flows can be exercised without SMTP, SMS, Redis, or password-hashing runtime setup. It is
 not a production persistence adapter.
 
+## Reference Persistence
+
+`@alyldas/uniauth/postgres` provides a reference Postgres implementation for the repository ports and
+`UnitOfWork`. It accepts an application-owned `pg.Pool`-compatible object instead of bundling a
+database driver into the root package. Schema rollout and migrations remain application-owned even
+though the package also ships a reference SQL schema helper for bootstrap and tests.
+
 ## Adapter Requirements
 
 Storage adapters should:

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,0 +1,88 @@
+# Postgres Persistence
+
+`@alyldas/uniauth/postgres` provides a reference Postgres adapter for the existing repository ports.
+It stays ORM-free and does not ship a hard dependency on `pg`: the application owns the actual
+connection pool and passes a `pg.Pool`-compatible object into the adapter.
+
+## Public API
+
+```ts
+import {
+  POSTGRES_AUTH_SCHEMA_SQL,
+  applyPostgresAuthSchema,
+  createPostgresAuthStore,
+} from '@alyldas/uniauth/postgres'
+```
+
+## Runtime Boundary
+
+The application owns:
+
+- the actual `pg` dependency and pool lifecycle;
+- connection string and secret loading;
+- migrations and schema rollout policy;
+- retry policy and pool sizing;
+- backup, replication, and failover setup.
+
+UniAuth owns only the repository and transaction wiring around the existing ports.
+
+## Wiring Example
+
+```ts
+import { Pool } from 'pg'
+import { DefaultAuthService } from '@alyldas/uniauth'
+import { createPostgresAuthStore, applyPostgresAuthSchema } from '@alyldas/uniauth/postgres'
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+})
+
+await applyPostgresAuthSchema(pool)
+
+const store = createPostgresAuthStore({ pool })
+
+const service = new DefaultAuthService({
+  repos: store,
+  transaction: store,
+})
+```
+
+The adapter expects a `pg.Pool`-compatible object:
+
+- `query(text, values?)`
+- `connect()` returning a client with `query(...)` and `release()`
+
+## Schema
+
+`POSTGRES_AUTH_SCHEMA_SQL` creates:
+
+- `uniauth_users`
+- `uniauth_identities`
+- `uniauth_credentials`
+- `uniauth_verifications`
+- `uniauth_sessions`
+- `uniauth_audit_events`
+
+The reference schema intentionally includes:
+
+- a unique constraint on `(provider, provider_user_id)` in `uniauth_identities`;
+- unique constraints on `(type, subject)` and `(type, user_id)` in `uniauth_credentials`;
+- partial indexes for verified email and phone lookups on active identities;
+- explicit `jsonb` columns for adapter-owned `metadata` and provider `trust`.
+
+## Transaction Model
+
+`PostgresAuthStore` implements `UnitOfWork`. `run()` opens a database transaction, reuses the same
+client inside nested UniAuth flows, commits on success, and rolls back on error.
+
+This means link, unlink, merge, session, and verification writes can share the same transaction
+boundary when the service calls them through `DefaultAuthService`.
+
+## Security Notes
+
+- Verification secrets remain hashed at rest; the adapter stores only `secret_hash`.
+- Trust and metadata fields are stored as `jsonb`, but provider SDK objects should still be reduced
+  before they reach UniAuth.
+- The adapter does not infer ownership from email or phone outside the core policy flow.
+- Migrations remain application-owned. `applyPostgresAuthSchema()` is for reference bootstrap,
+  tests, and examples, not for production migration orchestration.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,22 +75,30 @@ Tracking issues: #33, #34, #35, #36.
 
 Tracking issues: #37, #49.
 
-## Next Release
-
-### v0.9 - Reference Persistence and OAuth Policy Follow-Up
+### v0.9 - Trusted Provider Policy
 
 - Trusted provider policy hooks.
+- Provider trust context on assertions and linked identities.
+- Backward-compatible policy extension point for explicit link decisions.
+- Policy and docs alignment for post-OAuth account-linking trust decisions.
+
+Tracking issues: #38.
+
+## Next Release
+
+### v0.10 - Reference Persistence
+
 - Postgres reference storage.
 - SQL schema example.
 - Transactional merge flow.
 - Indexes and constraints.
 - In-memory testing kit decomposition aligned with reference persistence boundaries.
 
-Tracking issues: #38, #40, #41, #42, #47.
+Tracking issues: #40, #41, #42, #47.
 
 ## Planned
 
-### v0.10 - Production Hardening and Integration Backlog
+### v0.11 - Production Hardening and Integration Backlog
 
 - Threat model documentation.
 - Production email and phone normalization design.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.0.0",
         "husky": "^9.1.7",
+        "pg-mem": "^3.0.14",
         "prettier": "^3.0.0",
         "publint": "^0.3.18",
         "tsup": "^8.0.0",
@@ -2539,6 +2540,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2896,6 +2947,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2905,6 +2974,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -2917,6 +2993,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/emoji-regex": {
@@ -2966,12 +3057,45 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3367,6 +3491,23 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3375,6 +3516,45 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/git-raw-commits": {
@@ -3436,6 +3616,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3444,6 +3637,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/highlight.js": {
@@ -3488,6 +3720,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3610,6 +3849,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3717,12 +3963,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4206,6 +4482,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -4257,6 +4543,23 @@
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
       }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -4313,6 +4616,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -4337,6 +4670,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/obug": {
@@ -4489,6 +4842,89 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg-mem": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.14.tgz",
+      "integrity": "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.2"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz",
+      "integrity": "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4662,6 +5098,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4704,6 +5161,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rolldown": {
@@ -4809,6 +5276,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -5467,6 +5952,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./postgres": {
+      "types": "./dist/postgres.d.ts",
+      "import": "./dist/postgres/index.js"
+    },
     "./testing": {
       "types": "./dist/testing/index.d.ts",
       "import": "./dist/testing/index.js"
@@ -83,6 +87,7 @@
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.0.0",
     "husky": "^9.1.7",
+    "pg-mem": "^3.0.14",
     "prettier": "^3.0.0",
     "publint": "^0.3.18",
     "tsup": "^8.0.0",

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -22,6 +22,7 @@ describe('package exports', () => {
 
   it('loads the public ESM entry points', async () => {
     const core = await import('../dist')
+    const postgres = await import('../dist/postgres')
     const testing = await import('../dist/testing')
 
     expect(core.AuditEventType.SignIn).toBe('auth.sign_in')
@@ -59,6 +60,9 @@ describe('package exports', () => {
     expect(core.getUniAuthAttributionNotice({ productName: 'Smoke App' })).toContain(
       `Smoke App uses ${packageMetadata.name}.`,
     )
+    expect(postgres.POSTGRES_AUTH_SCHEMA_SQL).toContain('create table if not exists uniauth_users')
+    expect(postgres.applyPostgresAuthSchema).toBeTypeOf('function')
+    expect(postgres.createPostgresAuthStore).toBeTypeOf('function')
     expect(testing.createInMemoryAuthKit).toBeTypeOf('function')
     expect(testing.InMemoryEmailSender).toBeTypeOf('function')
     expect(testing.InMemoryPasswordHasher).toBeTypeOf('function')
@@ -86,6 +90,7 @@ describe('package exports', () => {
     for (const privateProviderSubpath of [
       `${packageMetadata.name}/providers/messenger.js`,
       `${packageMetadata.name}/providers/oauth-oidc.js`,
+      `${packageMetadata.name}/postgres/store.js`,
     ]) {
       const result = spawnSync(
         process.execPath,

--- a/src/postgres.ts
+++ b/src/postgres.ts
@@ -1,0 +1,3 @@
+export * from './postgres/schema.js'
+export * from './postgres/store.js'
+export * from './postgres/types.js'

--- a/src/postgres/schema.ts
+++ b/src/postgres/schema.ts
@@ -1,0 +1,95 @@
+import type { PostgresQueryable } from './types.js'
+
+const schemaStatements = [
+  `create table if not exists uniauth_users (
+    id text primary key,
+    display_name text,
+    email text,
+    phone text,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    disabled_at timestamptz,
+    metadata jsonb
+  )`,
+  `create table if not exists uniauth_identities (
+    id text primary key,
+    user_id text not null references uniauth_users(id) on delete restrict,
+    provider text not null,
+    provider_user_id text not null,
+    status text not null check (status in ('active', 'disabled')),
+    email text,
+    email_verified boolean,
+    phone text,
+    phone_verified boolean,
+    trust jsonb,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    disabled_at timestamptz,
+    metadata jsonb,
+    constraint uniauth_identities_provider_user_key unique (provider, provider_user_id)
+  )`,
+  `create index if not exists uniauth_identities_user_idx on uniauth_identities (user_id)`,
+  `create index if not exists uniauth_identities_verified_email_idx
+    on uniauth_identities (email)
+    where status = 'active' and email_verified = true and email is not null`,
+  `create index if not exists uniauth_identities_verified_phone_idx
+    on uniauth_identities (phone)
+    where status = 'active' and phone_verified = true and phone is not null`,
+  `create table if not exists uniauth_credentials (
+    id text primary key,
+    user_id text not null references uniauth_users(id) on delete restrict,
+    type text not null,
+    subject text not null,
+    password_hash text not null,
+    created_at timestamptz not null,
+    updated_at timestamptz not null,
+    metadata jsonb,
+    constraint uniauth_credentials_type_subject_key unique (type, subject),
+    constraint uniauth_credentials_type_user_key unique (type, user_id)
+  )`,
+  `create index if not exists uniauth_credentials_user_idx on uniauth_credentials (user_id)`,
+  `create table if not exists uniauth_verifications (
+    id text primary key,
+    purpose text not null,
+    target text not null,
+    provider text,
+    channel text,
+    secret_hash text not null,
+    status text not null check (status in ('pending', 'consumed')),
+    created_at timestamptz not null,
+    expires_at timestamptz not null,
+    consumed_at timestamptz,
+    metadata jsonb
+  )`,
+  `create index if not exists uniauth_verifications_target_idx on uniauth_verifications (target)`,
+  `create table if not exists uniauth_sessions (
+    id text primary key,
+    user_id text not null references uniauth_users(id) on delete restrict,
+    status text not null check (status in ('active', 'revoked', 'expired')),
+    created_at timestamptz not null,
+    expires_at timestamptz not null,
+    revoked_at timestamptz,
+    last_seen_at timestamptz,
+    metadata jsonb
+  )`,
+  `create index if not exists uniauth_sessions_user_idx on uniauth_sessions (user_id)`,
+  `create table if not exists uniauth_audit_events (
+    id text primary key,
+    type text not null,
+    occurred_at timestamptz not null,
+    user_id text,
+    identity_id text,
+    session_id text,
+    metadata jsonb
+  )`,
+  `create index if not exists uniauth_audit_events_user_idx on uniauth_audit_events (user_id)`,
+  `create index if not exists uniauth_audit_events_occurred_idx on uniauth_audit_events (occurred_at)`,
+] as const
+
+export const POSTGRES_AUTH_SCHEMA_SQL = `${schemaStatements.join(';\n\n')};\n`
+
+export async function applyPostgresAuthSchema(database: PostgresQueryable): Promise<void> {
+  for (const statement of schemaStatements) {
+    await database.query(statement)
+  }
+}

--- a/src/postgres/store.ts
+++ b/src/postgres/store.ts
@@ -1,0 +1,857 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import {
+  asCredentialId,
+  asIdentityId,
+  asSessionId,
+  asUserId,
+  asVerificationId,
+  ProviderTrustLevel,
+  type AuthIdentity,
+  type AuthIdentityProvider,
+  type Credential,
+  type CredentialType,
+  type OtpChannel,
+  type ProviderTrustContext,
+  type Session,
+  type SessionStatus,
+  type User,
+  type Verification,
+  type VerificationPurpose,
+  type VerificationStatus,
+} from '../domain/types.js'
+import { UniAuthError, UniAuthErrorCode } from '../errors.js'
+import type {
+  AuditLogRepo,
+  AuthServiceRepositories,
+  CredentialRepo,
+  IdentityRepo,
+  SessionRepo,
+  UnitOfWork,
+  UserRepo,
+  VerificationRepo,
+} from '../ports.js'
+import { optionalProp } from '../utils/optional.js'
+import type {
+  CreatePostgresAuthStoreOptions,
+  PostgresAuthStoreLike,
+  PostgresPoolClient,
+  PostgresQueryable,
+} from './types.js'
+
+const UniqueViolationCode = '23505'
+
+interface UserRow {
+  readonly id: string
+  readonly display_name: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+  readonly disabled_at: Date | string | null
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+interface IdentityRow {
+  readonly id: string
+  readonly user_id: string
+  readonly provider: string
+  readonly provider_user_id: string
+  readonly status: AuthIdentity['status']
+  readonly email: string | null
+  readonly email_verified: boolean | null
+  readonly phone: string | null
+  readonly phone_verified: boolean | null
+  readonly trust: Record<string, unknown> | string | null
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+  readonly disabled_at: Date | string | null
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+interface CredentialRow {
+  readonly id: string
+  readonly user_id: string
+  readonly type: CredentialType
+  readonly subject: string
+  readonly password_hash: string
+  readonly created_at: Date | string
+  readonly updated_at: Date | string
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+interface VerificationRow {
+  readonly id: string
+  readonly purpose: VerificationPurpose
+  readonly target: string
+  readonly provider: string | null
+  readonly channel: OtpChannel | null
+  readonly secret_hash: string
+  readonly status: VerificationStatus
+  readonly created_at: Date | string
+  readonly expires_at: Date | string
+  readonly consumed_at: Date | string | null
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+interface SessionRow {
+  readonly id: string
+  readonly user_id: string
+  readonly status: SessionStatus
+  readonly created_at: Date | string
+  readonly expires_at: Date | string
+  readonly revoked_at: Date | string | null
+  readonly last_seen_at: Date | string | null
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+interface UpdateColumn {
+  readonly key: string
+  readonly column: string
+}
+
+export class PostgresAuthStore
+  implements PostgresAuthStoreLike, AuthServiceRepositories, UnitOfWork
+{
+  private readonly transactionScope = new AsyncLocalStorage<PostgresPoolClient>()
+
+  constructor(private readonly options: CreatePostgresAuthStoreOptions) {}
+
+  readonly userRepo: UserRepo = {
+    findById: async (id) =>
+      this.queryOptionalRow<UserRow, User>(
+        `select id, display_name, email, phone, created_at, updated_at, disabled_at, metadata
+         from uniauth_users
+         where id = $1`,
+        [id],
+        mapUserRow,
+      ),
+    create: async (user) =>
+      this.queryRequiredRow<UserRow, User>(
+        `insert into uniauth_users (
+           id, display_name, email, phone, created_at, updated_at, disabled_at, metadata
+         ) values ($1, $2, $3, $4, $5, $6, $7, $8)
+         returning id, display_name, email, phone, created_at, updated_at, disabled_at, metadata`,
+        [
+          user.id,
+          user.displayName ?? null,
+          user.email ?? null,
+          user.phone ?? null,
+          user.createdAt,
+          user.updatedAt,
+          user.disabledAt ?? null,
+          user.metadata ?? null,
+        ],
+        mapUserRow,
+      ),
+    update: async (id, patch) => {
+      const existing = await this.userRepo.findById(id)
+
+      if (!existing) {
+        throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+      }
+
+      const update = buildUpdateQuery(patch, [
+        { key: 'displayName', column: 'display_name' },
+        { key: 'email', column: 'email' },
+        { key: 'phone', column: 'phone' },
+        { key: 'updatedAt', column: 'updated_at' },
+        { key: 'disabledAt', column: 'disabled_at' },
+        { key: 'metadata', column: 'metadata' },
+      ])
+
+      if (!update) {
+        return existing
+      }
+
+      return this.queryRequiredRow<UserRow, User>(
+        `update uniauth_users
+         set ${update.setClause}
+         where id = $${update.values.length + 1}
+         returning id, display_name, email, phone, created_at, updated_at, disabled_at, metadata`,
+        [...update.values, id],
+        mapUserRow,
+      )
+    },
+  }
+
+  readonly identityRepo: IdentityRepo = {
+    findById: async (id) =>
+      this.queryOptionalRow<IdentityRow, AuthIdentity>(
+        `select
+           id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+           phone_verified, trust, created_at, updated_at, disabled_at, metadata
+         from uniauth_identities
+         where id = $1`,
+        [id],
+        mapIdentityRow,
+      ),
+    findByProviderUserId: async (provider, providerUserId) =>
+      this.queryOptionalRow<IdentityRow, AuthIdentity>(
+        `select
+           id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+           phone_verified, trust, created_at, updated_at, disabled_at, metadata
+         from uniauth_identities
+         where provider = $1 and provider_user_id = $2`,
+        [provider, providerUserId],
+        mapIdentityRow,
+      ),
+    findByVerifiedEmail: async (email) =>
+      this.queryRows<IdentityRow, AuthIdentity>(
+        `select
+           id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+           phone_verified, trust, created_at, updated_at, disabled_at, metadata
+         from uniauth_identities
+         where status = 'active' and email_verified = true and email = $1
+         order by created_at asc, id asc`,
+        [email],
+        mapIdentityRow,
+      ),
+    findByVerifiedPhone: async (phone) =>
+      this.queryRows<IdentityRow, AuthIdentity>(
+        `select
+           id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+           phone_verified, trust, created_at, updated_at, disabled_at, metadata
+         from uniauth_identities
+         where status = 'active' and phone_verified = true and phone = $1
+         order by created_at asc, id asc`,
+        [phone],
+        mapIdentityRow,
+      ),
+    listByUserId: async (userId) =>
+      this.queryRows<IdentityRow, AuthIdentity>(
+        `select
+           id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+           phone_verified, trust, created_at, updated_at, disabled_at, metadata
+         from uniauth_identities
+         where user_id = $1
+         order by created_at asc, id asc`,
+        [userId],
+        mapIdentityRow,
+      ),
+    create: async (identity) => {
+      try {
+        return await this.queryRequiredRow<IdentityRow, AuthIdentity>(
+          `insert into uniauth_identities (
+             id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+             phone_verified, trust, created_at, updated_at, disabled_at, metadata
+           ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+           returning
+             id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+             phone_verified, trust, created_at, updated_at, disabled_at, metadata`,
+          [
+            identity.id,
+            identity.userId,
+            identity.provider,
+            identity.providerUserId,
+            identity.status,
+            identity.email ?? null,
+            identity.emailVerified ?? null,
+            identity.phone ?? null,
+            identity.phoneVerified ?? null,
+            identity.trust ?? null,
+            identity.createdAt,
+            identity.updatedAt,
+            identity.disabledAt ?? null,
+            identity.metadata ?? null,
+          ],
+          mapIdentityRow,
+        )
+      } catch (error) {
+        throw mapIdentityWriteError(error)
+      }
+    },
+    update: async (id, patch) => {
+      const existing = await this.identityRepo.findById(id)
+
+      if (!existing) {
+        throw new UniAuthError(UniAuthErrorCode.IdentityNotFound, 'Identity was not found.')
+      }
+
+      const update = buildUpdateQuery(patch, [
+        { key: 'userId', column: 'user_id' },
+        { key: 'provider', column: 'provider' },
+        { key: 'providerUserId', column: 'provider_user_id' },
+        { key: 'status', column: 'status' },
+        { key: 'email', column: 'email' },
+        { key: 'emailVerified', column: 'email_verified' },
+        { key: 'phone', column: 'phone' },
+        { key: 'phoneVerified', column: 'phone_verified' },
+        { key: 'trust', column: 'trust' },
+        { key: 'updatedAt', column: 'updated_at' },
+        { key: 'disabledAt', column: 'disabled_at' },
+        { key: 'metadata', column: 'metadata' },
+      ])
+
+      if (!update) {
+        return existing
+      }
+
+      try {
+        return await this.queryRequiredRow<IdentityRow, AuthIdentity>(
+          `update uniauth_identities
+           set ${update.setClause}
+           where id = $${update.values.length + 1}
+           returning
+             id, user_id, provider, provider_user_id, status, email, email_verified, phone,
+             phone_verified, trust, created_at, updated_at, disabled_at, metadata`,
+          [...update.values, id],
+          mapIdentityRow,
+        )
+      } catch (error) {
+        throw mapIdentityWriteError(error)
+      }
+    },
+  }
+
+  readonly credentialRepo: CredentialRepo = {
+    findPasswordByEmail: async (email) =>
+      this.queryOptionalRow<CredentialRow, Credential>(
+        `select
+           id, user_id, type, subject, password_hash, created_at, updated_at, metadata
+         from uniauth_credentials
+         where type = 'password' and subject = $1`,
+        [email],
+        mapCredentialRow,
+      ),
+    findPasswordByUserId: async (userId) =>
+      this.queryOptionalRow<CredentialRow, Credential>(
+        `select
+           id, user_id, type, subject, password_hash, created_at, updated_at, metadata
+         from uniauth_credentials
+         where type = 'password' and user_id = $1`,
+        [userId],
+        mapCredentialRow,
+      ),
+    create: async (credential) => {
+      try {
+        return await this.queryRequiredRow<CredentialRow, Credential>(
+          `insert into uniauth_credentials (
+             id, user_id, type, subject, password_hash, created_at, updated_at, metadata
+           ) values ($1, $2, $3, $4, $5, $6, $7, $8)
+           returning
+             id, user_id, type, subject, password_hash, created_at, updated_at, metadata`,
+          [
+            credential.id,
+            credential.userId,
+            credential.type,
+            credential.subject,
+            credential.passwordHash,
+            credential.createdAt,
+            credential.updatedAt,
+            credential.metadata ?? null,
+          ],
+          mapCredentialRow,
+        )
+      } catch (error) {
+        throw mapCredentialWriteError(error)
+      }
+    },
+    update: async (id, patch) => {
+      const existing = await this.queryOptionalRow<CredentialRow, Credential>(
+        `select
+           id, user_id, type, subject, password_hash, created_at, updated_at, metadata
+         from uniauth_credentials
+         where id = $1`,
+        [id],
+        mapCredentialRow,
+      )
+
+      if (!existing) {
+        throw new UniAuthError(UniAuthErrorCode.CredentialNotFound, 'Credential was not found.')
+      }
+
+      const update = buildUpdateQuery(patch, [
+        { key: 'subject', column: 'subject' },
+        { key: 'passwordHash', column: 'password_hash' },
+        { key: 'updatedAt', column: 'updated_at' },
+        { key: 'metadata', column: 'metadata' },
+      ])
+
+      if (!update) {
+        return existing
+      }
+
+      try {
+        return await this.queryRequiredRow<CredentialRow, Credential>(
+          `update uniauth_credentials
+           set ${update.setClause}
+           where id = $${update.values.length + 1}
+           returning
+             id, user_id, type, subject, password_hash, created_at, updated_at, metadata`,
+          [...update.values, id],
+          mapCredentialRow,
+        )
+      } catch (error) {
+        throw mapCredentialWriteError(error)
+      }
+    },
+  }
+
+  readonly verificationRepo: VerificationRepo = {
+    findById: async (id) =>
+      this.queryOptionalRow<VerificationRow, Verification>(
+        `select
+           id, purpose, target, provider, channel, secret_hash, status, created_at, expires_at,
+           consumed_at, metadata
+         from uniauth_verifications
+         where id = $1`,
+        [id],
+        mapVerificationRow,
+      ),
+    create: async (verification) =>
+      this.queryRequiredRow<VerificationRow, Verification>(
+        `insert into uniauth_verifications (
+           id, purpose, target, provider, channel, secret_hash, status, created_at, expires_at,
+           consumed_at, metadata
+         ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+         returning
+           id, purpose, target, provider, channel, secret_hash, status, created_at, expires_at,
+           consumed_at, metadata`,
+        [
+          verification.id,
+          verification.purpose,
+          verification.target,
+          verification.provider ?? null,
+          verification.channel ?? null,
+          verification.secretHash,
+          verification.status,
+          verification.createdAt,
+          verification.expiresAt,
+          verification.consumedAt ?? null,
+          verification.metadata ?? null,
+        ],
+        mapVerificationRow,
+      ),
+    update: async (id, patch) => {
+      const existing = await this.verificationRepo.findById(id)
+
+      if (!existing) {
+        throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+      }
+
+      const update = buildUpdateQuery(patch, [
+        { key: 'purpose', column: 'purpose' },
+        { key: 'target', column: 'target' },
+        { key: 'provider', column: 'provider' },
+        { key: 'channel', column: 'channel' },
+        { key: 'secretHash', column: 'secret_hash' },
+        { key: 'status', column: 'status' },
+        { key: 'expiresAt', column: 'expires_at' },
+        { key: 'consumedAt', column: 'consumed_at' },
+        { key: 'metadata', column: 'metadata' },
+      ])
+
+      if (!update) {
+        return existing
+      }
+
+      return this.queryRequiredRow<VerificationRow, Verification>(
+        `update uniauth_verifications
+         set ${update.setClause}
+         where id = $${update.values.length + 1}
+         returning
+           id, purpose, target, provider, channel, secret_hash, status, created_at, expires_at,
+           consumed_at, metadata`,
+        [...update.values, id],
+        mapVerificationRow,
+      )
+    },
+  }
+
+  readonly sessionRepo: SessionRepo = {
+    findById: async (id) =>
+      this.queryOptionalRow<SessionRow, Session>(
+        `select
+           id, user_id, status, created_at, expires_at, revoked_at, last_seen_at, metadata
+         from uniauth_sessions
+         where id = $1`,
+        [id],
+        mapSessionRow,
+      ),
+    listByUserId: async (userId) =>
+      this.queryRows<SessionRow, Session>(
+        `select
+           id, user_id, status, created_at, expires_at, revoked_at, last_seen_at, metadata
+         from uniauth_sessions
+         where user_id = $1
+         order by created_at asc, id asc`,
+        [userId],
+        mapSessionRow,
+      ),
+    create: async (session) =>
+      this.queryRequiredRow<SessionRow, Session>(
+        `insert into uniauth_sessions (
+           id, user_id, status, created_at, expires_at, revoked_at, last_seen_at, metadata
+         ) values ($1, $2, $3, $4, $5, $6, $7, $8)
+         returning
+           id, user_id, status, created_at, expires_at, revoked_at, last_seen_at, metadata`,
+        [
+          session.id,
+          session.userId,
+          session.status,
+          session.createdAt,
+          session.expiresAt,
+          session.revokedAt ?? null,
+          session.lastSeenAt ?? null,
+          session.metadata ?? null,
+        ],
+        mapSessionRow,
+      ),
+    update: async (id, patch) => {
+      const existing = await this.sessionRepo.findById(id)
+
+      if (!existing) {
+        throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
+      }
+
+      const update = buildUpdateQuery(patch, [
+        { key: 'userId', column: 'user_id' },
+        { key: 'status', column: 'status' },
+        { key: 'expiresAt', column: 'expires_at' },
+        { key: 'revokedAt', column: 'revoked_at' },
+        { key: 'lastSeenAt', column: 'last_seen_at' },
+        { key: 'metadata', column: 'metadata' },
+      ])
+
+      if (!update) {
+        return existing
+      }
+
+      return this.queryRequiredRow<SessionRow, Session>(
+        `update uniauth_sessions
+         set ${update.setClause}
+         where id = $${update.values.length + 1}
+         returning
+           id, user_id, status, created_at, expires_at, revoked_at, last_seen_at, metadata`,
+        [...update.values, id],
+        mapSessionRow,
+      )
+    },
+  }
+
+  readonly auditLogRepo: AuditLogRepo = {
+    append: async (event) => {
+      await this.query(
+        `insert into uniauth_audit_events (
+           id, type, occurred_at, user_id, identity_id, session_id, metadata
+         ) values ($1, $2, $3, $4, $5, $6, $7)`,
+        [
+          event.id,
+          event.type,
+          event.occurredAt,
+          event.userId ?? null,
+          event.identityId ?? null,
+          event.sessionId ?? null,
+          event.metadata ?? null,
+        ],
+      )
+    },
+  }
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    const activeTransaction = this.transactionScope.getStore()
+
+    if (activeTransaction) {
+      return operation()
+    }
+
+    const client = await this.options.pool.connect()
+
+    try {
+      await client.query('begin')
+      const result = await this.transactionScope.run(client, operation)
+      await client.query('commit')
+      return result
+    } catch (error) {
+      try {
+        await client.query('rollback')
+      } catch {
+        // rollback failure should not hide the original error
+      }
+
+      throw error
+    } finally {
+      await client.release()
+    }
+  }
+
+  private async query(text: string, values?: readonly unknown[]): Promise<void> {
+    await this.currentExecutor().query(text, values)
+  }
+
+  private async queryOptionalRow<Row extends object, Result>(
+    text: string,
+    values: readonly unknown[],
+    mapRow: (row: Row) => Result,
+  ): Promise<Result | undefined> {
+    const result = await this.currentExecutor().query<Row>(text, values)
+    const row = result.rows[0]
+    return row ? mapRow(row) : undefined
+  }
+
+  private async queryRequiredRow<Row extends object, Result>(
+    text: string,
+    values: readonly unknown[],
+    mapRow: (row: Row) => Result,
+  ): Promise<Result> {
+    const result = await this.queryOptionalRow(text, values, mapRow)
+
+    if (!result) {
+      throw new Error('Expected a database row to be returned.')
+    }
+
+    return result
+  }
+
+  private async queryRows<Row extends object, Result>(
+    text: string,
+    values: readonly unknown[],
+    mapRow: (row: Row) => Result,
+  ): Promise<readonly Result[]> {
+    const result = await this.currentExecutor().query<Row>(text, values)
+    return result.rows.map(mapRow)
+  }
+
+  private currentExecutor(): PostgresQueryable {
+    return this.transactionScope.getStore() ?? this.options.pool
+  }
+}
+
+export function createPostgresAuthStore(
+  options: CreatePostgresAuthStoreOptions,
+): PostgresAuthStore {
+  return new PostgresAuthStore(options)
+}
+
+function mapUserRow(row: UserRow): User {
+  return {
+    id: asUserId(row.id),
+    createdAt: readDate(row.created_at),
+    updatedAt: readDate(row.updated_at),
+    ...optionalProp('displayName', readString(row.display_name)),
+    ...optionalProp('email', readString(row.email)),
+    ...optionalProp('phone', readString(row.phone)),
+    ...optionalProp('disabledAt', readOptionalDate(row.disabled_at)),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+function mapIdentityRow(row: IdentityRow): AuthIdentity {
+  return {
+    id: asIdentityId(row.id),
+    userId: asUserId(row.user_id),
+    provider: row.provider,
+    providerUserId: row.provider_user_id,
+    status: row.status,
+    createdAt: readDate(row.created_at),
+    updatedAt: readDate(row.updated_at),
+    ...optionalProp('email', readString(row.email)),
+    ...(row.email_verified !== null ? { emailVerified: row.email_verified } : {}),
+    ...optionalProp('phone', readString(row.phone)),
+    ...(row.phone_verified !== null ? { phoneVerified: row.phone_verified } : {}),
+    ...optionalProp('trust', readProviderTrust(row.trust)),
+    ...optionalProp('disabledAt', readOptionalDate(row.disabled_at)),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+function mapCredentialRow(row: CredentialRow): Credential {
+  return {
+    id: asCredentialId(row.id),
+    userId: asUserId(row.user_id),
+    type: row.type,
+    subject: row.subject,
+    passwordHash: row.password_hash,
+    createdAt: readDate(row.created_at),
+    updatedAt: readDate(row.updated_at),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+function mapVerificationRow(row: VerificationRow): Verification {
+  return {
+    id: asVerificationId(row.id),
+    purpose: row.purpose,
+    target: row.target,
+    secretHash: row.secret_hash,
+    status: row.status,
+    createdAt: readDate(row.created_at),
+    expiresAt: readDate(row.expires_at),
+    ...optionalProp('provider', readString(row.provider) as AuthIdentityProvider | undefined),
+    ...optionalProp('channel', row.channel ?? undefined),
+    ...optionalProp('consumedAt', readOptionalDate(row.consumed_at)),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+function mapSessionRow(row: SessionRow): Session {
+  return {
+    id: asSessionId(row.id),
+    userId: asUserId(row.user_id),
+    status: row.status,
+    createdAt: readDate(row.created_at),
+    expiresAt: readDate(row.expires_at),
+    ...optionalProp('revokedAt', readOptionalDate(row.revoked_at)),
+    ...optionalProp('lastSeenAt', readOptionalDate(row.last_seen_at)),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+function buildUpdateQuery(
+  patch: Record<string, unknown>,
+  columns: readonly UpdateColumn[],
+): { readonly setClause: string; readonly values: readonly unknown[] } | undefined {
+  const assignments: string[] = []
+  const values: unknown[] = []
+
+  for (const column of columns) {
+    if (!Object.prototype.hasOwnProperty.call(patch, column.key)) {
+      continue
+    }
+
+    assignments.push(`${column.column} = $${values.length + 1}`)
+    values.push(patch[column.key] ?? null)
+  }
+
+  if (assignments.length === 0) {
+    return undefined
+  }
+
+  return {
+    setClause: assignments.join(', '),
+    values,
+  }
+}
+
+function mapIdentityWriteError(error: unknown): Error {
+  if (isUniqueViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
+  }
+
+  return toError(error)
+}
+
+function mapCredentialWriteError(error: unknown): Error {
+  if (isUniqueViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.CredentialAlreadyExists, 'Credential already exists.')
+  }
+
+  return toError(error)
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? (error as { code?: unknown }).code === UniqueViolationCode
+    : false
+}
+
+function readDate(value: Date | string): Date {
+  if (value instanceof Date) {
+    return value
+  }
+
+  const parsed = new Date(value)
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('Invalid date value returned from Postgres.')
+  }
+
+  return parsed
+}
+
+function readOptionalDate(value: Date | string | null): Date | undefined {
+  return value === null ? undefined : readDate(value)
+}
+
+function readString(value: string | null): string | undefined {
+  return value ?? undefined
+}
+
+function readJsonObject(
+  value: Record<string, unknown> | string | null,
+): Record<string, unknown> | undefined {
+  if (value === null) {
+    return undefined
+  }
+
+  if (typeof value === 'string') {
+    const parsed = JSON.parse(value) as unknown
+    return ensureRecord(parsed)
+  }
+
+  return ensureRecord(value)
+}
+
+function readProviderTrust(
+  value: Record<string, unknown> | string | null,
+): ProviderTrustContext | undefined {
+  const record = readJsonObject(value)
+
+  if (!record) {
+    return undefined
+  }
+
+  const level = readTrustLevel(record.level)
+
+  if (!level) {
+    throw new Error('Invalid provider trust payload returned from Postgres.')
+  }
+
+  const signals = readTrustSignals(record.signals)
+
+  return {
+    level,
+    ...optionalProp('signals', signals),
+    ...optionalProp('metadata', readNestedRecord(record.metadata)),
+  }
+}
+
+function readTrustLevel(value: unknown): ProviderTrustLevel | undefined {
+  if (value === ProviderTrustLevel.Trusted) {
+    return ProviderTrustLevel.Trusted
+  }
+
+  if (value === ProviderTrustLevel.Neutral) {
+    return ProviderTrustLevel.Neutral
+  }
+
+  if (value === ProviderTrustLevel.Untrusted) {
+    return ProviderTrustLevel.Untrusted
+  }
+
+  return undefined
+}
+
+function readTrustSignals(value: unknown): readonly string[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new Error('Invalid provider trust signals returned from Postgres.')
+  }
+
+  return value.length > 0
+    ? [...new Set(value.map((entry) => entry.trim()).filter(Boolean))]
+    : undefined
+}
+
+function readNestedRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) {
+    return undefined
+  }
+
+  return ensureRecord(value)
+}
+
+function ensureRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Expected a JSON object returned from Postgres.')
+  }
+
+  return value as Record<string, unknown>
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error('Unknown Postgres error.')
+}

--- a/src/postgres/types.ts
+++ b/src/postgres/types.ts
@@ -1,0 +1,27 @@
+import type { AuthServiceRepositories, UnitOfWork } from '../ports.js'
+
+export interface PostgresQueryResult<Row extends object = Record<string, unknown>> {
+  readonly rows: readonly Row[]
+  readonly rowCount: number | null
+}
+
+export interface PostgresQueryable {
+  query<Row extends object = Record<string, unknown>>(
+    text: string,
+    values?: readonly unknown[],
+  ): Promise<PostgresQueryResult<Row>>
+}
+
+export interface PostgresPoolClient extends PostgresQueryable {
+  release(): void | Promise<void>
+}
+
+export interface PostgresPool extends PostgresQueryable {
+  connect(): Promise<PostgresPoolClient>
+}
+
+export interface CreatePostgresAuthStoreOptions {
+  readonly pool: PostgresPool
+}
+
+export interface PostgresAuthStoreLike extends AuthServiceRepositories, UnitOfWork {}

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -1,0 +1,555 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ProviderTrustLevel,
+  UniAuthErrorCode,
+  asCredentialId,
+  asIdentityId,
+  asSessionId,
+  asUserId,
+  asVerificationId,
+} from '../src'
+import {
+  createPostgresAuthStore,
+  type PostgresPool,
+  type PostgresPoolClient,
+  type PostgresQueryResult,
+} from '../src/postgres'
+
+type QueryStep =
+  | {
+      readonly kind: 'result'
+      readonly rows?: readonly object[]
+      readonly rowCount?: number | null
+    }
+  | {
+      readonly kind: 'error'
+      readonly error: unknown
+    }
+
+interface RecordedQuery {
+  readonly executor: 'pool' | 'client'
+  readonly text: string
+  readonly values: readonly unknown[] | undefined
+}
+
+interface StubPoolHarness {
+  readonly calls: readonly RecordedQuery[]
+  readonly connectCount: number
+  readonly releaseCount: number
+  readonly pool: PostgresPool
+  readonly remainingSteps: number
+}
+
+function result(rows: readonly object[] = [], rowCount?: number | null): QueryStep {
+  return rowCount === undefined
+    ? {
+        kind: 'result',
+        rows,
+      }
+    : {
+        kind: 'result',
+        rows,
+        rowCount,
+      }
+}
+
+function failure(error: unknown): QueryStep {
+  return {
+    kind: 'error',
+    error,
+  }
+}
+
+function createStubPool(steps: readonly QueryStep[]): StubPoolHarness {
+  const queue = [...steps]
+  const calls: RecordedQuery[] = []
+  let connectCount = 0
+  let releaseCount = 0
+
+  const runQuery =
+    (executor: 'pool' | 'client') =>
+    async <Row extends object = Record<string, unknown>>(
+      text: string,
+      values?: readonly unknown[],
+    ): Promise<PostgresQueryResult<Row>> => {
+      calls.push({ executor, text, values })
+
+      const next = queue.shift()
+
+      if (!next) {
+        throw new Error(`Unexpected query: ${text}`)
+      }
+
+      if (next.kind === 'error') {
+        throw next.error
+      }
+
+      const rows = (next.rows ?? []) as readonly Row[]
+
+      return {
+        rows,
+        rowCount: next.rowCount ?? rows.length,
+      }
+    }
+
+  const client: PostgresPoolClient = {
+    query: runQuery('client'),
+    async release() {
+      releaseCount += 1
+    },
+  }
+
+  const pool: PostgresPool = {
+    query: runQuery('pool'),
+    async connect() {
+      connectCount += 1
+      return client
+    },
+  }
+
+  return {
+    get calls() {
+      return calls
+    },
+    get connectCount() {
+      return connectCount
+    },
+    get releaseCount() {
+      return releaseCount
+    },
+    pool,
+    get remainingSteps() {
+      return queue.length
+    },
+  }
+}
+
+function userRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'user-1',
+    display_name: null,
+    email: null,
+    phone: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    disabled_at: null,
+    metadata: null,
+    ...overrides,
+  }
+}
+
+function identityRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'identity-1',
+    user_id: 'user-1',
+    provider: 'oidc',
+    provider_user_id: 'provider-user-1',
+    status: 'active',
+    email: 'user@example.com',
+    email_verified: true,
+    phone: null,
+    phone_verified: null,
+    trust: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    disabled_at: null,
+    metadata: null,
+    ...overrides,
+  }
+}
+
+function credentialRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'credential-1',
+    user_id: 'user-1',
+    type: 'password',
+    subject: 'user@example.com',
+    password_hash: 'hashed-password',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    metadata: null,
+    ...overrides,
+  }
+}
+
+function verificationRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'verification-1',
+    purpose: 'sign-in',
+    target: 'user@example.com',
+    provider: null,
+    channel: null,
+    secret_hash: 'hashed-secret',
+    status: 'pending',
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-01-01T00:10:00.000Z',
+    consumed_at: null,
+    metadata: null,
+    ...overrides,
+  }
+}
+
+function sessionRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'session-1',
+    user_id: 'user-1',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-01-31T00:00:00.000Z',
+    revoked_at: null,
+    last_seen_at: null,
+    metadata: null,
+    ...overrides,
+  }
+}
+
+describe('PostgresAuthStore unit coverage', () => {
+  it('maps row payloads from the pool into public entities', async () => {
+    const harness = createStubPool([
+      result([
+        userRow({
+          display_name: 'Alice',
+          email: 'alice@example.com',
+          phone: '+10000000000',
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: '2026-01-01T00:01:00.000Z',
+          disabled_at: '2026-01-01T00:02:00.000Z',
+          metadata: '{"role":"admin"}',
+        }),
+      ]),
+      result([
+        identityRow({
+          trust: JSON.stringify({
+            level: ProviderTrustLevel.Trusted,
+            signals: [' device ', '', 'device', 'federated'],
+            metadata: { source: 'oidc' },
+          }),
+          phone: '+10000000000',
+          phone_verified: true,
+          disabled_at: '2026-01-01T00:03:00.000Z',
+          metadata: { state: 'seeded' },
+        }),
+      ]),
+      result([
+        {
+          ...identityRow(),
+          id: 'identity-2',
+          provider_user_id: 'provider-user-2',
+          email_verified: null,
+          trust: {
+            level: ProviderTrustLevel.Neutral,
+            signals: [],
+            metadata: null,
+          },
+        },
+      ]),
+      result([
+        {
+          ...identityRow(),
+          id: 'identity-3',
+          provider_user_id: 'provider-user-3',
+          trust: {
+            level: ProviderTrustLevel.Untrusted,
+          },
+        },
+      ]),
+      result([
+        {
+          ...identityRow({
+            id: 'identity-4',
+            provider_user_id: 'provider-user-4',
+            phone: '+12223334444',
+            phone_verified: true,
+          }),
+          trust: null,
+        },
+      ]),
+      result([
+        {
+          ...identityRow({
+            id: 'identity-5',
+            provider_user_id: 'provider-user-5',
+          }),
+          trust: {
+            level: ProviderTrustLevel.Trusted,
+            metadata: null,
+          },
+        },
+      ]),
+      result([
+        credentialRow({
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          updated_at: '2026-01-01T00:04:00.000Z',
+          metadata: '{"source":"import"}',
+        }),
+      ]),
+      result([
+        verificationRow({
+          provider: 'email-otp',
+          channel: 'email',
+          consumed_at: '2026-01-01T00:05:00.000Z',
+          metadata: { attempt: 1 },
+        }),
+      ]),
+      result([
+        sessionRow({
+          revoked_at: '2026-01-01T00:06:00.000Z',
+          last_seen_at: new Date('2026-01-01T00:07:00.000Z'),
+        }),
+      ]),
+    ])
+    const store = createPostgresAuthStore({ pool: harness.pool })
+
+    await expect(store.userRepo.findById(asUserId('user-1'))).resolves.toMatchObject({
+      id: asUserId('user-1'),
+      displayName: 'Alice',
+      email: 'alice@example.com',
+      phone: '+10000000000',
+      metadata: { role: 'admin' },
+    })
+    await expect(store.identityRepo.findById(asIdentityId('identity-1'))).resolves.toMatchObject({
+      id: asIdentityId('identity-1'),
+      trust: {
+        level: ProviderTrustLevel.Trusted,
+        signals: ['device', 'federated'],
+        metadata: { source: 'oidc' },
+      },
+      metadata: { state: 'seeded' },
+    })
+    await expect(
+      store.identityRepo.findByProviderUserId('oidc', 'provider-user-2'),
+    ).resolves.toMatchObject({
+      id: asIdentityId('identity-2'),
+      trust: { level: ProviderTrustLevel.Neutral },
+    })
+    await expect(store.identityRepo.findByVerifiedEmail('user@example.com')).resolves.toMatchObject(
+      [
+        {
+          id: asIdentityId('identity-3'),
+          trust: { level: ProviderTrustLevel.Untrusted },
+        },
+      ],
+    )
+    await expect(store.identityRepo.findByVerifiedPhone('+12223334444')).resolves.toMatchObject([
+      {
+        id: asIdentityId('identity-4'),
+      },
+    ])
+    await expect(store.identityRepo.listByUserId(asUserId('user-1'))).resolves.toMatchObject([
+      {
+        id: asIdentityId('identity-5'),
+        trust: { level: ProviderTrustLevel.Trusted },
+      },
+    ])
+    await expect(
+      store.credentialRepo.findPasswordByEmail('user@example.com'),
+    ).resolves.toMatchObject({
+      id: asCredentialId('credential-1'),
+      metadata: { source: 'import' },
+    })
+    await expect(
+      store.verificationRepo.findById(asVerificationId('verification-1')),
+    ).resolves.toMatchObject({
+      id: asVerificationId('verification-1'),
+      provider: 'email-otp',
+      channel: 'email',
+      metadata: { attempt: 1 },
+    })
+    await expect(store.sessionRepo.findById(asSessionId('session-1'))).resolves.toMatchObject({
+      id: asSessionId('session-1'),
+      status: 'active',
+    })
+
+    expect(harness.remainingSteps).toBe(0)
+  })
+
+  it('maps write failures into domain and generic errors', async () => {
+    const identityWriteError = new Error('identity write failed')
+    const credentialWriteError = new Error('credential write failed')
+    const harness = createStubPool([
+      failure({ code: '23505' }),
+      failure('identity-unknown'),
+      result([identityRow()]),
+      failure(identityWriteError),
+      failure({ code: '23505' }),
+      failure('credential-unknown'),
+      result([credentialRow()]),
+      failure(credentialWriteError),
+    ])
+    const store = createPostgresAuthStore({ pool: harness.pool })
+
+    await expect(
+      store.identityRepo.create({
+        id: asIdentityId('identity-create-1'),
+        userId: asUserId('user-1'),
+        provider: 'oidc',
+        providerUserId: 'provider-user-create-1',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.IdentityAlreadyLinked,
+    })
+    await expect(
+      store.identityRepo.create({
+        id: asIdentityId('identity-create-2'),
+        userId: asUserId('user-1'),
+        provider: 'oidc',
+        providerUserId: 'provider-user-create-2',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('Unknown Postgres error.')
+    await expect(
+      store.identityRepo.update(asIdentityId('identity-1'), {
+        providerUserId: 'updated-provider-user',
+      }),
+    ).rejects.toBe(identityWriteError)
+
+    await expect(
+      store.credentialRepo.create({
+        id: asCredentialId('credential-create-1'),
+        userId: asUserId('user-1'),
+        type: 'password',
+        subject: 'user@example.com',
+        passwordHash: 'hash',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.CredentialAlreadyExists,
+    })
+    await expect(
+      store.credentialRepo.create({
+        id: asCredentialId('credential-create-2'),
+        userId: asUserId('user-1'),
+        type: 'password',
+        subject: 'user@example.com',
+        passwordHash: 'hash',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('Unknown Postgres error.')
+    await expect(
+      store.credentialRepo.update(asCredentialId('credential-1'), { passwordHash: 'new-hash' }),
+    ).rejects.toBe(credentialWriteError)
+
+    expect(harness.remainingSteps).toBe(0)
+  })
+
+  it('surfaces invalid database payloads and missing required rows', async () => {
+    const harness = createStubPool([
+      result(),
+      result([
+        userRow({
+          created_at: 'not-a-date',
+        }),
+      ]),
+      result([
+        userRow({
+          metadata: '[]',
+        }),
+      ]),
+      result([
+        identityRow({
+          trust: { level: 'invalid-trust-level' },
+        }),
+      ]),
+      result([
+        identityRow({
+          trust: { level: ProviderTrustLevel.Trusted, signals: [1] },
+        }),
+      ]),
+      result([
+        identityRow({
+          trust: { level: ProviderTrustLevel.Trusted, metadata: [] },
+        }),
+      ]),
+    ])
+    const store = createPostgresAuthStore({ pool: harness.pool })
+
+    await expect(
+      store.userRepo.create({
+        id: asUserId('user-create-1'),
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('Expected a database row to be returned.')
+    await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
+      'Invalid date value returned from Postgres.',
+    )
+    await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
+      'Expected a JSON object returned from Postgres.',
+    )
+    await expect(store.identityRepo.findById(asIdentityId('identity-1'))).rejects.toThrow(
+      'Invalid provider trust payload returned from Postgres.',
+    )
+    await expect(store.identityRepo.findById(asIdentityId('identity-1'))).rejects.toThrow(
+      'Invalid provider trust signals returned from Postgres.',
+    )
+    await expect(store.identityRepo.findById(asIdentityId('identity-1'))).rejects.toThrow(
+      'Expected a JSON object returned from Postgres.',
+    )
+
+    expect(harness.remainingSteps).toBe(0)
+  })
+
+  it('runs transactional operations through the client and handles rollbacks', async () => {
+    const successHarness = createStubPool([
+      result(),
+      result([userRow({ id: 'transaction-user' })]),
+      result(),
+    ])
+    const successStore = createPostgresAuthStore({ pool: successHarness.pool })
+
+    await expect(
+      successStore.run(async () => {
+        await expect(
+          successStore.userRepo.findById(asUserId('transaction-user')),
+        ).resolves.toMatchObject({
+          id: asUserId('transaction-user'),
+        })
+
+        return successStore.run(async () => 'nested-ok')
+      }),
+    ).resolves.toBe('nested-ok')
+
+    expect(successHarness.connectCount).toBe(1)
+    expect(successHarness.releaseCount).toBe(1)
+    expect(successHarness.calls.map((call) => call.executor)).toEqual([
+      'client',
+      'client',
+      'client',
+    ])
+
+    const rollbackHarness = createStubPool([result(), result()])
+    const rollbackStore = createPostgresAuthStore({ pool: rollbackHarness.pool })
+    const originalError = new Error('transaction failed')
+
+    await expect(
+      rollbackStore.run(async () => {
+        throw originalError
+      }),
+    ).rejects.toBe(originalError)
+
+    expect(rollbackHarness.connectCount).toBe(1)
+    expect(rollbackHarness.releaseCount).toBe(1)
+    expect(rollbackHarness.calls.map((call) => call.text)).toEqual(['begin', 'rollback'])
+
+    const rollbackFailureHarness = createStubPool([result(), failure(new Error('rollback failed'))])
+    const rollbackFailureStore = createPostgresAuthStore({ pool: rollbackFailureHarness.pool })
+    const rollbackOriginalError = new Error('still fail')
+
+    await expect(
+      rollbackFailureStore.run(async () => {
+        throw rollbackOriginalError
+      }),
+    ).rejects.toBe(rollbackOriginalError)
+
+    expect(rollbackFailureHarness.connectCount).toBe(1)
+    expect(rollbackFailureHarness.releaseCount).toBe(1)
+    expect(rollbackFailureHarness.calls.map((call) => call.text)).toEqual(['begin', 'rollback'])
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,0 +1,447 @@
+import { newDb } from 'pg-mem'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  AuthIdentityStatus,
+  ProviderTrustLevel,
+  SessionStatus,
+  UniAuthErrorCode,
+  VerificationStatus,
+  VerificationPurpose,
+  asAuditEventId,
+  asCredentialId,
+  asIdentityId,
+  asSessionId,
+  asUserId,
+  asVerificationId,
+  createAuthService,
+  createDefaultAuthPolicy,
+  createSequentialIdGenerator,
+  type Credential,
+} from '../src'
+import {
+  applyPostgresAuthSchema,
+  createPostgresAuthStore,
+  type PostgresPool,
+} from '../src/postgres'
+import { InMemoryPasswordHasher, StaticAuthProvider } from '../src/testing'
+import { identity, now, user } from './helpers.js'
+
+interface PostgresTestKit {
+  readonly pool: PostgresPool & { end(): Promise<void> }
+  readonly store: ReturnType<typeof createPostgresAuthStore>
+  readonly service: ReturnType<typeof createAuthService>
+}
+
+const openPools = new Set<{ end(): Promise<void> }>()
+
+afterEach(async () => {
+  for (const pool of openPools) {
+    await pool.end()
+  }
+
+  openPools.clear()
+})
+
+async function createPostgresTestKit(): Promise<PostgresTestKit> {
+  const database = newDb({ autoCreateForeignKeyIndices: true })
+  const pg = database.adapters.createPg()
+  const pool = new pg.Pool() as PostgresPool & { end(): Promise<void> }
+
+  openPools.add(pool)
+
+  await applyPostgresAuthSchema(pool)
+
+  const store = createPostgresAuthStore({ pool })
+  const provider = new StaticAuthProvider('oidc', {
+    providerUserId: 'oidc-user',
+    email: 'oidc@example.com',
+    emailVerified: true,
+    trust: {
+      level: ProviderTrustLevel.Trusted,
+      signals: ['oidc-email-verified'],
+    },
+  })
+  const providerRegistry = {
+    async get(id: string) {
+      return id === provider.id ? provider : undefined
+    },
+  }
+
+  const service = createAuthService({
+    repos: store,
+    transaction: store,
+    providerRegistry,
+    idGenerator: createSequentialIdGenerator('pg'),
+    passwordHasher: new InMemoryPasswordHasher(),
+    policy: createDefaultAuthPolicy({
+      allowAutoLink: true,
+      allowMergeAccounts: true,
+      requireReAuthFor: [],
+    }),
+  })
+
+  return {
+    pool,
+    store,
+    service,
+  }
+}
+
+describe('Postgres reference persistence', () => {
+  it('applies the schema and supports repository round-trips', async () => {
+    const { pool, store } = await createPostgresTestKit()
+    const idGenerator = createSequentialIdGenerator('pg-repo')
+    const createdUser = await store.userRepo.create(user('pg-user-1'))
+    const createdIdentity = await store.identityRepo.create(
+      identity({
+        id: idGenerator.identityId(),
+        userId: createdUser.id,
+        provider: 'email',
+        providerUserId: 'pg-user@example.com',
+        email: 'pg-user@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+          signals: ['seeded'],
+        },
+      }),
+    )
+    const credential: Credential = {
+      id: asCredentialId('pg-credential-1'),
+      userId: createdUser.id,
+      type: 'password',
+      subject: 'pg-user@example.com',
+      passwordHash: 'hashed-password',
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    await store.credentialRepo.create(credential)
+    await store.sessionRepo.create({
+      id: createSequentialIdGenerator('pg-session').sessionId(),
+      userId: createdUser.id,
+      status: 'active',
+      createdAt: now,
+      expiresAt: new Date('2026-01-31T00:00:00.000Z'),
+    })
+    await store.verificationRepo.create({
+      id: createSequentialIdGenerator('pg-verification').verificationId(),
+      purpose: VerificationPurpose.SignIn,
+      target: 'pg-user@example.com',
+      secretHash: 'hashed-secret',
+      status: 'pending',
+      createdAt: now,
+      expiresAt: new Date('2026-01-01T00:10:00.000Z'),
+    })
+    await store.auditLogRepo.append({
+      id: asAuditEventId('pg-audit-1'),
+      type: 'auth.sign_in',
+      occurredAt: now,
+      userId: createdUser.id,
+      identityId: createdIdentity.id,
+    })
+
+    expect(await store.userRepo.findById(createdUser.id)).toMatchObject({
+      id: createdUser.id,
+    })
+    expect(
+      await store.identityRepo.findByProviderUserId('email', 'pg-user@example.com'),
+    ).toMatchObject({
+      id: createdIdentity.id,
+      trust: {
+        level: ProviderTrustLevel.Trusted,
+        signals: ['seeded'],
+      },
+    })
+    expect(await store.identityRepo.findByVerifiedEmail('pg-user@example.com')).toHaveLength(1)
+    expect(await store.credentialRepo.findPasswordByEmail('pg-user@example.com')).toMatchObject({
+      id: credential.id,
+    })
+    expect(await store.sessionRepo.listByUserId(createdUser.id)).toHaveLength(1)
+    expect(
+      await pool.query<{ count: number }>(
+        'select count(*)::int as count from uniauth_audit_events',
+      ),
+    ).toMatchObject({
+      rows: [{ count: 1 }],
+    })
+
+    expect(
+      await store.identityRepo
+        .create(
+          identity({
+            id: createSequentialIdGenerator('duplicate-identity').identityId(),
+            userId: createdUser.id,
+            provider: 'email',
+            providerUserId: 'pg-user@example.com',
+          }),
+        )
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.IdentityAlreadyLinked })
+    expect(
+      await store.credentialRepo
+        .create({
+          ...credential,
+          id: asCredentialId('pg-credential-2'),
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.CredentialAlreadyExists })
+  })
+
+  it('runs core auth flows on top of the Postgres store', async () => {
+    const { pool, service } = await createPostgresTestKit()
+
+    const first = await service.signIn({
+      provider: 'oidc',
+      finishInput: { payload: { code: 'oidc-code' } },
+      now,
+    })
+    const second = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'oidc@example.com',
+        email: 'oidc@example.com',
+        emailVerified: true,
+        trust: {
+          level: ProviderTrustLevel.Trusted,
+          signals: ['first-party-email'],
+        },
+      },
+      now,
+    })
+    const verification = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'oidc@example.com',
+      secret: '123456',
+      now,
+    })
+
+    expect(first.user.id).toBe(second.user.id)
+    expect(second.isNewIdentity).toBe(true)
+
+    const storedVerification = await pool.query<{ secret_hash: string }>(
+      'select secret_hash from uniauth_verifications where id = $1',
+      [verification.verification.id],
+    )
+
+    expect(storedVerification.rows[0]?.secret_hash).toBeTypeOf('string')
+    expect(storedVerification.rows[0]?.secret_hash).not.toBe('123456')
+  })
+
+  it('persists writes executed inside the transaction boundary', async () => {
+    const { store } = await createPostgresTestKit()
+    const transactionUser = user('tx-user-1')
+
+    const created = await store.run(async () => store.userRepo.create(transactionUser))
+
+    expect(created.id).toBe(transactionUser.id)
+    expect(await store.userRepo.findById(transactionUser.id)).toMatchObject({
+      id: transactionUser.id,
+    })
+  })
+
+  it('supports update flows and not-found branches across repositories', async () => {
+    const { store } = await createPostgresTestKit()
+    const createdUser = await store.userRepo.create({
+      ...user('pg-user-update'),
+      displayName: 'Before',
+      email: 'before@example.com',
+      phone: '+10000000000',
+      metadata: { state: 'before' },
+    })
+    const createdIdentity = await store.identityRepo.create(
+      identity({
+        id: asIdentityId('pg-identity-update'),
+        userId: createdUser.id,
+        provider: 'oidc',
+        providerUserId: 'oidc-update-user',
+        email: 'before@example.com',
+        emailVerified: false,
+        phone: '+10000000000',
+        phoneVerified: false,
+        trust: {
+          level: ProviderTrustLevel.Neutral,
+          signals: [],
+        },
+        metadata: { state: 'before' },
+      }),
+    )
+    const createdCredential = await store.credentialRepo.create({
+      id: asCredentialId('pg-credential-update'),
+      userId: createdUser.id,
+      type: 'password',
+      subject: 'before@example.com',
+      passwordHash: 'before-hash',
+      createdAt: now,
+      updatedAt: now,
+      metadata: { state: 'before' },
+    })
+    const createdVerification = await store.verificationRepo.create({
+      id: asVerificationId('pg-verification-update'),
+      purpose: VerificationPurpose.SignIn,
+      target: 'before@example.com',
+      provider: 'email-otp',
+      channel: 'email',
+      secretHash: 'before-secret-hash',
+      status: VerificationStatus.Pending,
+      createdAt: now,
+      expiresAt: new Date('2026-01-01T00:30:00.000Z'),
+      metadata: { state: 'before' },
+    })
+    const createdSession = await store.sessionRepo.create({
+      id: asSessionId('pg-session-update'),
+      userId: createdUser.id,
+      status: SessionStatus.Active,
+      createdAt: now,
+      expiresAt: new Date('2026-01-31T00:00:00.000Z'),
+      metadata: { state: 'before' },
+    })
+
+    expect(await store.userRepo.update(createdUser.id, {})).toMatchObject({
+      id: createdUser.id,
+      displayName: 'Before',
+    })
+
+    const updatedUser = await store.userRepo.update(createdUser.id, {
+      displayName: 'After',
+      updatedAt: new Date('2026-01-01T00:05:00.000Z'),
+      metadata: { state: 'after' },
+    })
+
+    expect(updatedUser).toMatchObject({
+      id: createdUser.id,
+      displayName: 'After',
+      metadata: { state: 'after' },
+    })
+
+    const clearedUserPhone = await store.userRepo.update(createdUser.id, {
+      phone: undefined,
+      updatedAt: new Date('2026-01-01T00:05:30.000Z'),
+    } as unknown as Parameters<typeof store.userRepo.update>[1])
+
+    expect(clearedUserPhone).not.toHaveProperty('phone')
+
+    await expect(store.userRepo.update(asUserId('missing-user'), {})).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+
+    expect(await store.identityRepo.findById(createdIdentity.id)).toMatchObject({
+      id: createdIdentity.id,
+      trust: { level: ProviderTrustLevel.Neutral },
+    })
+    expect(await store.identityRepo.update(createdIdentity.id, {})).toMatchObject({
+      id: createdIdentity.id,
+      status: AuthIdentityStatus.Active,
+    })
+
+    const updatedIdentity = await store.identityRepo.update(createdIdentity.id, {
+      status: AuthIdentityStatus.Disabled,
+      phoneVerified: true,
+      trust: {
+        level: ProviderTrustLevel.Untrusted,
+      },
+      updatedAt: new Date('2026-01-01T00:06:00.000Z'),
+      disabledAt: new Date('2026-01-01T00:07:00.000Z'),
+      metadata: { state: 'after' },
+    })
+
+    expect(updatedIdentity).toMatchObject({
+      id: createdIdentity.id,
+      status: AuthIdentityStatus.Disabled,
+      phoneVerified: true,
+      trust: { level: ProviderTrustLevel.Untrusted },
+      metadata: { state: 'after' },
+    })
+
+    await expect(
+      store.identityRepo.update(asIdentityId('missing-identity'), {}),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.IdentityNotFound,
+    })
+
+    expect(await store.credentialRepo.findPasswordByUserId(createdUser.id)).toMatchObject({
+      id: createdCredential.id,
+    })
+    expect(await store.credentialRepo.update(createdCredential.id, {})).toMatchObject({
+      id: createdCredential.id,
+    })
+
+    const updatedCredential = await store.credentialRepo.update(createdCredential.id, {
+      subject: 'after@example.com',
+      passwordHash: 'after-hash',
+      updatedAt: new Date('2026-01-01T00:08:00.000Z'),
+      metadata: { state: 'after' },
+    })
+
+    expect(updatedCredential).toMatchObject({
+      id: createdCredential.id,
+      subject: 'after@example.com',
+      passwordHash: 'after-hash',
+      metadata: { state: 'after' },
+    })
+
+    await expect(
+      store.credentialRepo.update(asCredentialId('missing-credential'), {}),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.CredentialNotFound,
+    })
+
+    expect(await store.verificationRepo.findById(createdVerification.id)).toMatchObject({
+      id: createdVerification.id,
+      provider: 'email-otp',
+      channel: 'email',
+    })
+    expect(await store.verificationRepo.update(createdVerification.id, {})).toMatchObject({
+      id: createdVerification.id,
+      status: VerificationStatus.Pending,
+    })
+
+    const updatedVerification = await store.verificationRepo.update(createdVerification.id, {
+      status: VerificationStatus.Consumed,
+      expiresAt: new Date('2026-01-01T00:45:00.000Z'),
+      consumedAt: new Date('2026-01-01T00:15:00.000Z'),
+      metadata: { state: 'after' },
+    })
+
+    expect(updatedVerification).toMatchObject({
+      id: createdVerification.id,
+      status: VerificationStatus.Consumed,
+      metadata: { state: 'after' },
+    })
+
+    await expect(
+      store.verificationRepo.update(asVerificationId('missing-verification'), {}),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    expect(await store.sessionRepo.findById(createdSession.id)).toMatchObject({
+      id: createdSession.id,
+      status: SessionStatus.Active,
+    })
+    expect(await store.sessionRepo.update(createdSession.id, {})).toMatchObject({
+      id: createdSession.id,
+      status: SessionStatus.Active,
+    })
+
+    const updatedSession = await store.sessionRepo.update(createdSession.id, {
+      status: SessionStatus.Revoked,
+      expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+      revokedAt: new Date('2026-01-01T00:20:00.000Z'),
+      lastSeenAt: new Date('2026-01-01T00:10:00.000Z'),
+      metadata: { state: 'after' },
+    })
+
+    expect(updatedSession).toMatchObject({
+      id: createdSession.id,
+      status: SessionStatus.Revoked,
+      metadata: { state: 'after' },
+    })
+
+    await expect(
+      store.sessionRepo.update(asSessionId('missing-session'), {}),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "files": ["src/index.ts", "src/testing/index.ts"],
+  "files": ["src/index.ts", "src/postgres.ts", "src/testing/index.ts"],
   "include": []
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   define: attributionDefines,
   entry: {
     index: 'src/index.ts',
+    'postgres/index': 'src/postgres.ts',
     'testing/index': 'src/testing/index.ts',
   },
   format: ['esm'],


### PR DESCRIPTION
## Summary
- add `@alyldas/uniauth/postgres` as a reference Postgres persistence adapter
- ship schema bootstrap helpers, transaction-aware repositories, and package exports
- cover the adapter with integration, unit, export, and package checks

## Testing
- npm run check

Closes #40
Closes #42