### PR TITLE
feat: harden transactional account merge flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ license, subscription, private contract, or other written permission.
 - Maps SDK-free OAuth/OIDC provider profiles into the existing provider sign-in pipeline.
 - Creates local session records after successful sign-in.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
+- Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
+  when the configured `UnitOfWork` supports atomic rollback.
 - Exposes ports for repositories, providers, sender infrastructure, rate limits, password hashing,
   audit logs, and transactions.
 - Ships an in-memory testing implementation through `@alyldas/uniauth/testing`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,9 @@ not a production persistence adapter.
 `@alyldas/uniauth/postgres` provides a reference Postgres implementation for the repository ports and
 `UnitOfWork`. It accepts an application-owned `pg.Pool`-compatible object instead of bundling a
 database driver into the root package. Schema rollout and migrations remain application-owned even
-though the package also ships a reference SQL schema helper for bootstrap and tests.
+though the package also ships a reference SQL schema helper for bootstrap and tests. The merge flow
+is designed to move identities and credentials, revoke source sessions, and disable the source user
+inside one transaction boundary.
 
 ## Adapter Requirements
 
@@ -119,6 +121,7 @@ Storage adapters should:
 - keep user, identity, session, verification, and audit records separate;
 - keep password credentials separate from identities and store only password hashes;
 - apply `UnitOfWork` to sensitive multi-write flows;
+- keep merge conflict detection aligned with unique credential and identity ownership constraints;
 - store only hashed verification secrets;
 - avoid email/phone ownership inference outside the policy-controlled flow.
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -78,6 +78,34 @@ client inside nested UniAuth flows, commits on success, and rolls back on error.
 This means link, unlink, merge, session, and verification writes can share the same transaction
 boundary when the service calls them through `DefaultAuthService`.
 
+## Merge Semantics
+
+`mergeAccounts()` on the reference adapter is designed to be atomic:
+
+- active source identities move to the target user;
+- source credentials move to the target user;
+- the source user is disabled;
+- active source sessions are revoked;
+- if a target credential of the same type already exists, the merge is rejected before any write is
+  committed.
+
+The merge audit payload records only structural data such as moved identity IDs, moved credential
+IDs, revoked session IDs, conflicting credential types, and source user IDs. It does not record
+credential subjects, passwords, or verification secrets.
+
+## Isolation Assumptions
+
+The reference implementation assumes:
+
+- all UniAuth merge writes run through the same `PostgresAuthStore.run()` transaction boundary;
+- the unique constraints on `(provider, provider_user_id)`, `(type, subject)`, and `(type, user_id)`
+  remain enabled;
+- default Postgres `READ COMMITTED` isolation is acceptable for the reference adapter because the
+  uniqueness constraints are the final guard against duplicate identity and credential ownership.
+
+If the application adds external side effects or non-UniAuth writes into the same merge workflow, it
+should place them in the same database transaction or choose a stricter isolation level itself.
+
 ## Security Notes
 
 - Verification secrets remain hashed at rest; the adapter stores only `secret_hash`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,21 +84,28 @@ Tracking issues: #37, #49.
 
 Tracking issues: #38.
 
-## Next Release
-
 ### v0.10 - Reference Persistence
 
 - Postgres reference storage.
-- SQL schema example.
-- Transactional merge flow.
 - Indexes and constraints.
+- SQL schema example.
+
+Tracking issues: #40, #42.
+
+## Next Release
+
+### v0.11 - Transactional Merge and Testing Boundaries
+
+- Transactional merge flow.
+- Merge idempotency and partial-failure prevention.
+- Audit coverage for merge decisions without secret leakage.
 - In-memory testing kit decomposition aligned with reference persistence boundaries.
 
-Tracking issues: #40, #41, #42, #47.
+Tracking issues: #41, #47.
 
 ## Planned
 
-### v0.11 - Production Hardening and Integration Backlog
+### v0.12 - Production Hardening and Integration Backlog
 
 - Threat model documentation.
 - Production email and phone normalization design.

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,6 +88,15 @@
 - Provider adapters can expose normalized trust context without leaking provider SDK objects into
   the core policy contract.
 
+## Threats Covered in v0.11
+
+- Merge retries can return a stable no-op result after the source account has already been merged.
+- Password credential conflicts abort merge before disabling the source user or moving partial state.
+- Merge denial and success audit metadata stay free of credential subjects, passwords, and
+  verification secrets.
+- Transaction-aware stores can roll merge state back when persistence fails after intermediate
+  updates.
+
 ## Out of Scope for Core
 
 - Cookie flags and browser session transport.

--- a/src/application/accounts.ts
+++ b/src/application/accounts.ts
@@ -11,13 +11,17 @@ import {
 } from './support.js'
 import type {
   AuthIdentity,
+  Credential,
+  CredentialId,
   IdentityId,
   LinkInput,
   LinkResult,
   MergeAccountsInput,
   MergeResult,
+  SessionId,
   UnlinkInput,
   UserId,
+  User,
 } from '../domain/types.js'
 import { AuditEventType, AuthIdentityStatus, SessionStatus } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
