### PR TITLE
feat: add optional auth bridge helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ license, subscription, private contract, or other written permission.
 - Starts and finishes email password recovery on the shared verification lifecycle.
 - Validates signed Telegram Mini App and MAX WebApp `initData` without provider SDK lock-in.
 - Maps SDK-free OAuth/OIDC provider profiles into the existing provider sign-in pipeline.
+- Maps Auth.js and Better Auth OAuth callback data into `ProviderIdentityAssertion` through the
+  optional `@alyldas/uniauth/bridges` entry point.
 - Creates local session records after successful sign-in.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
@@ -44,6 +46,8 @@ license, subscription, private contract, or other written permission.
 - It does not generate one mandatory ORM schema.
 - It does not include SMTP, SMS gateway, OAuth/OIDC, Telegram, or MAX SDKs, bot setup, webhook
   handlers, or frontend bridge code in core.
+- It does not embed Better Auth or Auth.js runtime, session stores, cookies, callbacks, or plugin
+  wiring into core.
 - It does not send messages by itself; OTP, magic-link, and recovery delivery use sender ports you
   provide.
 - It does not bundle a password hashing runtime; password hashing uses a `PasswordHasher` adapter you
@@ -183,6 +187,12 @@ import {
 } from '@alyldas/uniauth/postgres'
 ```
 
+Optional framework bridge helpers come from a dedicated bridges entry point:
+
+```ts
+import { mapAuthJsOAuthToAssertion, mapBetterAuthOAuthToAssertion } from '@alyldas/uniauth/bridges'
+```
+
 There are no root side effects. Importing the package does not register providers, touch storage,
 create sessions, read environment variables, or mutate global state.
 
@@ -227,6 +237,9 @@ launch data. See [Messenger providers](docs/messenger-providers.md).
 
 OAuth/OIDC providers use an SDK-free client contract for authorization-code finish flows. See
 [OAuth / OIDC providers](docs/oauth-oidc.md).
+
+Optional Better Auth and Auth.js bridge helpers live in their own subpath so the core package stays
+free of framework runtime dependencies. See [Auth bridges](docs/bridges.md).
 
 Reference Postgres persistence lives in a separate subpath so the core API stays ORM-free and does
 not take a hard runtime dependency on `pg`. See [Postgres persistence](docs/postgres.md).
@@ -411,9 +424,14 @@ Provider adapters should return a normalized `ProviderIdentityAssertion` from `f
 provider payloads should stay adapter-owned or be reduced to explicit `metadata`; core does not
 persist raw provider profiles.
 
+Framework bridge helpers should stay equally narrow: they normalize framework callback data into
+`ProviderIdentityAssertion`, but they do not own provider SDK setup, cookies, sessions, token
+storage, or framework callback routing.
+
 ## Entry Points
 
 - `@alyldas/uniauth`: public domain types, service implementation, policy API, ports, errors, and utilities.
