### PR TITLE
docs: define otp delivery boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,10 @@ await service.finishEmailPasswordRecovery({
 OTP delivery is outside the storage transaction. `startOtpChallenge` first persists the hashed
 verification record, then calls the configured sender port. If the sender rejects, the pending
 verification remains in storage until it is consumed, expires, or is cleaned up by your adapter.
-This keeps external SMTP/SMS/queue side effects out of `UnitOfWork`; applications that need retry or
-dead-letter behavior should implement it in their sender adapter.
+This keeps external SMTP/SMS/queue side effects out of `UnitOfWork`. Queue-backed delivery should
+wrap `EmailSender` or `SmsSender` instead of introducing a new core dispatcher, and exhausted
+delivery remains adapter-owned state rather than a new core verification status. See
+[OTP delivery boundary](docs/otp-delivery.md).
 
 Verification hashing is pluggable. The default hasher keeps the package usable out of the box, while
 production OTP deployments should provide an app-owned pepper through `createHmacSecretHasher` or a
@@ -466,6 +468,7 @@ contact `alyldas@ya.ru`.
 - [Security model](docs/security.md)
 - [Threat model](docs/threat-model.md)
 - [Local auth flows](docs/local-auth.md)
+- [OTP delivery boundary](docs/otp-delivery.md)
 - [Messenger providers](docs/messenger-providers.md)
 - [OAuth / OIDC providers](docs/oauth-oidc.md)
 - [Postgres persistence](docs/postgres.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,11 @@ Delivery happens after the verification record has been created inside `UnitOfWo
 fails, the pending verification stays in storage until normal expiry or adapter cleanup; core does
 not roll back storage after an external delivery side effect fails.
 
+Queue-backed delivery should wrap `EmailSender` or `SmsSender`, not replace them with a new core
+dispatcher contract. Core does not track delivery attempts, retries, dead-letter state, or
+provider-specific webhooks. Those remain application-owned or optional-adapter-owned delivery
+infrastructure concerns.
+
 `UnitOfWork` is intentionally part of v0.1 so storage adapters can provide real transaction
 boundaries for link, unlink, merge, session, and verification flows.
 

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -30,7 +30,8 @@ win over configured generation. Empty generated secrets are rejected before a ve
 created.
 
 `emailOtpSubject` customizes only the built-in email OTP subject. Full templates, localization,
-provider payloads, queues, retry, and dead-letter behavior remain sender-adapter concerns.
+provider payloads, queues, retry, and dead-letter behavior remain sender-adapter concerns. See
+[OTP delivery boundary](otp-delivery.md).
 
 ## Magic Link
 
@@ -121,8 +122,9 @@ headers, retry-after formatting, and abuse analytics remain application or adapt
 
 ## Production Boundaries
 
-Current v0.6 local auth hardening does not try to solve every production edge. The production
-normalization and delivery orchestration designs are tracked for v0.10 in [Roadmap](roadmap.md).
+Current local auth hardening does not try to solve every production edge. The OTP delivery boundary
+is documented in [OTP delivery boundary](otp-delivery.md), and production normalization remains
+tracked in [Roadmap](roadmap.md).
 
 For storage and security invariants, see [Architecture](architecture.md) and
 [Security model](security.md).

--- a/docs/otp-delivery.md
+++ b/docs/otp-delivery.md
@@ -1,0 +1,152 @@
+# OTP Delivery Boundary
+
+This document defines the production delivery orchestration boundary for OTP email and SMS sends.
+
+It preserves the current UniAuth sender-port model and explains how applications can add queue,
+retry, and dead-letter behavior without changing the OTP lifecycle.
+
+## Decision Summary
+
+Keep the current core contract:
+
+- UniAuth creates and stores the verification first;
+- UniAuth then calls `EmailSender` or `SmsSender`;
+- sender side effects stay outside `UnitOfWork`;
+- sender failure does not roll back the verification record;
+- queue, retry, dead-letter, bounce handling, and provider-specific delivery state remain
+  application-owned or adapter-owned concerns.
+
+UniAuth does not add a new `DeliveryDispatcher`, delivery repository, verification status, or audit
+event type for provider delivery attempts.
+
+## Current Core Flow
+
+```mermaid
+sequenceDiagram
+  participant App
+  participant Service as AuthService
+  participant Store as VerificationRepo
+  participant Sender as EmailSender / SmsSender
+  participant Queue as App Queue / Provider
+
+  App->>Service: startOtpChallenge(...)
+  Service->>Store: create pending verification
+  Store-->>Service: persisted verification + secret
+  Service->>Sender: send(message)
+  Sender->>Queue: enqueue or deliver
+  Queue-->>Sender: accepted or failed
+  Sender-->>Service: success or error
+  Service-->>App: challenge result or send failure
+```
+
+The sender can deliver directly or enqueue work. From core's point of view both are the same
+contract: `send(...)` is an app-owned side effect after verification persistence.
+
+## What Core Owns
+
+UniAuth owns only the generic auth semantics:
+
+- normalized OTP target handling;
+- verification creation before delivery;
+- hash-only verification secret storage;
+- consume-once finish semantics;
+- neutral account-state behavior;
+- rate-limit hooks before start and finish;
+- leaving the verification pending if delivery fails.
+
+That last rule is intentional. A failed send does not mean the secret became invalid. It only means
+the external delivery side effect failed or was not accepted by downstream infrastructure.
+
+## What Core Does Not Own
+
+UniAuth does not own:
+
+- retry schedules or backoff policies;
+- queue backend choice such as BullMQ, SQS, Cloud Tasks, Redis streams, or provider-native queues;
+- bounce, complaint, or delivery webhook ingestion;
+- delivery-attempt counters;
+- dead-letter queues and replay tooling;
+- provider-specific message templates, localization, or payload shaping;
+- exhausted-delivery operational policy.
+
+Those are delivery infrastructure concerns, not auth-domain state transitions.
+
+## Queue-Backed Composition
+
+The recommended production pattern is to keep the current sender ports and implement queueing inside
+the sender adapter:
+
+1. `AuthService.startOtpChallenge(...)` creates the pending verification and plain secret.
+2. An `EmailSender` or `SmsSender` adapter enqueues a delivery job instead of talking to the vendor
+   inline.
+3. A worker later sends the message through SMTP, SES, Twilio, Vonage, or another provider.
+4. Retry, backoff, DLQ, and webhook handling stay inside that queue or provider integration layer.
+
+This keeps the OTP lifecycle stable for existing applications and avoids making one queue model a
+core dependency.
+
+## Exhausted Delivery Semantics
+
+When retries are exhausted, core still should not mutate verification state into a special
+"delivery failed" auth status.
+
+The recommended meaning is:
+
+- the verification remains pending until normal TTL expiry, successful consumption, or explicit
+  adapter cleanup;
+- the application may record delivery state in queue storage, provider logs, adapter metadata, or
+  its own observability tables;
+- the application may choose to stop retries, mark the job dead-lettered, or proactively delete the
+  pending verification through an app-owned cleanup path.
+
+UniAuth intentionally does not infer that exhausted delivery changes ownership, secrecy, or
+verification validity.
+
+## Why No New Core Dispatcher
+
+A `DeliveryDispatcher`-style core port would blur the boundary:
+
+- it would push queue semantics into the auth package;
+- it would create pressure for generic retry metadata, attempt counters, and exhausted states;
+- it would still not remove the need for provider-specific workers, webhooks, and observability.
+
+The current sender ports are already enough for direct delivery and queued delivery.
+
+## Delivery Tracking and Audit
+
+UniAuth does not add generic auth audit events for provider delivery attempts.
+
+Reasoning:
+
+- delivery acceptance and retries are infrastructure telemetry, not user identity state;
+- provider webhooks are often noisy and vendor-specific;
+- a generic core audit surface would either be too weak to be useful or too coupled to delivery
+  vendors.
+
+If an application needs delivery audit or observability, it should emit adapter-owned logs or store
+application-owned delivery events outside the core auth event model.
+
+## Public Behavior Requirements
+
+Applications should preserve these external behaviors:
+
+- start responses remain neutral about account existence;
+- sender failures must not expose whether the target account exists;
+- retry and dead-letter identifiers must not leak in public error payloads;
+- cleanup logic must not invalidate a successfully delivered verification that is still within TTL
+  unless the application explicitly chooses that policy.
+
+## Current Core Test Coverage
+
+Core-owned delivery semantics are already covered by generic tests:
+
+- [test/core.test.ts](../test/core.test.ts): failed OTP delivery leaves a pending verification;
+- [test/magic-link.test.ts](../test/magic-link.test.ts): failed magic-link creation or delivery
+  keeps the verification pending;
+- [test/password.test.ts](../test/password.test.ts): failed password-recovery link creation or
+  delivery keeps the verification pending;
+- [test/rate-limit.test.ts](../test/rate-limit.test.ts): OTP start rate-limit denial happens before
+  verification creation or send side effects.
+
+Those tests are intentionally provider-agnostic. Provider-specific retry workers, webhook payloads,
+and DLQ tooling should be tested in optional adapter packages or in application code.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,8 @@ Tracking issues: #39.
 
 - Threat model documentation.
 - Production email and phone normalization design.
-- OTP delivery orchestration, retry, queue, and dead-letter boundary design.
+- OTP delivery orchestration boundary documented for queue, retry, and dead-letter adapters without
+  moving sender side effects into core.
 - Anti-takeover tests.
 - Merge idempotency tests.
 - Audit coverage.

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,6 +26,8 @@ risks, see [Threat model](threat-model.md).
 - Password recovery uses hashed verification secrets and consume-once finish semantics.
 - OTP delivery failures do not expose account state; the app-owned sender adapter decides retry,
   dead-letter, and cleanup behavior.
+- Queue-backed delivery may wrap sender ports, but delivery attempts and exhausted-delivery state
+  remain outside core.
 - Rate-limit denials do not create users or sessions, do not consume pending verifications, and do not
   reveal whether a target account exists.
 - Public errors avoid exposing which user owns an identity.
@@ -114,3 +116,6 @@ risks, see [Threat model](threat-model.md).
   headers.
 - Database migrations and production SQL constraints.
 - Application secret loading, pepper rotation, and key management.
+
+See [OTP delivery boundary](otp-delivery.md) for the intended queue/retry/DLQ composition around
+the current sender-port model.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -112,7 +112,8 @@ Residual risk:
 
 - delivery retries, queue isolation, abuse controls at SMTP/SMS providers, and dead-letter policy
   remain application-owned;
-- OTP delivery orchestration hardening is still backlog work under `#28`.
+- delivery orchestration boundary is documented in [OTP delivery boundary](otp-delivery.md), but
+  provider-specific workers, retries, and webhooks still remain outside core.
 
 ### Session Creation, Revocation, and Residual Access
 


### PR DESCRIPTION
## Summary
- add a dedicated OTP delivery boundary document that keeps queue/retry/DLQ behavior outside core while preserving the sender-port model
- sync README, architecture, local auth, security, threat model, and roadmap with the delivery-boundary decision
- map current generic core delivery semantics to existing tests instead of adding provider-specific delivery behavior to core

## Testing
- npm run check

Closes #28