### PR TITLE
docs: define normalization boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,11 @@ wrap `EmailSender` or `SmsSender` instead of introducing a new core dispatcher, 
 delivery remains adapter-owned state rather than a new core verification status. See
 [OTP delivery boundary](docs/otp-delivery.md).
 
+Email and phone normalization stay intentionally lightweight in the root helpers so the package does
+not silently impose one production syntax or phone metadata policy on every consumer. Current
+exports remain compatibility-oriented; stricter validation, E.164 canonicalization guidance, and
+migration cautions are documented in [Normalization boundary](docs/normalization.md).
+
 Verification hashing is pluggable. The default hasher keeps the package usable out of the box, while
 production OTP deployments should provide an app-owned pepper through `createHmacSecretHasher` or a
 custom `SecretHasher` implementation:
@@ -469,6 +474,7 @@ contact `alyldas@ya.ru`.
 - [Threat model](docs/threat-model.md)
 - [Local auth flows](docs/local-auth.md)
 - [OTP delivery boundary](docs/otp-delivery.md)
+- [Normalization boundary](docs/normalization.md)
 - [Messenger providers](docs/messenger-providers.md)
 - [OAuth / OIDC providers](docs/oauth-oidc.md)
 - [Postgres persistence](docs/postgres.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,12 @@ start/finish, password sign-in, and password recovery. Applications own the real
 edge runtime, or hosted rate-limit adapter and decide exact bucket sizes, key hashing, and retry
 headers.
 
+The built-in `normalizeEmail`, `normalizePhone`, and `normalizeTarget` helpers are compatibility
+utilities, not a full production canonicalization policy. If an application needs strict email
+validation or E.164 phone handling, it should apply one shared policy across provider assertions,
+OTP, magic link, password, and repository lookup paths instead of normalizing each flow
+independently. See [Normalization boundary](normalization.md).
+
 Messenger WebApp providers are reference `AuthProvider` factories, not SDK integrations. They
 validate signed Telegram Mini App and MAX WebApp launch data with an application-provided bot token,
 map the signed user into `ProviderIdentityAssertion`, and leave bot setup, frontend bridge code,

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -123,8 +123,8 @@ headers, retry-after formatting, and abuse analytics remain application or adapt
 ## Production Boundaries
 
 Current local auth hardening does not try to solve every production edge. The OTP delivery boundary
-is documented in [OTP delivery boundary](otp-delivery.md), and production normalization remains
-tracked in [Roadmap](roadmap.md).
+is documented in [OTP delivery boundary](otp-delivery.md), and production normalization policy is
+documented in [Normalization boundary](normalization.md).
 
 For storage and security invariants, see [Architecture](architecture.md) and
 [Security model](security.md).

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -1,0 +1,202 @@
+# Normalization Boundary
+
+This document defines the production boundary for email and phone normalization in UniAuth.
+
+It does not silently replace the current lightweight helpers with stricter behavior. Instead, it
+defines what remains compatibility default, what production applications should own, and how future
+strict normalization should be introduced without breaking identity matching semantics by surprise.
+
+## Decision Summary
+
+Keep the current exported helpers as compatibility utilities in `v0.13`:
+
+- `normalizeEmail(...)` keeps trim + lowercase behavior;
+- `normalizePhone(...)` keeps separator stripping behavior;
+- `normalizeTarget(...)` keeps the current email-vs-phone heuristic.
+
+Do not silently change those helpers into strict validators or provider-specific canonicalizers.
+
+Production-grade validation and canonicalization should follow these rules:
+
+- one shared normalization policy must be used across OTP, magic link, password, provider
+  assertions, and repository lookup paths;
+- email stays provider-agnostic in core, without mailbox-vendor alias rules;
+- phone canonicalization should target E.164 when applications want production-stable phone
+  identity matching;
+- region-specific phone parsing must be explicit and application-owned or future-adapter-owned;
+- no mandatory phone metadata dependency should be added to the core package.
+
+If UniAuth later grows configurable strict normalization, it should be introduced as one shared
+runtime boundary, not as separate ad hoc flags for each auth flow.
+
+## Current Compatibility Mode
+
+The current root exports are intentionally lightweight:
+
+- `normalizeEmail(...)`: trims and lowercases;
+- `normalizePhone(...)`: removes spaces, parentheses, dots, and dashes;
+- `normalizeTarget(...)`: trims first, then routes to email normalization when the input contains
+  `@`, otherwise to phone normalization.
+
+Those helpers are good enough for:
+
+- examples and tests;
+- backward-compatible local development behavior;
+- low-friction repository and verification demos.
+
+They are not a complete production policy for:
+
+- email syntax validation;
+- mailbox-provider alias rules such as Gmail dot/plus handling;
+- E.164 guarantees for phone storage and lookup;
+- migration-safe canonicalization across persisted identities and credentials.
+
+## Shared Flow Requirement
+
+Applications should treat normalization as one cross-cutting identity policy, not as a per-endpoint
+tweak.
+
+The same normalized output must be used everywhere that a value becomes a lookup key or persisted
+identifier:
+
+- provider assertion mapping into `ProviderIdentityAssertion`;
+- OTP target creation;
+- email magic-link start;
+- password credential email;
+- repository lookup and uniqueness constraints;
+- application-owned rate-limit keys built around normalized targets.
+
+```mermaid
+flowchart LR
+  Input["User input / provider payload"] --> Policy["App-owned normalization policy"]
+  Policy --> Service["UniAuth service"]
+  Service --> Lookup["Repo lookups / uniqueness"]
+  Service --> Verification["Verification target storage"]
+  Service --> Credential["Credential subject storage"]
+  Policy --> Buckets["App-owned rate-limit keys"]
+```
+
+Mixing old and new normalized forms across these paths is unsafe. A deployment should not write one
+format in OTP flows and a different one in password or provider flows.
+
+## Email Policy
+
+UniAuth keeps the current lowercase email compatibility behavior because most authentication systems
+treat email lookup as case-insensitive in practice.
+
+At the same time, core should not grow mailbox-vendor-specific ownership rules such as:
+
+- Gmail dot folding;
+- Gmail plus-tag stripping;
+- Outlook alias collapsing;
+- provider-specific hosted-domain heuristics.
+
+Those rules are product policy, not universal auth-domain truth.
+
+Production guidance:
+
+- reject obviously malformed email input before creating OTP, magic-link, or recovery
+  verifications;
+- reject obviously malformed email input before creating or updating password credentials;
+- if an application needs stricter syntax validation, do it through one shared policy that every
+  local-auth path uses;
+- if an application needs case preservation for display, keep a separate display value outside the
+  canonical lookup key.
+
+Email remains an optional identity attribute and, by itself, does not become proof of account
+ownership.
+
+## Phone Policy
+
+Production phone matching should use canonical E.164 values when phone identity is meant to be
+stable across flows and storage adapters.
+
+Recommended guidance:
+
+- if the application already collects E.164 input, keep UniAuth on that canonical form end to end;
+- if the application accepts national-format input, the default region must be explicit in the
+  application or future normalization adapter;
+- core should not guess a region implicitly from process locale, deployment country, or user
+  profile metadata;
+- provider-specific raw phone strings should be normalized before they are relied on for matching
+  or rate limiting.
+
+UniAuth should not bundle a mandatory phone metadata/runtime dependency into the core package just
+to support every numbering plan. If applications need region-aware canonicalization, that belongs in
+an app-owned or optional-adapter-owned boundary.
+
+## Invalid Input Behavior
+
+When strict normalization is eventually wired into the runtime, invalid email or phone input should
+fail as `invalid_input` before core creates new verifications or password credentials.
+
+That behavior should apply consistently to:
+
+- email OTP start;
+- phone OTP start;
+- email magic-link start;
+- password sign-in;
+- password recovery start;
+- password creation and update paths;
+- provider assertions only when the application has decided that the mapped email or phone claim is
+  authoritative enough to normalize strictly.
+
+Public behavior must stay neutral. Invalid account ownership must not be inferred from validation
+errors, and stricter normalization must not reopen account-enumeration leaks.
+
+## Migration and Rollout
+
+Changing normalization semantics is a data migration, not a helper refactor.
+
+Before tightening normalization in production, applications should inventory every place where the
+normalized value is persisted or used as a key:
+
+- `AuthIdentity.email`;
+- `AuthIdentity.phone`;
+- `AuthIdentity.providerUserId` for local email-derived identities;
+- `Credential.subject` for password credentials;
+- pending `Verification.target` values;
+- application-owned rate-limit keys or analytics dimensions;
+- database unique indexes that protect those values.
+
+Recommended rollout:
+
+1. Define the canonical email and phone policy outside core first.
+2. Dry-run it against existing stored values and detect collisions.
+3. Resolve collisions explicitly; do not auto-merge users because two legacy values canonicalize to
+   the same target.
+4. Backfill stored records and supporting indexes.
+5. Switch write paths and lookup paths together.
+6. Expire, migrate, or carefully tolerate pending verifications created under the legacy format.
+
+The main risk is not syntax rejection. The main risk is changing identity matching keys without
+updating all persisted data and all lookup paths consistently.
+
+## Future Core Integration
+
+If UniAuth later exposes configurable normalization, it should follow these constraints:
+
+- one shared runtime-level boundary for email and phone normalization;
+- used by OTP, magic link, password, verification, and provider-assertion orchestration paths;
+- returns one canonical string or throws `invalid_input`;
+- optional by default so the package does not force one validator or phone library on every
+  consumer.
+
+The current root `normalizeEmail`, `normalizePhone`, and `normalizeTarget` exports can remain as
+compatibility utilities and may back the default runtime behavior, but stricter validation should
+arrive through an explicit opt-in or a clearly documented pre-1.0 minor release with migration
+notes.
+
+## What Core Still Does Not Own
+
+Even with a future stricter boundary, UniAuth should still not own:
+
+- disposable-email policy;
+- mailbox-vendor alias rules;
+- phone country allowlists or business-region policy;
+- SMS vendor parsing quirks;
+- UI formatting and form hints;
+- database migration execution.
+
+Those choices remain application-owned because they depend on product geography, compliance, and
+user-experience requirements.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -115,7 +115,7 @@ Tracking issues: #39.
 ### v0.13 - Production Hardening and Integration Backlog
 
 - Threat model documentation.
-- Production email and phone normalization design.
+- Production email and phone normalization boundary and migration guidance.
 - OTP delivery orchestration boundary documented for queue, retry, and dead-letter adapters without
   moving sender side effects into core.
 - Anti-takeover tests.

--- a/docs/security.md
+++ b/docs/security.md
@@ -119,3 +119,6 @@ risks, see [Threat model](threat-model.md).
 
 See [OTP delivery boundary](otp-delivery.md) for the intended queue/retry/DLQ composition around
 the current sender-port model.
+
+See [Normalization boundary](normalization.md) for the intended compatibility defaults, production
+strictness guidance, and migration cautions around email and phone canonicalization.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -57,7 +57,8 @@ Current coverage:
 Residual risk:
 
 - provider trust assignment is still application-owned;
-- production normalization policy for email and phone is still backlog work under `#29`.
+- the normalization boundary is now documented in [Normalization boundary](normalization.md), but
+  strict validator/canonicalizer rollout is still application-owned or future work.
 
 ### Provider Identity Confusion
 


### PR DESCRIPTION
## Summary
- add a dedicated normalization boundary doc for email and phone policy
- document compatibility defaults, production strictness guidance, and migration cautions
- sync README, architecture, local auth, security, threat model, and roadmap references

Closes #29
