### PR TITLE
docs: sync roadmap after v0.12.0 release

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,8 +102,6 @@ Tracking issues: #40, #42.
 
 Tracking issues: #41, #47.
 
-## Next Release
-
 ### v0.12 - Optional Auth Bridges
 
 - Optional Better Auth and Auth.js bridge helpers that do not add hard dependencies to core.
@@ -112,7 +110,7 @@ Tracking issues: #41, #47.
 
 Tracking issues: #39.
 
-## Planned
+## Next Release
 
 ### v0.13 - Production Hardening and Integration Backlog
 


### PR DESCRIPTION
## Summary
- move v0.12 optional auth bridges from next release to released
- make v0.13 production hardening the next release in the roadmap
- keep roadmap and GitHub release planning metadata aligned after the 0.12.0 release

## Testing
- npm run check