+- `@alyldas/uniauth/bridges`: optional Better Auth and Auth.js assertion mapping helpers.
 - `@alyldas/uniauth/postgres`: reference Postgres repositories, schema helper, and transaction wiring.
 - `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, in-memory email
   and SMS senders, and test kit.
@@ -444,6 +462,7 @@ contact `alyldas@ya.ru`.
 
 - [Development](docs/development.md)
 - [Architecture](docs/architecture.md)
+- [Auth bridges](docs/bridges.md)
 - [Security model](docs/security.md)
 - [Local auth flows](docs/local-auth.md)
 - [Messenger providers](docs/messenger-providers.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,11 @@ them in app-owned persistence keyed by local auth/session state, not inside core
 Applications can additionally attach normalized trust context to assertions so `AuthPolicy` can make
 auto-link, explicit-link, and merge decisions without receiving raw SDK objects.
 
+Optional framework bridge helpers under `@alyldas/uniauth/bridges` stay even narrower. They accept
+framework-owned Better Auth or Auth.js callback/account data, reduce it to
+`ProviderIdentityAssertion`, and intentionally do not take ownership of framework routes, cookies,
+session transport, token lifecycle, or plugin state.
+
 Delivery happens after the verification record has been created inside `UnitOfWork`. If a sender
 fails, the pending verification stays in storage until normal expiry or adapter cleanup; core does
 not roll back storage after an external delivery side effect fails.

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -1,0 +1,141 @@
+# Auth Bridges
+
+`@alyldas/uniauth/bridges` exposes optional helper functions for application auth frameworks.
+
+The bridge helpers do one narrow job: they map framework-owned OAuth callback or account data into a
+stable `ProviderIdentityAssertion` that the existing UniAuth service can consume.
+
+They do not add runtime dependencies on Better Auth or Auth.js to the core package.
+
+## Import
+
+```ts
+import { mapAuthJsOAuthToAssertion, mapBetterAuthOAuthToAssertion } from '@alyldas/uniauth/bridges'
+```
+
+## What the Framework Still Owns
+
+- provider setup and provider SDK/runtime wiring;
+- routes, callbacks, middleware, and request lifecycle;
+- cookies, session transport, JWT handling, and CSRF state;
+- token storage, refresh, rotation, and revocation;
+- framework-specific user/account/session tables and plugins.
+
+## What UniAuth Still Owns
+
+- local user and identity records;
+- exact `(provider, providerUserId)` matching;
+- policy-driven auto-link, explicit link, unlink, and merge decisions;
+- local sessions, verifications, audit events, and storage ports.
+
+## Auth.js
+
+Use the bridge helper inside your app-owned Auth.js sign-in or callback flow after Auth.js has
+already validated the provider response:
+
+```ts
+import { mapAuthJsOAuthToAssertion } from '@alyldas/uniauth/bridges'
+
+const assertion = mapAuthJsOAuthToAssertion({
+  providerId: 'google-workspace',
+  account: {
+    provider: account.provider,
+    providerAccountId: account.providerAccountId,
+    type: account.type,
+  },
+  profile: profile
+    ? {
+        sub: profile.sub,
+        id: profile.id,
+        name: profile.name,
+        email: profile.email,
+        email_verified: profile.email_verified,
+        phone_number: profile.phone_number,
+        phone_number_verified: profile.phone_number_verified,
+        preferred_username: profile.preferred_username,
+        picture: profile.picture,
+        locale: profile.locale,
+      }
+    : undefined,
+  user: user
+    ? {
+        name: user.name ?? undefined,
+        email: user.email ?? undefined,
+        image: user.image ?? undefined,
+      }
+    : undefined,
+  trust: {
+    level: 'trusted',
+    signals: ['workspace-admin'],
+  },
+  metadata: {
+    tenantId,
+  },
+})
+
+await authService.signIn({ assertion })
+```
+
+`providerAccountId` is treated as the exact provider identity key. If the profile subject disagrees
+with it, the helper rejects the input instead of silently picking one.
+
+If you want a UniAuth provider namespace that differs from the framework provider id, pass
+`providerId`. The original framework id is then kept as `metadata.frameworkProviderId`.
+
+## Better Auth
+
+Use the bridge helper after your Better Auth integration has already completed provider validation.
+The exact hook or middleware entry point is application-owned and depends on your Better Auth setup.
+
+```ts
+import { mapBetterAuthOAuthToAssertion } from '@alyldas/uniauth/bridges'
+
+const assertion = mapBetterAuthOAuthToAssertion({
+  providerId: 'discord-app',
+  account: {
+    providerId: account.providerId,
+    accountId: account.accountId,
+  },
+  profile: oauthProfile
+    ? {
+        id: oauthProfile.id,
+        email: oauthProfile.email,
+        emailVerified: oauthProfile.emailVerified,
+        name: oauthProfile.name,
+        image: oauthProfile.image,
+      }
+    : undefined,
+  user: frameworkUser
+    ? {
+        email: frameworkUser.email,
+        emailVerified: frameworkUser.emailVerified,
+        name: frameworkUser.name,
+        image: frameworkUser.image,
+      }
+    : undefined,
+  metadata: {
+    tenantId,
+  },
+})
+
+await authService.signIn({ assertion })
+```
+
+The helper accepts either:
+
+- `account.accountId` from the framework-owned provider account record;
+- `profile.id` from the validated OAuth profile.
+
+If both are present and disagree, the helper rejects the input.
+
+## Security Notes
+
+- The bridge helpers do not copy access tokens, refresh tokens, or ID tokens into UniAuth
+  assertion metadata.
+- If you need token persistence, keep it in application-owned storage keyed by your own session or
+  callback state.
+- UniAuth policy invariants still apply after mapping. A framework callback does not bypass
+  `AuthPolicy`, last-identity rules, or exact provider identity matching.
+- These helpers are intentionally thin. If your integration needs framework-native session
+  replacement, cookie ownership, or provider-specific token lifecycle management, that remains
+  outside the UniAuth package boundary.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,5 +15,10 @@ framework integration, route handling, session transport, and application-facing
 
 ## Intended Relationship
 
-`@alyldas/uniauth` can later expose bridge adapters around Better Auth or Auth.js, but core should
-not depend on either library.
+`@alyldas/uniauth` now exposes optional bridge helpers through `@alyldas/uniauth/bridges`.
+
+Those helpers only map framework-owned OAuth callback or account data into a stable
+`ProviderIdentityAssertion`.
+
+They do not make UniAuth the primary session engine, route owner, cookie owner, or token store for
+either framework.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -106,7 +106,7 @@ Tracking issues: #41, #47.
 
 ### v0.12 - Optional Auth Bridges
 
-- Optional Better Auth and Auth.js bridge adapters that do not add hard dependencies to core.
+- Optional Better Auth and Auth.js bridge helpers that do not add hard dependencies to core.
 - Bridge boundaries that preserve UniAuth account-linking and policy invariants.
 - Documentation that explains what external auth libraries own and what UniAuth still owns.
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./bridges": {
+      "types": "./dist/bridges.d.ts",
+      "import": "./dist/bridges/index.js"
+    },
     "./postgres": {
       "types": "./dist/postgres.d.ts",
       "import": "./dist/postgres/index.js"

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -22,10 +22,13 @@ describe('package exports', () => {
   })
 
   it('loads the public ESM entry points', async () => {
+    const bridges = await import('../dist/bridges')
     const core = await import('../dist')
     const postgres = await import('../dist/postgres')
     const testing = await import('../dist/testing')
 
+    expect(bridges.mapAuthJsOAuthToAssertion).toBeTypeOf('function')
+    expect(bridges.mapBetterAuthOAuthToAssertion).toBeTypeOf('function')
     expect(core.AuditEventType.SignIn).toBe('auth.sign_in')
     expect(core.CredentialType.Password).toBe('password')
     expect(core.AuthPolicyAction.ChangePassword).toBe('changePassword')
@@ -99,6 +102,8 @@ describe('package exports', () => {
 
   it('keeps internal provider adapter modules private', () => {
     for (const privateProviderSubpath of [
+      `${packageMetadata.name}/bridges/authjs.js`,
+      `${packageMetadata.name}/bridges/better-auth.js`,
       `${packageMetadata.name}/providers/messenger.js`,
       `${packageMetadata.name}/providers/oauth-oidc.js`,
       `${packageMetadata.name}/postgres/store.js`,

--- a/src/bridges.ts
+++ b/src/bridges.ts
@@ -1,0 +1,2 @@
+export * from './bridges/authjs.js'
+export * from './bridges/better-auth.js'

--- a/src/bridges/authjs.ts
+++ b/src/bridges/authjs.ts
@@ -1,0 +1,107 @@
+import type {
+  AuthIdentityProvider,
+  ProviderIdentityAssertion,
+  ProviderTrustContext,
+} from '../domain/types.js'
+import { invalidInput } from '../errors.js'
+import { optionalProp } from '../utils/optional.js'
+import {
+  buildMetadata,
+  readBooleanLike,
+  readString,
+  requireMatchingStrings,
+  requireNonBlankString,
+} from './support.js'
+
+const AUTH_JS_OAUTH_ACCOUNT_TYPES = new Set(['oauth', 'oidc'])
+
+export interface AuthJsOAuthAccount {
+  readonly provider: string
+  readonly providerAccountId: string
+  readonly type?: string
+}
+
+export interface AuthJsOAuthProfile {
+  readonly sub?: string
+  readonly id?: string
+  readonly name?: string
+  readonly email?: string
+  readonly email_verified?: boolean | string
+  readonly phone_number?: string
+  readonly phone_number_verified?: boolean | string
+  readonly preferred_username?: string
+  readonly picture?: string
+  readonly locale?: string
+}
+
+export interface AuthJsUser {
+  readonly name?: string
+  readonly email?: string
+  readonly image?: string
+  readonly emailVerified?: boolean | string
+}
+
+export interface AuthJsOAuthAssertionInput {
+  readonly providerId?: AuthIdentityProvider
+  readonly account: AuthJsOAuthAccount
+  readonly profile?: AuthJsOAuthProfile
+  readonly user?: AuthJsUser
+  readonly trust?: ProviderTrustContext
+  readonly metadata?: Record<string, unknown>
+}
+
+export function mapAuthJsOAuthToAssertion(
+  input: AuthJsOAuthAssertionInput,
+): ProviderIdentityAssertion {
+  const accountType = readString(input.account.type)?.toLowerCase()
+
+  if (accountType && !AUTH_JS_OAUTH_ACCOUNT_TYPES.has(accountType)) {
+    throw invalidInput('Auth.js bridge only accepts oauth or oidc accounts.')
+  }
+
+  const frameworkProviderId = requireNonBlankString(
+    input.account.provider,
+    'Auth.js account provider is required.',
+  )
+  const provider = readString(input.providerId) ?? frameworkProviderId
+  const providerUserId = requireNonBlankString(
+    input.account.providerAccountId,
+    'Auth.js account providerAccountId is required.',
+  )
+  const profileSubject = readString(input.profile?.sub) ?? readString(input.profile?.id)
+
+  requireMatchingStrings(
+    providerUserId,
+    profileSubject,
+    'Auth.js account providerAccountId and profile subject must match.',
+  )
+
+  const email = readString(input.profile?.email) ?? readString(input.user?.email)
+  const emailVerified =
+    readBooleanLike(input.profile?.email_verified) ?? readBooleanLike(input.user?.emailVerified)
+  const phone = readString(input.profile?.phone_number)
+  const phoneVerified = readBooleanLike(input.profile?.phone_number_verified)
+  const displayName =
+    readString(input.profile?.name) ??
+    readString(input.user?.name) ??
+    readString(input.profile?.preferred_username)
+  const metadata = buildMetadata(
+    {
+      frameworkProviderId: provider !== frameworkProviderId ? frameworkProviderId : undefined,
+      preferredUsername: readString(input.profile?.preferred_username),
+      pictureUrl: readString(input.profile?.picture) ?? readString(input.user?.image),
+      locale: readString(input.profile?.locale),
+    },
+    input.metadata,
+  )
+
+  return {
+    provider,
+    providerUserId,
+    ...(email ? { email, emailVerified: emailVerified === true } : {}),
+    ...(phone ? { phone, phoneVerified: phoneVerified === true } : {}),
+    ...optionalProp('displayName', displayName),
+    ...optionalProp('trust', input.trust),
+    ...optionalProp('metadata', metadata),
+  }
+}

--- a/src/bridges/better-auth.ts
+++ b/src/bridges/better-auth.ts
@@ -1,0 +1,84 @@
+import type {
+  AuthIdentityProvider,
+  ProviderIdentityAssertion,
+  ProviderTrustContext,
+} from '../domain/types.js'
+import { invalidInput } from '../errors.js'
+import { optionalProp } from '../utils/optional.js'
+import { buildMetadata, readBooleanLike, readString, requireMatchingStrings } from './support.js'
+
+export interface BetterAuthAccount {
+  readonly providerId?: string
+  readonly accountId?: string
+}
+
+export interface BetterAuthOAuthProfile {
+  readonly id?: string
+  readonly email?: string
+  readonly emailVerified?: boolean | string
+  readonly name?: string
+  readonly image?: string
+}
+
+export interface BetterAuthUser {
+  readonly email?: string
+  readonly emailVerified?: boolean | string
+  readonly name?: string
+  readonly image?: string
+}
+
+export interface BetterAuthOAuthAssertionInput {
+  readonly providerId?: AuthIdentityProvider
+  readonly account?: BetterAuthAccount
+  readonly profile?: BetterAuthOAuthProfile
+  readonly user?: BetterAuthUser
+  readonly trust?: ProviderTrustContext
+  readonly metadata?: Record<string, unknown>
+}
+
+export function mapBetterAuthOAuthToAssertion(
+  input: BetterAuthOAuthAssertionInput,
+): ProviderIdentityAssertion {
+  const frameworkProviderId = readString(input.account?.providerId)
+  const provider = readString(input.providerId) ?? frameworkProviderId
+
+  if (!provider) {
+    throw invalidInput('Better Auth bridge providerId is required.')
+  }
+
+  const accountId = readString(input.account?.accountId)
+  const profileId = readString(input.profile?.id)
+  const providerUserId = accountId ?? profileId
+
+  if (!providerUserId) {
+    throw invalidInput('Better Auth accountId or profile.id is required.')
+  }
+
+  requireMatchingStrings(
+    accountId,
+    profileId,
+    'Better Auth accountId and profile.id must match when both are provided.',
+  )
+
+  const email = readString(input.profile?.email) ?? readString(input.user?.email)
+  const emailVerified =
+    readBooleanLike(input.profile?.emailVerified) ?? readBooleanLike(input.user?.emailVerified)
+  const displayName = readString(input.profile?.name) ?? readString(input.user?.name)
+  const metadata = buildMetadata(
+    {
+      frameworkProviderId:
+        frameworkProviderId && provider !== frameworkProviderId ? frameworkProviderId : undefined,
+      pictureUrl: readString(input.profile?.image) ?? readString(input.user?.image),
+    },
+    input.metadata,
+  )
+
+  return {
+    provider,
+    providerUserId,
+    ...(email ? { email, emailVerified: emailVerified === true } : {}),
+    ...optionalProp('displayName', displayName),
+    ...optionalProp('trust', input.trust),
+    ...optionalProp('metadata', metadata),
+  }
+}

--- a/src/bridges/support.ts
+++ b/src/bridges/support.ts
@@ -1,0 +1,69 @@
+import { invalidInput } from '../errors.js'
+
+export function requireNonBlankString(value: unknown, message: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw invalidInput(message)
+  }
+
+  return value.trim()
+}
+
+export function readString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  return value.trim() || undefined
+}
+
+export function readBooleanLike(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value !== 'string') {
+    return undefined
+  }
+
+  const normalized = value.trim().toLowerCase()
+
+  if (normalized === 'true') {
+    return true
+  }
+
+  if (normalized === 'false') {
+    return false
+  }
+
+  return undefined
+}
+
+export function requireMatchingStrings(
+  left: string | undefined,
+  right: string | undefined,
+  message: string,
+): void {
+  if (left && right && left !== right) {
+    throw invalidInput(message)
+  }
+}
+
+export function buildMetadata(
+  ...records: ReadonlyArray<Record<string, unknown> | undefined>
+): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = {}
+
+  for (const record of records) {
+    if (!record) {
+      continue
+    }
+
+    for (const [key, value] of Object.entries(record)) {
+      if (value !== undefined) {
+        metadata[key] = value
+      }
+    }
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined
+}

--- a/test/bridges.test.ts
+++ b/test/bridges.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from 'vitest'
+import { ProviderTrustLevel, UniAuthErrorCode } from '../src'
+import { mapAuthJsOAuthToAssertion, mapBetterAuthOAuthToAssertion } from '../src/bridges'
+import { createInMemoryAuthKit } from '../src/testing'
+import { now } from './helpers.js'
+
+async function catchError(operation: () => unknown | Promise<unknown>): Promise<unknown> {
+  try {
+    await operation()
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}
+
+describe('auth bridge helpers', () => {
+  it('maps Auth.js oauth inputs into a UniAuth assertion without copying tokens', () => {
+    const assertion = mapAuthJsOAuthToAssertion({
+      providerId: 'google-workspace',
+      account: {
+        provider: 'google',
+        providerAccountId: ' provider-user-1 ',
+        type: 'oauth',
+      },
+      profile: {
+        sub: 'provider-user-1',
+        email: ' Person@Example.COM ',
+        email_verified: 'true',
+        phone_number: ' +1 555 000 1234 ',
+        phone_number_verified: false,
+        name: ' Person Example ',
+        preferred_username: ' person ',
+        picture: ' https://example.com/avatar.png ',
+        locale: ' en ',
+      },
+      user: {
+        image: ' https://example.com/fallback.png ',
+      },
+      trust: {
+        level: ProviderTrustLevel.Trusted,
+        signals: ['workspace-admin'],
+      },
+      metadata: {
+        tenantId: 'tenant-1',
+      },
+    })
+
+    expect(assertion).toEqual({
+      provider: 'google-workspace',
+      providerUserId: 'provider-user-1',
+      email: 'Person@Example.COM',
+      emailVerified: true,
+      phone: '+1 555 000 1234',
+      phoneVerified: false,
+      displayName: 'Person Example',
+      trust: {
+        level: ProviderTrustLevel.Trusted,
+        signals: ['workspace-admin'],
+      },
+      metadata: {
+        frameworkProviderId: 'google',
+        preferredUsername: 'person',
+        pictureUrl: 'https://example.com/avatar.png',
+        locale: 'en',
+        tenantId: 'tenant-1',
+      },
+    })
+    expect(assertion.metadata).not.toHaveProperty('accessToken')
+    expect(assertion.metadata).not.toHaveProperty('refreshToken')
+    expect(assertion.metadata).not.toHaveProperty('idToken')
+  })
+
+  it('rejects Auth.js non-oauth accounts and mismatched subjects', async () => {
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: {
+            provider: 'credentials',
+            providerAccountId: 'user-1',
+            type: 'credentials',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Auth.js bridge only accepts oauth or oidc accounts.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: {
+            provider: 'google',
+            providerAccountId: 'user-1',
+            type: 'oauth',
+          },
+          profile: {
+            sub: 'user-2',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Auth.js account providerAccountId and profile subject must match.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: {
+            provider: 'google',
+            providerAccountId: '   ',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Auth.js account providerAccountId is required.',
+    })
+  })
+
+  it('supports Auth.js fallback fields and keeps metadata empty when nothing safe is left', () => {
+    expect(
+      mapAuthJsOAuthToAssertion({
+        account: {
+          provider: 'github',
+          providerAccountId: ' github-user-1 ',
+          type: 'oidc',
+        },
+        profile: {
+          id: 'github-user-1',
+          email_verified: 'not-a-boolean',
+          name: '   ',
+          preferred_username: '   ',
+          picture: '   ',
+          locale: '   ',
+        },
+        user: {
+          email: ' GitHubUser@Example.COM ',
+          emailVerified: 'false',
+          name: ' GitHub User ',
+          image: ' https://example.com/github.png ',
+        },
+      }),
+    ).toEqual({
+      provider: 'github',
+      providerUserId: 'github-user-1',
+      email: 'GitHubUser@Example.COM',
+      emailVerified: false,
+      displayName: 'GitHub User',
+      metadata: {
+        pictureUrl: 'https://example.com/github.png',
+      },
+    })
+  })
+
+  it('returns a minimal Auth.js assertion when only the exact provider identity is available', () => {
+    expect(
+      mapAuthJsOAuthToAssertion({
+        account: {
+          provider: 'google',
+          providerAccountId: 'google-user-1',
+        },
+      }),
+    ).toEqual({
+      provider: 'google',
+      providerUserId: 'google-user-1',
+    })
+  })
+
+  it('maps Better Auth account or profile data without copying account tokens', () => {
+    const assertion = mapBetterAuthOAuthToAssertion({
+      providerId: 'discord-app',
+      account: {
+        providerId: 'discord',
+        accountId: ' discord-user-1 ',
+      },
+      profile: {
+        id: 'discord-user-1',
+        email: ' Discord@Example.COM ',
+        emailVerified: true,
+        name: ' Discord User ',
+        image: ' https://example.com/discord.png ',
+      },
+      user: {
+        email: 'ignored@example.com',
+        image: 'https://example.com/fallback.png',
+      },
+      metadata: {
+        tenantId: 'tenant-2',
+      },
+    })
+
+    expect(assertion).toEqual({
+      provider: 'discord-app',
+      providerUserId: 'discord-user-1',
+      email: 'Discord@Example.COM',
+      emailVerified: true,
+      displayName: 'Discord User',
+      metadata: {
+        frameworkProviderId: 'discord',
+        pictureUrl: 'https://example.com/discord.png',
+        tenantId: 'tenant-2',
+      },
+    })
+    expect(assertion.metadata).not.toHaveProperty('accessToken')
+    expect(assertion.metadata).not.toHaveProperty('refreshToken')
+    expect(assertion.metadata).not.toHaveProperty('idToken')
+  })
+
+  it('supports Better Auth profile-only mapping when the app chooses the provider id', () => {
+    expect(
+      mapBetterAuthOAuthToAssertion({
+        providerId: 'github',
+        profile: {
+          id: 'github-user-1',
+          name: ' GitHub User ',
+          email: ' GitHub@Example.COM ',
+          emailVerified: 'false',
+        },
+        trust: {
+          level: ProviderTrustLevel.Neutral,
+        },
+      }),
+    ).toEqual({
+      provider: 'github',
+      providerUserId: 'github-user-1',
+      email: 'GitHub@Example.COM',
+      emailVerified: false,
+      displayName: 'GitHub User',
+      trust: {
+        level: ProviderTrustLevel.Neutral,
+      },
+    })
+  })
+
+  it('rejects Better Auth inputs without a stable provider id or with conflicting subjects', async () => {
+    await expect(
+      catchError(() =>
+        mapBetterAuthOAuthToAssertion({
+          profile: {
+            id: 'user-1',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Better Auth bridge providerId is required.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapBetterAuthOAuthToAssertion({
+          providerId: 'discord',
+          account: {
+            accountId: 'user-1',
+          },
+          profile: {
+            id: 'user-2',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Better Auth accountId and profile.id must match when both are provided.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapBetterAuthOAuthToAssertion({
+          providerId: 'discord',
+          account: {
+            providerId: 'discord',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Better Auth accountId or profile.id is required.',
+    })
+  })
+
+  it('returns a minimal Better Auth assertion when only the provider account record is available', () => {
+    expect(
+      mapBetterAuthOAuthToAssertion({
+        account: {
+          providerId: 'google',
+          accountId: ' google-user-2 ',
+        },
+      }),
+    ).toEqual({
+      provider: 'google',
+      providerUserId: 'google-user-2',
+    })
+  })
+
+  it('feeds mapped framework assertions through the normal sign-in pipeline', async () => {
+    const kit = createInMemoryAuthKit()
+
+    const result = await kit.service.signIn({
+      assertion: mapAuthJsOAuthToAssertion({
+        account: {
+          provider: 'authjs-google',
+          providerAccountId: 'authjs-user-1',
+          type: 'oauth',
+        },
+        profile: {
+          sub: 'authjs-user-1',
+          email: 'Bridge@Example.COM',
+          email_verified: true,
+          name: 'Bridge User',
+        },
+      }),
+      now,
+    })
+
+    expect(result.identity.provider).toBe('authjs-google')
+    expect(result.identity.providerUserId).toBe('authjs-user-1')
+    expect(result.identity.email).toBe('bridge@example.com')
+    expect(result.identity.emailVerified).toBe(true)
+    expect(result.user.id).toBe(result.session.userId)
+  })
+})

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "files": ["src/index.ts", "src/postgres.ts", "src/testing/index.ts"],
+  "files": ["src/index.ts", "src/bridges.ts", "src/postgres.ts", "src/testing/index.ts"],
   "include": []
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   clean: true,
   define: attributionDefines,
   entry: {
+    'bridges/index': 'src/bridges.ts',
     index: 'src/index.ts',
     'postgres/index': 'src/postgres.ts',
     'testing/index': 'src/testing/index.ts',


### PR DESCRIPTION
## Summary
- add optional `@alyldas/uniauth/bridges` helpers for Auth.js and Better Auth OAuth mapping
- preserve exact provider identity invariants and avoid copying framework tokens into UniAuth assertions
- document the bridge boundary and add unit/export smoke coverage

## Testing
- npm run check

Closes #39