### PR TITLE
fix: keep testing public exports stable

### DIFF
--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import packageJson from '../package.json'
@@ -69,6 +70,16 @@ describe('package exports', () => {
     expect(testing.InMemoryRateLimiter).toBeTypeOf('function')
     expect(testing.InMemorySmsSender).toBeTypeOf('function')
     expect(testing.StaticAuthProvider).toBeTypeOf('function')
+  })
+
+  it('keeps testing package declarations aligned with the stable public surface', async () => {
+    const testingKitDeclarations = await readFile(
+      new URL('../dist/testing/in-memory/kit.d.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(testingKitDeclarations).not.toContain('export interface InMemoryAuthKit')
+    expect(testingKitDeclarations).toContain('export interface CreateInMemoryAuthKitOptions')
   })
 
   it('keeps internal application helpers private', () => {

--- a/src/testing/in-memory/kit.ts
+++ b/src/testing/in-memory/kit.ts
@@ -28,7 +28,7 @@ export interface CreateInMemoryAuthKitOptions {
   readonly verificationTtlSeconds?: number
 }
 
-export interface InMemoryAuthKit {
+interface InMemoryAuthKitResult {
   readonly service: DefaultAuthService
   readonly store: InMemoryAuthStore
   readonly providerRegistry: InMemoryProviderRegistry
@@ -39,7 +39,9 @@ export interface InMemoryAuthKit {
   readonly idGenerator: IdGenerator
 }
 
-export function createInMemoryAuthKit(options: CreateInMemoryAuthKitOptions = {}): InMemoryAuthKit {
+export function createInMemoryAuthKit(
+  options: CreateInMemoryAuthKitOptions = {},
+): InMemoryAuthKitResult {
   const store = new InMemoryAuthStore()
   const providerRegistry = new InMemoryProviderRegistry()
   const emailSender = new InMemoryEmailSender()


### PR DESCRIPTION
## Summary
- remove the accidental `InMemoryAuthKit` type export introduced during the in-memory module split
- keep `createInMemoryAuthKit(...)` typed internally without widening the public `@alyldas/uniauth/testing` surface
- add a declaration smoke assertion so the testing package surface stays stable across future refactors

## Testing
- npm run check