@@ -27,6 +31,7 @@ const PolicyDenialReason = {
   LinkDenied: 'link-denied',
   UnlinkDenied: 'unlink-denied',
   MergeDenied: 'merge-denied',
+  MergeCredentialConflict: 'merge-credential-conflict',
 } as const
 
 export async function link(runtime: AuthServiceRuntime, input: LinkInput): Promise<LinkResult> {
@@ -132,82 +137,167 @@ export async function mergeAccounts(
   runtime: AuthServiceRuntime,
   input: MergeAccountsInput,
 ): Promise<MergeResult> {
-  return runtime.transaction.run(async () => {
-    const now = input.now ?? runtime.clock.now()
-    const sourceUser = await getActiveUser(runtime, input.sourceUserId)
-    const targetUser = await getActiveUser(runtime, input.targetUserId)
+  const now = input.now ?? runtime.clock.now()
+  let deniedAudit:
+    | {
+        readonly userId: UserId
+        readonly metadata: Record<string, unknown>
+      }
+    | undefined
 
-    if (sourceUser.id === targetUser.id) {
-      throw invalidInput('Source and target users must be different.')
-    }
+  try {
+    return await runtime.transaction.run(async () => {
+      const sourceUser = await runtime.repos.userRepo.findById(input.sourceUserId)
+      const targetUser = await getActiveUser(runtime, input.targetUserId)
 
-    await ensureReAuth(
-      runtime,
-      AuthPolicyAction.MergeAccounts,
-      targetUser.id,
-      input.reAuthenticatedAt,
-      now,
-    )
+      if (!sourceUser) {
+        throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+      }
 
-    const sourceIdentities = (await runtime.repos.identityRepo.listByUserId(sourceUser.id)).filter(
-      isActiveIdentity,
-    )
-    const targetIdentities = (await runtime.repos.identityRepo.listByUserId(targetUser.id)).filter(
-      isActiveIdentity,
-    )
-    const allowed = await runtime.policy.canMergeUsers({
-      sourceUser,
-      targetUser,
-      sourceIdentityCount: sourceIdentities.length,
-      sourceIdentities,
-      targetIdentities,
-    })
+      if (sourceUser.id === targetUser.id) {
+        throw invalidInput('Source and target users must be different.')
+      }
 
-    if (!allowed) {
-      await audit(runtime, AuditEventType.PolicyDenied, now, {
-        userId: targetUser.id,
-        metadata: { reason: PolicyDenialReason.MergeDenied, sourceUserId: sourceUser.id },
+      await ensureReAuth(
+        runtime,
+        AuthPolicyAction.MergeAccounts,
+        targetUser.id,
+        input.reAuthenticatedAt,
+        now,
+      )
+
+      const sourceIdentities = (
+        await runtime.repos.identityRepo.listByUserId(sourceUser.id)
+      ).filter(isActiveIdentity)
+      const targetIdentities = (
+        await runtime.repos.identityRepo.listByUserId(targetUser.id)
+      ).filter(isActiveIdentity)
+      const sourceCredentials = await runtime.repos.credentialRepo.listByUserId(sourceUser.id)
+      const targetCredentials = await runtime.repos.credentialRepo.listByUserId(targetUser.id)
+      const sourceSessions = await runtime.repos.sessionRepo.listByUserId(sourceUser.id)
+
+      if (sourceUser.disabledAt) {
+        if (!isAlreadyMergedSource(sourceIdentities, sourceCredentials, sourceSessions)) {
+          throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+        }
+
+        const result = createMergeResult({
+          sourceUser,
+          targetUser,
+        })
+
+        await audit(runtime, AuditEventType.AccountsMerged, now, {
+          userId: targetUser.id,
+          metadata: buildMergeAuditMetadata({
+            decision: 'already-merged',
+            sourceUserId: sourceUser.id,
+            result,
+            requestMetadata: input.metadata,
+          }),
+        })
+
+        return result
+      }
+
+      const allowed = await runtime.policy.canMergeUsers({
+        sourceUser,
+        targetUser,
+        sourceIdentityCount: sourceIdentities.length,
+        sourceIdentities,
+        targetIdentities,
       })
-      throw new UniAuthError(UniAuthErrorCode.PolicyDenied, 'Auth policy denied this action.')
-    }
 
-    const movedIdentityIds: IdentityId[] = []
+      if (!allowed) {
+        deniedAudit = {
+          userId: targetUser.id,
+          metadata: { reason: PolicyDenialReason.MergeDenied, sourceUserId: sourceUser.id },
+        }
+        throw new UniAuthError(UniAuthErrorCode.PolicyDenied, 'Auth policy denied this action.')
+      }
 
-    for (const identity of sourceIdentities) {
-      await runtime.repos.identityRepo.update(identity.id, {
-        userId: targetUser.id,
+      const conflictingCredentialTypes = findCredentialConflictTypes(
+        sourceCredentials,
+        targetCredentials,
+      )
+
+      if (conflictingCredentialTypes.length > 0) {
+        deniedAudit = {
+          userId: targetUser.id,
+          metadata: {
+            reason: PolicyDenialReason.MergeCredentialConflict,
+            sourceUserId: sourceUser.id,
+            credentialTypes: conflictingCredentialTypes,
+            ...optionalProp('requestMetadata', input.metadata),
+          },
+        }
+        throw new UniAuthError(
+          UniAuthErrorCode.CredentialAlreadyExists,
+          'Credential already exists.',
+        )
+      }
+
+      const movedIdentityIds: IdentityId[] = []
+      const movedCredentialIds: CredentialId[] = []
+      const revokedSessionIds: SessionId[] = []
+
+      for (const identity of sourceIdentities) {
+        await runtime.repos.identityRepo.update(identity.id, {
+          userId: targetUser.id,
+          updatedAt: now,
+        })
+        movedIdentityIds.push(identity.id)
+      }
+
+      for (const credential of sourceCredentials) {
+        await runtime.repos.credentialRepo.update(credential.id, {
+          userId: targetUser.id,
+          updatedAt: now,
+        })
+        movedCredentialIds.push(credential.id)
+      }
+
+      const disabledSourceUser = await runtime.repos.userRepo.update(sourceUser.id, {
+        disabledAt: now,
         updatedAt: now,
       })
-      movedIdentityIds.push(identity.id)
-    }
 
-    const disabledSourceUser = await runtime.repos.userRepo.update(sourceUser.id, {
-      disabledAt: now,
-      updatedAt: now,
-    })
-
-    const sourceSessions = await runtime.repos.sessionRepo.listByUserId(sourceUser.id)
-
-    for (const session of sourceSessions) {
-      if (session.status === SessionStatus.Active) {
-        await runtime.repos.sessionRepo.update(session.id, {
-          status: SessionStatus.Revoked,
-          revokedAt: now,
-        })
+      for (const session of sourceSessions) {
+        if (session.status === SessionStatus.Active) {
+          await runtime.repos.sessionRepo.update(session.id, {
+            status: SessionStatus.Revoked,
+            revokedAt: now,
+          })
+          revokedSessionIds.push(session.id)
+        }
       }
-    }
 
-    await audit(runtime, AuditEventType.AccountsMerged, now, {
-      userId: targetUser.id,
-      metadata: { sourceUserId: sourceUser.id, movedIdentityIds },
+      const result = createMergeResult({
+        sourceUser: disabledSourceUser,
+        targetUser,
+        movedIdentityIds,
+        movedCredentialIds,
+        revokedSessionIds,
+      })
+
+      await audit(runtime, AuditEventType.AccountsMerged, now, {
+        userId: targetUser.id,
+        metadata: buildMergeAuditMetadata({
+          decision: 'merged',
+          sourceUserId: sourceUser.id,
+          result,
+          requestMetadata: input.metadata,
+        }),
+      })
+
+      return result
     })
-
-    return {
-      sourceUser: disabledSourceUser,
-      targetUser,
-      movedIdentityIds,
+  } catch (error) {
+    if (deniedAudit) {
+      await audit(runtime, AuditEventType.PolicyDenied, now, deniedAudit)
     }
-  })
+
+    throw error
+  }
 }
 
 export async function getUserIdentities(
@@ -216,4 +306,64 @@ export async function getUserIdentities(
 ): Promise<readonly AuthIdentity[]> {
   await getActiveUser(runtime, userId)
   return runtime.repos.identityRepo.listByUserId(userId)
+}
+
+function findCredentialConflictTypes(
+  sourceCredentials: readonly Credential[],
+  targetCredentials: readonly Credential[],
+): readonly Credential['type'][] {
+  const targetTypes = new Set(targetCredentials.map((credential) => credential.type))
+  const conflicts = new Set<Credential['type']>()
+
+  for (const credential of sourceCredentials) {
+    if (targetTypes.has(credential.type)) {
+      conflicts.add(credential.type)
+    }
+  }
+
+  return [...conflicts]
+}
+
+function isAlreadyMergedSource(
+  activeSourceIdentities: readonly AuthIdentity[],
+  sourceCredentials: readonly Credential[],
+  sourceSessions: readonly { readonly status: SessionStatus }[],
+): boolean {
+  return (
+    activeSourceIdentities.length === 0 &&
+    sourceCredentials.length === 0 &&
+    sourceSessions.every((session) => session.status !== SessionStatus.Active)
+  )
+}
+
+function createMergeResult(input: {
+  readonly sourceUser: User
+  readonly targetUser: User
+  readonly movedIdentityIds?: readonly IdentityId[]
+  readonly movedCredentialIds?: readonly CredentialId[]
+  readonly revokedSessionIds?: readonly SessionId[]
+}): MergeResult {
+  return {
+    sourceUser: input.sourceUser,
+    targetUser: input.targetUser,
+    movedIdentityIds: input.movedIdentityIds ?? [],
+    movedCredentialIds: input.movedCredentialIds ?? [],
+    revokedSessionIds: input.revokedSessionIds ?? [],
+  }
+}
+
+function buildMergeAuditMetadata(input: {
+  readonly decision: 'merged' | 'already-merged'
+  readonly sourceUserId: UserId
+  readonly result: MergeResult
+  readonly requestMetadata: Record<string, unknown> | undefined
+}): Record<string, unknown> {
+  return {
+    decision: input.decision,
+    sourceUserId: input.sourceUserId,
+    movedIdentityIds: [...input.result.movedIdentityIds],
+    movedCredentialIds: [...input.result.movedCredentialIds],
+    revokedSessionIds: [...input.result.revokedSessionIds],
+    ...optionalProp('requestMetadata', input.requestMetadata),
+  }
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -239,6 +239,8 @@ export interface MergeResult {
   readonly sourceUser: User
   readonly targetUser: User
   readonly movedIdentityIds: readonly IdentityId[]
+  readonly movedCredentialIds: readonly CredentialId[]
+  readonly revokedSessionIds: readonly SessionId[]
 }
 
 export interface CreateSessionInput {

--- a/src/ports.ts
+++ b/src/ports.ts
@@ -92,10 +92,11 @@ export interface IdentityRepo {
 export interface CredentialRepo {
   findPasswordByEmail(email: string): Promise<Credential | undefined>
   findPasswordByUserId(userId: UserId): Promise<Credential | undefined>
+  listByUserId(userId: UserId): Promise<readonly Credential[]>
   create(credential: Credential): Promise<Credential>
   update(
     id: CredentialId,
-    patch: Partial<Omit<Credential, 'id' | 'userId' | 'type' | 'createdAt'>>,
+    patch: Partial<Omit<Credential, 'id' | 'type' | 'createdAt'>>,
   ): Promise<Credential>
 }
 

--- a/src/postgres/store.ts
+++ b/src/postgres/store.ts
@@ -322,6 +322,16 @@ export class PostgresAuthStore
         [userId],
         mapCredentialRow,
       ),
+    listByUserId: async (userId) =>
+      this.queryRows<CredentialRow, Credential>(
+        `select
+           id, user_id, type, subject, password_hash, created_at, updated_at, metadata
+         from uniauth_credentials
+         where user_id = $1
+         order by created_at asc, id asc`,
+        [userId],
+        mapCredentialRow,
+      ),
     create: async (credential) => {
       try {
         return await this.queryRequiredRow<CredentialRow, Credential>(
@@ -361,6 +371,7 @@ export class PostgresAuthStore
       }
 
       const update = buildUpdateQuery(patch, [
+        { key: 'userId', column: 'user_id' },
         { key: 'subject', column: 'subject' },
         { key: 'passwordHash', column: 'password_hash' },
         { key: 'updatedAt', column: 'updated_at' },

--- a/src/testing/in-memory.ts
+++ b/src/testing/in-memory.ts
@@ -52,6 +52,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   private readonly verifications = new Map<Verification['id'], Verification>()
   private readonly sessions = new Map<Session['id'], Session>()
   private readonly auditEvents: AuditEvent[] = []
+  private transactionDepth = 0
 
   readonly userRepo: UserRepo = {
     findById: async (id) => this.users.get(id),
@@ -164,6 +165,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       )
       return id ? this.credentials.get(id) : undefined
     },
+    listByUserId: async (userId) =>
+      [...this.credentials.values()].filter((credential) => credential.userId === userId),
     create: async (credential) => {
       const key = this.credentialKey(credential.type, credential.subject)
       const userKey = this.credentialUserKey(credential.type, credential.userId)
@@ -190,9 +193,15 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       const updated: Credential = { ...existing, ...patch }
       const oldKey = this.credentialKey(existing.type, existing.subject)
       const newKey = this.credentialKey(updated.type, updated.subject)
+      const oldUserKey = this.credentialUserKey(existing.type, existing.userId)
+      const newUserKey = this.credentialUserKey(updated.type, updated.userId)
       const existingCredentialId = this.credentialKeys.get(newKey)
+      const existingCredentialUserId = this.credentialUserKeys.get(newUserKey)
 
-      if (newKey !== oldKey && existingCredentialId) {
+      if (
+        (newKey !== oldKey && existingCredentialId) ||
+        (newUserKey !== oldUserKey && existingCredentialUserId)
+      ) {
         throw new UniAuthError(
           UniAuthErrorCode.CredentialAlreadyExists,
           'Credential already exists.',
@@ -201,6 +210,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
       this.credentialKeys.delete(oldKey)
       this.credentialKeys.set(newKey, updated.id)
+      this.credentialUserKeys.delete(oldUserKey)
+      this.credentialUserKeys.set(newUserKey, updated.id)
       this.credentials.set(updated.id, updated)
       return updated
     },
@@ -234,7 +245,21 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   }
 
   async run<T>(operation: () => Promise<T>): Promise<T> {
-    return operation()
+    if (this.transactionDepth > 0) {
+      return operation()
+    }
+
+    const snapshot = this.snapshot()
+    this.transactionDepth += 1
+
+    try {
+      return await operation()
+    } catch (error) {
+      this.restore(snapshot)
+      throw error
+    } finally {
+      this.transactionDepth -= 1
+    }
   }
 
   listUsers(): readonly User[] {
@@ -271,6 +296,76 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
   private credentialUserKey(type: CredentialType, userId: User['id']): string {
     return `${type}\u0000${userId}`
+  }
+
+  private snapshot(): {
+    readonly users: Map<User['id'], User>
+    readonly identities: Map<AuthIdentity['id'], AuthIdentity>
+    readonly identityKeys: Map<string, AuthIdentity['id']>
+    readonly credentials: Map<Credential['id'], Credential>
+    readonly credentialKeys: Map<string, Credential['id']>
+    readonly credentialUserKeys: Map<string, Credential['id']>
+    readonly verifications: Map<Verification['id'], Verification>
+    readonly sessions: Map<Session['id'], Session>
+    readonly auditEvents: AuditEvent[]
+  } {
+    return {
+      users: new Map(this.users),
+      identities: new Map(this.identities),
+      identityKeys: new Map(this.identityKeys),
+      credentials: new Map(this.credentials),
+      credentialKeys: new Map(this.credentialKeys),
+      credentialUserKeys: new Map(this.credentialUserKeys),
+      verifications: new Map(this.verifications),
+      sessions: new Map(this.sessions),
+      auditEvents: [...this.auditEvents],
+    }
+  }
+
+  private restore(snapshot: ReturnType<InMemoryAuthStore['snapshot']>): void {
+    this.users.clear()
+    this.identities.clear()
+    this.identityKeys.clear()
+    this.credentials.clear()
+    this.credentialKeys.clear()
+    this.credentialUserKeys.clear()
+    this.verifications.clear()
+    this.sessions.clear()
+    this.auditEvents.length = 0
+
+    for (const [id, user] of snapshot.users) {
+      this.users.set(id, user)
+    }
+
+    for (const [id, identity] of snapshot.identities) {
+      this.identities.set(id, identity)
+    }
+
+    for (const [key, id] of snapshot.identityKeys) {
+      this.identityKeys.set(key, id)
+    }
+
+    for (const [id, credential] of snapshot.credentials) {
+      this.credentials.set(id, credential)
+    }
+
+    for (const [key, id] of snapshot.credentialKeys) {
+      this.credentialKeys.set(key, id)
+    }
+
+    for (const [key, id] of snapshot.credentialUserKeys) {
+      this.credentialUserKeys.set(key, id)
+    }
+
+    for (const [id, verification] of snapshot.verifications) {
+      this.verifications.set(id, verification)
+    }
+
+    for (const [id, session] of snapshot.sessions) {
+      this.sessions.set(id, session)
+    }
+
+    this.auditEvents.push(...snapshot.auditEvents)
   }
 }
 

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -704,6 +704,8 @@ describe('DefaultAuthService', () => {
     })
 
     expect(merged.movedIdentityIds).toEqual([source.identity.id])
+    expect(merged.movedCredentialIds).toEqual([])
+    expect(merged.revokedSessionIds).toEqual([source.session.id])
     expect(merged.sourceUser.disabledAt).toEqual(now)
     expect(
       allowedKit.store
@@ -717,6 +719,155 @@ describe('DefaultAuthService', () => {
         .filter((session) => session.userId === source.user.id)
         .map((session) => session.status),
     ).toEqual([SessionStatus.Revoked])
+  })
+
+  it('moves password credentials on merge, supports idempotent retry, and keeps audit metadata secret-free', async () => {
+    const kit = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({ allowMergeAccounts: true, requireReAuthFor: [] }),
+    })
+    const source = await kit.service.signIn({
+      assertion: assertion({ providerUserId: 'source-password', email: 'source@example.com' }),
+      now,
+    })
+    const target = await kit.service.signIn({
+      assertion: assertion({ providerUserId: 'target-password', email: 'target@example.com' }),
+      now,
+    })
+    const sourceCredential = await kit.service.setPassword({
+      userId: source.user.id,
+      email: 'source@example.com',
+      password: 'source-secret',
+      now,
+    })
+
+    const merged = await kit.service.mergeAccounts({
+      sourceUserId: source.user.id,
+      targetUserId: target.user.id,
+      reAuthenticatedAt: now,
+      now,
+    })
+
+    expect(merged.movedCredentialIds).toEqual([sourceCredential.id])
+    expect(merged.revokedSessionIds).toEqual([source.session.id])
+    expect(merged.movedIdentityIds).toEqual(expect.arrayContaining([source.identity.id]))
+    expect(
+      kit.store
+        .listCredentials()
+        .filter((credential) => credential.id === sourceCredential.id)
+        .map((credential) => credential.userId),
+    ).toEqual([target.user.id])
+
+    const passwordSignIn = await kit.service.signInWithPassword({
+      email: 'source@example.com',
+      password: 'source-secret',
+      now,
+    })
+
+    expect(passwordSignIn.user.id).toBe(target.user.id)
+
+    const retriedMerge = await kit.service.mergeAccounts({
+      sourceUserId: source.user.id,
+      targetUserId: target.user.id,
+      reAuthenticatedAt: now,
+      now,
+    })
+
+    expect(retriedMerge.movedIdentityIds).toEqual([])
+    expect(retriedMerge.movedCredentialIds).toEqual([])
+    expect(retriedMerge.revokedSessionIds).toEqual([])
+
+    const mergeEvents = kit.store
+      .listAuditEvents()
+      .filter((event) => event.type === AuditEventType.AccountsMerged)
+
+    expect(mergeEvents).toHaveLength(2)
+    expect(mergeEvents[0]?.metadata).toMatchObject({
+      decision: 'merged',
+      sourceUserId: source.user.id,
+      movedCredentialIds: [sourceCredential.id],
+      revokedSessionIds: [source.session.id],
+    })
+    expect(mergeEvents[1]?.metadata).toMatchObject({
+      decision: 'already-merged',
+      sourceUserId: source.user.id,
+      movedIdentityIds: [],
+      movedCredentialIds: [],
+      revokedSessionIds: [],
+    })
+    expect(JSON.stringify(mergeEvents)).not.toContain('source-secret')
+    expect(JSON.stringify(mergeEvents)).not.toContain('source@example.com')
+  })
+
+  it('rejects merge credential conflicts without moving data or leaking subjects into audit metadata', async () => {
+    const kit = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({ allowMergeAccounts: true, requireReAuthFor: [] }),
+    })
+    const source = await kit.service.signIn({
+      assertion: assertion({
+        providerUserId: 'source-conflict',
+        email: 'source-conflict@example.com',
+      }),
+      now,
+    })
+    const target = await kit.service.signIn({
+      assertion: assertion({
+        providerUserId: 'target-conflict',
+        email: 'target-conflict@example.com',
+      }),
+      now,
+    })
+    const sourceCredential = await kit.service.setPassword({
+      userId: source.user.id,
+      email: 'source-conflict@example.com',
+      password: 'source-conflict-secret',
+      now,
+    })
+    await kit.service.setPassword({
+      userId: target.user.id,
+      email: 'target-conflict@example.com',
+      password: 'target-conflict-secret',
+      now,
+    })
+
+    const mergeError = await kit.service
+      .mergeAccounts({
+        sourceUserId: source.user.id,
+        targetUserId: target.user.id,
+        reAuthenticatedAt: now,
+        now,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(mergeError).toMatchObject({ code: UniAuthErrorCode.CredentialAlreadyExists })
+    expect(
+      kit.store
+        .listCredentials()
+        .filter((credential) => credential.id === sourceCredential.id)
+        .map((credential) => credential.userId),
+    ).toEqual([source.user.id])
+    expect(
+      kit.store.listUsers().find((user) => user.id === source.user.id)?.disabledAt,
+    ).toBeUndefined()
+    expect(
+      kit.store
+        .listSessions()
+        .filter((session) => session.userId === source.user.id)
+        .map((session) => session.status),
+    ).toEqual([SessionStatus.Active])
+
+    const denialEvent = [...kit.store.listAuditEvents()]
+      .reverse()
+      .find((event) => event.type === AuditEventType.PolicyDenied)
+
+    expect(denialEvent?.type).toBe(AuditEventType.PolicyDenied)
+    expect(denialEvent?.metadata).toMatchObject({
+      reason: 'merge-credential-conflict',
+      sourceUserId: source.user.id,
+      credentialTypes: ['password'],
+    })
+    expect(JSON.stringify(denialEvent?.metadata)).not.toContain('source-conflict-secret')
+    expect(JSON.stringify(denialEvent?.metadata)).not.toContain('source-conflict@example.com')
+    expect(JSON.stringify(denialEvent?.metadata)).not.toContain('target-conflict@example.com')
   })
 
   it('resolves assertions through a provider registry when requested', async () => {

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -123,6 +123,7 @@ describe('InMemoryAuthStore', () => {
     expect(await store.credentialRepo.create(credential)).toBe(credential)
     expect(await store.credentialRepo.findPasswordByEmail(' Alice@Example.com ')).toBe(credential)
     expect(await store.credentialRepo.findPasswordByUserId(createdUser.id)).toBe(credential)
+    expect(await store.credentialRepo.listByUserId(createdUser.id)).toEqual([credential])
     expect(
       await store.credentialRepo.create(credential).catch((caught: unknown) => caught),
     ).toMatchObject({
@@ -142,6 +143,13 @@ describe('InMemoryAuthStore', () => {
     expect(
       await store.credentialRepo
         .update(credential.id, { subject: secondCredential.subject })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.CredentialAlreadyExists,
+    })
+    expect(
+      await store.credentialRepo
+        .update(credential.id, { userId: otherUser.id })
         .catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.CredentialAlreadyExists,
@@ -215,5 +223,47 @@ describe('InMemoryAuthStore', () => {
     expect(store.listVerifications()).toHaveLength(1)
     expect(store.listSessions()).toHaveLength(1)
     expect(store.listAuditEvents()).toHaveLength(1)
+  })
+
+  it('rolls back outer state while allowing nested transaction reuse', async () => {
+    const store = new InMemoryAuthStore()
+    const createdUser = user('transaction-user')
+
+    const nestedResult = await store.run(async () => {
+      await store.userRepo.create(createdUser)
+
+      return store.run(async () => {
+        await store.auditLogRepo.append({
+          id: asAuditEventId('audit-nested'),
+          type: AuditEventType.SignIn,
+          occurredAt: now,
+          userId: createdUser.id,
+        })
+
+        return 'nested-ok'
+      })
+    })
+
+    expect(nestedResult).toBe('nested-ok')
+    expect(store.listUsers()).toHaveLength(1)
+    expect(store.listAuditEvents()).toHaveLength(1)
+
+    await expect(
+      store.run(async () => {
+        await store.userRepo.create(user('rollback-user'))
+        await store.auditLogRepo.append({
+          id: asAuditEventId('audit-rollback'),
+          type: AuditEventType.PolicyDenied,
+          occurredAt: now,
+        })
+
+        throw new Error('rollback')
+      }),
+    ).rejects.toThrow('rollback')
+
+    expect(store.listUsers().map((entry) => entry.id)).toEqual([createdUser.id])
+    expect(store.listAuditEvents().map((event) => event.id)).toEqual([
+      asAuditEventId('audit-nested'),
+    ])
   })
 })

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -444,4 +444,132 @@ describe('Postgres reference persistence', () => {
       code: UniAuthErrorCode.SessionNotFound,
     })
   })
+
+  it('moves password credentials during merge and supports idempotent retries on Postgres', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const source = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-merge-source',
+        email: 'pg-merge-source@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const target = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-merge-target',
+        email: 'pg-merge-target@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const sourceCredential = await service.setPassword({
+      userId: source.user.id,
+      email: 'pg-merge-source@example.com',
+      password: 'pg-merge-secret',
+      now,
+    })
+
+    const merged = await service.mergeAccounts({
+      sourceUserId: source.user.id,
+      targetUserId: target.user.id,
+      reAuthenticatedAt: now,
+      now,
+    })
+
+    expect(merged.movedCredentialIds).toEqual([sourceCredential.id])
+    expect(merged.revokedSessionIds).toEqual([source.session.id])
+    expect(await store.credentialRepo.listByUserId(target.user.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: sourceCredential.id,
+          userId: target.user.id,
+        }),
+      ]),
+    )
+
+    const passwordSignIn = await service.signInWithPassword({
+      email: 'pg-merge-source@example.com',
+      password: 'pg-merge-secret',
+      now,
+    })
+
+    expect(passwordSignIn.user.id).toBe(target.user.id)
+
+    const retriedMerge = await service.mergeAccounts({
+      sourceUserId: source.user.id,
+      targetUserId: target.user.id,
+      reAuthenticatedAt: now,
+      now,
+    })
+
+    expect(retriedMerge.movedIdentityIds).toEqual([])
+    expect(retriedMerge.movedCredentialIds).toEqual([])
+    expect(retriedMerge.revokedSessionIds).toEqual([])
+  })
+
+  it('rejects merge credential conflicts on Postgres without partial writes', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const source = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-conflict-source',
+        email: 'pg-conflict-source@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const target = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-conflict-target',
+        email: 'pg-conflict-target@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const sourceCredential = await service.setPassword({
+      userId: source.user.id,
+      email: 'pg-conflict-source@example.com',
+      password: 'pg-conflict-source-secret',
+      now,
+    })
+    await service.setPassword({
+      userId: target.user.id,
+      email: 'pg-conflict-target@example.com',
+      password: 'pg-conflict-target-secret',
+      now,
+    })
+
+    await expect(
+      service.mergeAccounts({
+        sourceUserId: source.user.id,
+        targetUserId: target.user.id,
+        reAuthenticatedAt: now,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.CredentialAlreadyExists,
+    })
+
+    expect(await store.userRepo.findById(source.user.id)).toMatchObject({
+      id: source.user.id,
+    })
+    expect(await store.credentialRepo.listByUserId(source.user.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: sourceCredential.id,
+          userId: source.user.id,
+        }),
+      ]),
+    )
+    expect(
+      (await store.identityRepo.listByUserId(source.user.id)).map((identity) => identity.userId),
+    ).toEqual(expect.arrayContaining([source.user.id]))
+    expect(
+      (await store.sessionRepo.listByUserId(source.user.id)).map((session) => session.status),
+    ).toEqual([SessionStatus.Active])
+  })
 })

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -10,7 +10,7 @@ import {
   asUserId,
   createDefaultAuthPolicy,
 } from '../src'
-import { InMemoryAuthStore, createInMemoryAuthKit } from '../src/testing'
+import { InMemoryAuthStore, InMemoryPasswordHasher, createInMemoryAuthKit } from '../src/testing'
 import { assertion, now } from './helpers.js'
 
 describe('DefaultAuthService edge cases', () => {
@@ -174,6 +174,18 @@ describe('DefaultAuthService edge cases', () => {
     ).toMatchObject({
       code: UniAuthErrorCode.UserNotFound,
     })
+    expect(
+      await defaultService
+        .mergeAccounts({
+          sourceUserId: asUserId('missing-source'),
+          targetUserId: first.user.id,
+          reAuthenticatedAt: now,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
   })
 
   it('covers disabled and malformed auto-link candidates', async () => {
@@ -302,5 +314,136 @@ describe('DefaultAuthService edge cases', () => {
       }),
     ).toMatchObject({ movedIdentityIds: [source.identity.id] })
     expect(nonActiveSourceSession.status).toBe(SessionStatus.Active)
+  })
+
+  it('rolls merge state back when audit persistence fails inside the transaction boundary', async () => {
+    const policy = createDefaultAuthPolicy({ allowMergeAccounts: true, requireReAuthFor: [] })
+    const store = new InMemoryAuthStore()
+    const setupService = new DefaultAuthService({
+      repos: store,
+      transaction: store,
+      policy,
+      passwordHasher: new InMemoryPasswordHasher(),
+    })
+    const source = await setupService.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'source-rollback',
+        email: 'source-rollback@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const target = await setupService.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'target-rollback',
+        email: 'target-rollback@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const sourceCredential = await setupService.setPassword({
+      userId: source.user.id,
+      email: 'source-rollback@example.com',
+      password: 'rollback-secret',
+      now,
+    })
+    const auditCountBeforeMerge = store.listAuditEvents().length
+    const auditFailure = new Error('audit persistence failed')
+    const failingService = new DefaultAuthService({
+      repos: {
+        userRepo: store.userRepo,
+        identityRepo: store.identityRepo,
+        credentialRepo: store.credentialRepo,
+        verificationRepo: store.verificationRepo,
+        sessionRepo: store.sessionRepo,
+        auditLogRepo: {
+          append: async () => {
+            throw auditFailure
+          },
+        },
+      },
+      transaction: store,
+      policy,
+    })
+
+    await expect(
+      failingService.mergeAccounts({
+        sourceUserId: source.user.id,
+        targetUserId: target.user.id,
+        reAuthenticatedAt: now,
+        now,
+      }),
+    ).rejects.toBe(auditFailure)
+
+    expect(store.listUsers().find((user) => user.id === source.user.id)?.disabledAt).toBeUndefined()
+    expect(
+      store
+        .listIdentities()
+        .filter((identity) => identity.userId === source.user.id)
+        .map((identity) => identity.id),
+    ).toContain(source.identity.id)
+    expect(
+      store
+        .listCredentials()
+        .filter((credential) => credential.id === sourceCredential.id)
+        .map((credential) => credential.userId),
+    ).toEqual([source.user.id])
+    expect(
+      store
+        .listSessions()
+        .filter((session) => session.userId === source.user.id)
+        .map((session) => session.status),
+    ).toEqual([SessionStatus.Active])
+    expect(store.listAuditEvents()).toHaveLength(auditCountBeforeMerge)
+  })
+
+  it('rejects merge for a disabled source that still has active state attached', async () => {
+    const policy = createDefaultAuthPolicy({ allowMergeAccounts: true, requireReAuthFor: [] })
+    const store = new InMemoryAuthStore()
+    const service = new DefaultAuthService({
+      repos: store,
+      transaction: store,
+      policy,
+    })
+    const target = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'merge-target',
+        email: 'merge-target@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await store.userRepo.create({
+      id: asUserId('disabled-source'),
+      createdAt: now,
+      updatedAt: now,
+      disabledAt: now,
+    })
+    await store.identityRepo.create({
+      id: asIdentityId('disabled-source-identity'),
+      userId: asUserId('disabled-source'),
+      provider: 'email',
+      providerUserId: 'disabled-source@example.com',
+      email: 'disabled-source@example.com',
+      emailVerified: true,
+      status: AuthIdentityStatus.Active,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    await expect(
+      service.mergeAccounts({
+        sourceUserId: asUserId('disabled-source'),
+        targetUserId: target.user.id,
+        reAuthenticatedAt: now,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- make `mergeAccounts` transaction-safe for identities, credentials, sessions, and retry-safe no-op replays
- persist merge-denial audit decisions without leaking credential subjects or secrets
- add rollback/idempotency/conflict coverage for in-memory and Postgres stores, and update persistence docs

## Testing
- npm run check

Closes #41
Refs #47