### PR TITLE
feat: add configurable normalization boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,12 @@ import {
   UniAuthError,
   UniAuthErrorCode,
   VerificationPurpose,
+  compatibilityAuthNormalizer,
+  createAuthNormalizer,
   createDefaultAuthPolicy,
   createHmacSecretHasher,
   isUniAuthError,
+  type AuthNormalizer,
   type AuthProvider,
   type AuthService,
   type EmailMagicLink,
@@ -195,6 +198,36 @@ import { mapAuthJsOAuthToAssertion, mapBetterAuthOAuthToAssertion } from '@alyld
 
 There are no root side effects. Importing the package does not register providers, touch storage,
 create sessions, read environment variables, or mutate global state.
+
+Normalization can be shared through one optional runtime boundary:
+
+```ts
+const strictNormalizer: AuthNormalizer = createAuthNormalizer({
+  normalizeEmail(email) {
+    const normalized = compatibilityAuthNormalizer.normalizeEmail(email)
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(normalized)) {
+      throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Email is invalid.')
+    }
+
+    return normalized
+  },
+  normalizePhone(phone) {
+    const digits = phone.replace(/\D+/g, '')
+    const normalized = digits.length === 10 ? `+1${digits}` : `+${digits}`
+
+    if (!/^\+[1-9]\d{7,14}$/u.test(normalized)) {
+      throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Phone is invalid.')
+    }
+
+    return normalized
+  },
+})
+
+const { service } = createInMemoryAuthKit({
+  normalizer: strictNormalizer,
+})
+```
 
 The service contract is policy-driven:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,8 +77,8 @@ headers.
 
 The built-in `normalizeEmail`, `normalizePhone`, and `normalizeTarget` helpers are compatibility
 utilities, not a full production canonicalization policy. If an application needs strict email
-validation or E.164 phone handling, it should apply one shared policy across provider assertions,
-OTP, magic link, password, and repository lookup paths instead of normalizing each flow
+validation or E.164 phone handling, it should pass one shared `normalizer` boundary across provider
+assertions, OTP, magic link, password, and repository lookup paths instead of normalizing each flow
 independently. See [Normalization boundary](normalization.md).
 
 Messenger WebApp providers are reference `AuthProvider` factories, not SDK integrations. They

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -123,8 +123,9 @@ headers, retry-after formatting, and abuse analytics remain application or adapt
 ## Production Boundaries
 
 Current local auth hardening does not try to solve every production edge. The OTP delivery boundary
-is documented in [OTP delivery boundary](otp-delivery.md), and production normalization policy is
-documented in [Normalization boundary](normalization.md).
+is documented in [OTP delivery boundary](otp-delivery.md), and production normalization policy can
+be wired through the shared `normalizer` runtime option documented in
+[Normalization boundary](normalization.md).
 
 For storage and security invariants, see [Architecture](architecture.md) and
 [Security model](security.md).

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -26,8 +26,62 @@ Production-grade validation and canonicalization should follow these rules:
 - region-specific phone parsing must be explicit and application-owned or future-adapter-owned;
 - no mandatory phone metadata dependency should be added to the core package.
 
-If UniAuth later grows configurable strict normalization, it should be introduced as one shared
-runtime boundary, not as separate ad hoc flags for each auth flow.
+Configurable strict normalization should stay on one shared runtime boundary, not split into ad hoc
+flags for each auth flow.
+
+## Runtime API
+
+UniAuth now exposes one optional runtime-level normalization boundary through the `normalizer`
+service option.
+
+The boundary shape is:
+
+- `normalizeEmail(email)`
+- `normalizePhone(phone)`
+- `normalizeTarget(target)`
+
+The default runtime uses `compatibilityAuthNormalizer`, which preserves the historical lightweight
+behavior. Applications can pass a stricter shared normalizer to `DefaultAuthService` or
+`createInMemoryAuthKit`.
+
+```ts
+import {
+  UniAuthError,
+  UniAuthErrorCode,
+  compatibilityAuthNormalizer,
+  createAuthNormalizer,
+} from '@alyldas/uniauth'
+import { createInMemoryAuthKit } from '@alyldas/uniauth/testing'
+
+const strictNormalizer = createAuthNormalizer({
+  normalizeEmail(email) {
+    const normalized = compatibilityAuthNormalizer.normalizeEmail(email)
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(normalized)) {
+      throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Email is invalid.')
+    }
+
+    return normalized
+  },
+  normalizePhone(phone) {
+    const digits = phone.replace(/\D+/g, '')
+    const normalized = digits.length === 10 ? `+1${digits}` : `+${digits}`
+
+    if (!/^\+[1-9]\d{7,14}$/u.test(normalized)) {
+      throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Phone is invalid.')
+    }
+
+    return normalized
+  },
+})
+
+const { service } = createInMemoryAuthKit({
+  normalizer: strictNormalizer,
+})
+```
+
+The important part is not the regex itself. The important part is that OTP, magic link, password,
+verification, and provider-assertion paths all use the same configured normalizer object.
 
 ## Current Compatibility Mode
 
@@ -174,7 +228,8 @@ updating all persisted data and all lookup paths consistently.
 
 ## Future Core Integration
 
-If UniAuth later exposes configurable normalization, it should follow these constraints:
+The runtime-level normalization boundary now exists. Future tightening should still follow these
+constraints:
 
 - one shared runtime-level boundary for email and phone normalization;
 - used by OTP, magic link, password, verification, and provider-assertion orchestration paths;

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -57,8 +57,9 @@ Current coverage:
 Residual risk:
 
 - provider trust assignment is still application-owned;
-- the normalization boundary is now documented in [Normalization boundary](normalization.md), but
-  strict validator/canonicalizer rollout is still application-owned or future work.
+- the shared normalization boundary is now available and documented in
+  [Normalization boundary](normalization.md), but strict validator choice, phone-region policy, and
+  migration rollout are still application-owned.
 
 ### Provider Identity Confusion
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -49,10 +49,12 @@ describe('package exports', () => {
       core.isUniAuthError(new core.UniAuthError(core.UniAuthErrorCode.InvalidInput, 'x')),
     ).toBe(true)
     expect(core.createDefaultAuthPolicy).toBeTypeOf('function')
+    expect(core.createAuthNormalizer).toBeTypeOf('function')
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createMaxWebAppProvider).toBeTypeOf('function')
     expect(core.createOAuthOidcProvider).toBeTypeOf('function')
     expect(core.createTelegramMiniAppProvider).toBeTypeOf('function')
+    expect(core.compatibilityAuthNormalizer).toBeTypeOf('object')
     expect(core.mapOAuthOidcProfileToAssertion).toBeTypeOf('function')
     expect(core.validateSignedWebAppInitData).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')

--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -15,7 +15,6 @@ import {
 } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
 import { RateLimitAction } from '../ports.js'
-import { normalizeEmail } from '../utils/normalization.js'
 import { generateSecret } from '../utils/secrets.js'
 
 const DEFAULT_EMAIL_MAGIC_LINK_SUBJECT = 'Your sign-in link'
@@ -25,7 +24,7 @@ export async function startEmailMagicLinkSignIn(
   input: StartEmailMagicLinkSignInInput,
 ): Promise<StartEmailMagicLinkSignInResult> {
   const now = input.now ?? runtime.clock.now()
-  const email = normalizeEmail(input.email)
+  const email = runtime.normalizer.normalizeEmail(input.email)
 
   if (!email) {
     throw invalidInput('Email is required.')
@@ -104,7 +103,7 @@ export async function finishEmailMagicLinkSignIn(
 
     return signInWithAssertion(
       runtime,
-      normalizeAssertion({
+      normalizeAssertion(runtime, {
         provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
         providerUserId: consumed.target,
         email: consumed.target,

--- a/src/application/otp-delivery.ts
+++ b/src/application/otp-delivery.ts
@@ -7,7 +7,6 @@ import {
   type OtpChannel as OtpChannelType,
 } from '../domain/types.js'
 import { invalidInput } from '../errors.js'
-import { normalizeEmail, normalizePhone, normalizeTarget } from '../utils/normalization.js'
 
 const DEFAULT_EMAIL_OTP_SUBJECT = 'Your sign-in code'
 const DEFAULT_SMS_OTP_PREFIX = 'Your sign-in code is'
@@ -19,13 +18,17 @@ export interface OtpDelivery {
   send(created: CreateVerificationResult): Promise<void>
 }
 
-export function normalizeOtpTarget(channel: OtpChannelType, target: string): string {
+export function normalizeOtpTarget(
+  runtime: Pick<AuthServiceRuntime, 'normalizer'>,
+  channel: OtpChannelType,
+  target: string,
+): string {
   const normalized =
     channel === OtpChannel.Email
-      ? normalizeEmail(target)
+      ? runtime.normalizer.normalizeEmail(target)
       : channel === OtpChannel.Phone
-        ? normalizePhone(target)
-        : normalizeTarget(target)
+        ? runtime.normalizer.normalizePhone(target)
+        : runtime.normalizer.normalizeTarget(target)
 
   if (normalized) {
     return normalized

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -33,7 +33,7 @@ export async function startOtpChallenge(
   input: StartOtpChallengeInput,
 ): Promise<StartOtpChallengeResult> {
   const now = input.now ?? runtime.clock.now()
-  const target = normalizeOtpTarget(input.channel, input.target)
+  const target = normalizeOtpTarget(runtime, input.channel, input.target)
   const delivery = getOtpDelivery(runtime, input.channel)
   await enforceRateLimit(runtime, {
     action: RateLimitAction.OtpStart,
@@ -130,7 +130,7 @@ export async function finishOtpSignIn(
 
     return signInWithAssertion(
       runtime,
-      assertionFromOtpVerification(verification, currentChallenge.channel),
+      assertionFromOtpVerification(runtime, verification, currentChallenge.channel),
       {
         now,
         ...optionalProp('sessionExpiresAt', input.sessionExpiresAt),
@@ -227,11 +227,12 @@ function otpChannelFromVerification(verification: Verification): SupportedOtpCha
 }
 
 function assertionFromOtpVerification(
+  runtime: AuthServiceRuntime,
   verification: Verification,
   channel: SupportedOtpChannel,
 ): ProviderIdentityAssertion {
   if (channel === OtpChannel.Email) {
-    return normalizeAssertion({
+    return normalizeAssertion(runtime, {
       provider: EMAIL_OTP_PROVIDER_ID,
       providerUserId: verification.target,
       email: verification.target,
@@ -239,7 +240,7 @@ function assertionFromOtpVerification(
     })
   }
 
-  return normalizeAssertion({
+  return normalizeAssertion(runtime, {
     provider: PHONE_OTP_PROVIDER_ID,
     providerUserId: verification.target,
     phone: verification.target,

--- a/src/application/passwords.ts
+++ b/src/application/passwords.ts
@@ -32,7 +32,6 @@ import {
 } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidCredentials, invalidInput } from '../errors.js'
 import { RateLimitAction, type PasswordHasher } from '../ports.js'
-import { normalizeEmail } from '../utils/normalization.js'
 import { generateSecret } from '../utils/secrets.js'
 
 const DEFAULT_PASSWORD_RECOVERY_SUBJECT = 'Reset your password'
@@ -45,7 +44,7 @@ export async function signInWithPassword(
   input: SignInWithPasswordInput,
 ): Promise<AuthResult> {
   const now = input.now ?? runtime.clock.now()
-  const email = normalizePasswordEmail(input.email)
+  const email = normalizePasswordEmail(runtime, input.email)
   assertPassword(input.password)
   const passwordHasher = getPasswordHasher(runtime)
 
@@ -97,7 +96,7 @@ export async function setPassword(
     const user = await getActiveUser(runtime, input.userId)
     await ensureReAuth(runtime, AuthPolicyAction.SetPassword, user.id, input.reAuthenticatedAt, now)
 
-    const email = normalizePasswordEmail(input.email)
+    const email = normalizePasswordEmail(runtime, input.email)
     assertPassword(input.password)
     const passwordHasher = getPasswordHasher(runtime)
     const existingForEmail = await runtime.repos.credentialRepo.findPasswordByEmail(email)
@@ -177,7 +176,7 @@ export async function startEmailPasswordRecovery(
   input: StartEmailPasswordRecoveryInput,
 ): Promise<StartEmailPasswordRecoveryResult> {
   const now = input.now ?? runtime.clock.now()
-  const email = normalizePasswordEmail(input.email)
+  const email = normalizePasswordEmail(runtime, input.email)
 
   if (!runtime.emailSender) {
     throw invalidInput('Email sender is required for password recovery.')
@@ -264,8 +263,11 @@ export async function finishEmailPasswordRecovery(
   })
 }
 
-function normalizePasswordEmail(email: string): string {
-  const normalized = normalizeEmail(email)
+function normalizePasswordEmail(
+  runtime: Pick<AuthServiceRuntime, 'normalizer'>,
+  email: string,
+): string {
+  const normalized = runtime.normalizer.normalizeEmail(email)
 
   if (!normalized) {
     throw invalidInput('Email is required.')

--- a/src/application/runtime.ts
+++ b/src/application/runtime.ts
@@ -10,6 +10,7 @@ import type {
   UnitOfWork,
 } from '../ports.js'
 import { createRandomIdGenerator } from '../utils/ids.js'
+import { compatibilityAuthNormalizer, type AuthNormalizer } from '../utils/normalization.js'
 import { sha256SecretHasher, type SecretHasher } from '../utils/secrets.js'
 import { systemClock } from '../utils/time.js'
 
@@ -26,6 +27,7 @@ export interface AuthServiceRuntime extends AuthServiceInfrastructure {
   readonly providerRegistry: ProviderRegistry | undefined
   readonly transaction: UnitOfWork
   readonly idGenerator: IdGenerator
+  readonly normalizer: AuthNormalizer
   readonly secretHasher: SecretHasher
   readonly clock: Clock
   readonly sessionTtlSeconds: number
@@ -46,6 +48,7 @@ export function createAuthServiceRuntime(options: DefaultAuthServiceOptions): Au
     providerRegistry: options.providerRegistry,
     transaction: options.transaction ?? immediateUnitOfWork,
     idGenerator: options.idGenerator ?? createRandomIdGenerator(),
+    normalizer: options.normalizer ?? compatibilityAuthNormalizer,
     secretHasher: options.secretHasher ?? sha256SecretHasher,
     clock: options.clock ?? systemClock,
     sessionTtlSeconds: options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS,

--- a/src/application/sign-in.ts
+++ b/src/application/sign-in.ts
@@ -23,7 +23,6 @@ import {
 } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
 import { RateLimitAction } from '../ports.js'
-import { normalizeEmail, normalizePhone } from '../utils/normalization.js'
 
 const SignInAuditMode = {
   Exact: 'exact',
@@ -168,7 +167,7 @@ export async function resolveAssertion(
   },
 ): Promise<ProviderIdentityAssertion> {
   if (input.assertion) {
-    return normalizeAssertion(input.assertion)
+    return normalizeAssertion(runtime, input.assertion)
   }
 
   if (!input.provider || !input.finishInput) {
@@ -185,10 +184,11 @@ export async function resolveAssertion(
     throw new UniAuthError(UniAuthErrorCode.ProviderNotFound, 'Auth provider was not found.')
   }
 
-  return normalizeAssertion(await provider.finish(input.finishInput))
+  return normalizeAssertion(runtime, await provider.finish(input.finishInput))
 }
 
 export function normalizeAssertion(
+  runtime: Pick<AuthServiceRuntime, 'normalizer'>,
   assertion: Partial<ProviderIdentityAssertion>,
 ): ProviderIdentityAssertion {
   const provider = assertion.provider?.trim() ?? ''
@@ -198,8 +198,8 @@ export function normalizeAssertion(
     throw invalidInput('Provider and provider user id are required.')
   }
 
-  const email = assertion.email ? normalizeEmail(assertion.email) : undefined
-  const phone = assertion.phone ? normalizePhone(assertion.phone) : undefined
+  const email = assertion.email ? runtime.normalizer.normalizeEmail(assertion.email) : undefined
+  const phone = assertion.phone ? runtime.normalizer.normalizePhone(assertion.phone) : undefined
   const displayName = assertion.displayName?.trim() || undefined
 
   return {

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -12,7 +12,6 @@ import {
   type Verification,
 } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
-import { normalizeTarget } from '../utils/normalization.js'
 import { generateSecret } from '../utils/secrets.js'
 import { addSeconds } from '../utils/time.js'
 
@@ -46,7 +45,7 @@ export async function createVerificationRecord(
   input: CreateVerificationRecordInput,
 ): Promise<CreateVerificationResult> {
   const secret = input.secret ?? generateSecret()
-  const target = normalizeTarget(input.target)
+  const target = runtime.normalizer.normalizeTarget(input.target)
 
   if (!target) {
     throw invalidInput('Verification target is required.')

--- a/src/ports.ts
+++ b/src/ports.ts
@@ -16,6 +16,7 @@ import type {
   VerificationId,
   VerificationPurpose,
 } from './domain/types.js'
+import type { AuthNormalizer } from './utils/normalization.js'
 import type { SecretHasher } from './utils/secrets.js'
 
 export const RateLimitAction = {
@@ -140,6 +141,7 @@ export interface SmsSender {
 export interface AuthServiceInfrastructure {
   readonly emailSender?: EmailSender
   readonly smsSender?: SmsSender
+  readonly normalizer?: AuthNormalizer
   readonly secretHasher?: SecretHasher
   readonly rateLimiter?: RateLimiter
   readonly otpSecretLength?: number

--- a/src/testing/in-memory/kit.ts
+++ b/src/testing/in-memory/kit.ts
@@ -8,6 +8,7 @@ import type { AuthPolicy } from '../../application/policy.js'
 import type { Clock, IdGenerator } from '../../domain/types.js'
 import type { OtpSecretGenerator, PasswordHasher, RateLimiter } from '../../ports.js'
 import { createSequentialIdGenerator } from '../../utils/ids.js'
+import type { AuthNormalizer } from '../../utils/normalization.js'
 import type { SecretHasher } from '../../utils/secrets.js'
 import { InMemoryProviderRegistry } from '../providers.js'
 import { InMemoryEmailSender, InMemorySmsSender } from './senders.js'
@@ -18,6 +19,7 @@ export interface CreateInMemoryAuthKitOptions {
   readonly policy?: AuthPolicy
   readonly clock?: Clock
   readonly idGenerator?: IdGenerator
+  readonly normalizer?: AuthNormalizer
   readonly secretHasher?: SecretHasher
   readonly rateLimiter?: RateLimiter
   readonly otpSecretLength?: number
@@ -42,7 +44,9 @@ interface InMemoryAuthKitResult {
 export function createInMemoryAuthKit(
   options: CreateInMemoryAuthKitOptions = {},
 ): InMemoryAuthKitResult {
-  const store = new InMemoryAuthStore()
+  const store = new InMemoryAuthStore({
+    ...optionalProp('normalizer', options.normalizer),
+  })
   const providerRegistry = new InMemoryProviderRegistry()
   const emailSender = new InMemoryEmailSender()
   const smsSender = new InMemorySmsSender()
@@ -58,6 +62,7 @@ export function createInMemoryAuthKit(
     providerRegistry,
     transaction: store,
     idGenerator,
+    ...optionalProp('normalizer', options.normalizer),
     ...optionalProp('secretHasher', options.secretHasher),
     ...optionalProp('policy', options.policy),
     ...optionalProp('clock', options.clock),

--- a/src/testing/in-memory/store.ts
+++ b/src/testing/in-memory/store.ts
@@ -20,7 +20,7 @@ import type {
   UserRepo,
   VerificationRepo,
 } from '../../ports.js'
-import { normalizeEmail, normalizePhone } from '../../utils/normalization.js'
+import { compatibilityAuthNormalizer, type AuthNormalizer } from '../../utils/normalization.js'
 
 interface StoreSnapshot {
   readonly users: Map<User['id'], User>
@@ -34,6 +34,10 @@ interface StoreSnapshot {
   readonly auditEvents: AuditEvent[]
 }
 
+export interface InMemoryAuthStoreOptions {
+  readonly normalizer?: AuthNormalizer
+}
+
 export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   private readonly users = new Map<User['id'], User>()
   private readonly identities = new Map<AuthIdentity['id'], AuthIdentity>()
@@ -45,6 +49,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   private readonly sessions = new Map<Session['id'], Session>()
   private readonly auditEvents: AuditEvent[] = []
   private transactionDepth = 0
+
+  constructor(private readonly options: InMemoryAuthStoreOptions = {}) {}
 
   readonly userRepo: UserRepo = {
     findById: async (id) => this.users.get(id),
@@ -72,7 +78,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       return id ? this.identities.get(id) : undefined
     },
     findByVerifiedEmail: async (email) => {
-      const normalizedEmail = normalizeEmail(email)
+      const normalizedEmail = this.normalizer.normalizeEmail(email)
       return [...this.identities.values()].filter(
         (identity) =>
           identity.status === AuthIdentityStatus.Active &&
@@ -81,7 +87,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       )
     },
     findByVerifiedPhone: async (phone) => {
-      const normalizedPhone = normalizePhone(phone)
+      const normalizedPhone = this.normalizer.normalizePhone(phone)
       return [...this.identities.values()].filter(
         (identity) =>
           identity.status === AuthIdentityStatus.Active &&
@@ -128,7 +134,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   readonly credentialRepo: CredentialRepo = {
     findPasswordByEmail: async (email) => {
       const id = this.credentialKeys.get(
-        this.credentialKey(CredentialType.Password, normalizeEmail(email)),
+        this.credentialKey(CredentialType.Password, this.normalizer.normalizeEmail(email)),
       )
       return id ? this.credentials.get(id) : undefined
     },
@@ -280,6 +286,10 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
   private identityKey(provider: AuthIdentityProvider, providerUserId: string): string {
     return `${provider}\u0000${providerUserId}`
+  }
+
+  private get normalizer(): AuthNormalizer {
+    return this.options.normalizer ?? compatibilityAuthNormalizer
   }
 
   private credentialKey(type: Credential['type'], subject: string): string {

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -1,3 +1,22 @@
+export interface AuthNormalizer {
+  normalizeEmail(email: string): string
+  normalizePhone(phone: string): string
+  normalizeTarget(target: string): string
+}
+
+export type AuthValueNormalizer = (value: string) => string
+
+export type AuthTargetNormalizer = (
+  target: string,
+  helpers: Pick<AuthNormalizer, 'normalizeEmail' | 'normalizePhone'>,
+) => string
+
+export interface CreateAuthNormalizerOptions {
+  readonly normalizeEmail?: AuthValueNormalizer
+  readonly normalizePhone?: AuthValueNormalizer
+  readonly normalizeTarget?: AuthTargetNormalizer
+}
+
 export function normalizeEmail(email: string): string {
   return email.trim().toLowerCase()
 }
@@ -7,11 +26,37 @@ export function normalizePhone(phone: string): string {
 }
 
 export function normalizeTarget(target: string): string {
+  return defaultNormalizeTarget(target, {
+    normalizeEmail,
+    normalizePhone,
+  })
+}
+
+export function createAuthNormalizer(options: CreateAuthNormalizerOptions = {}): AuthNormalizer {
+  const helpers = {
+    normalizeEmail: options.normalizeEmail ?? normalizeEmail,
+    normalizePhone: options.normalizePhone ?? normalizePhone,
+  }
+  const normalizeTargetHandler = options.normalizeTarget ?? defaultNormalizeTarget
+
+  return {
+    normalizeEmail: helpers.normalizeEmail,
+    normalizePhone: helpers.normalizePhone,
+    normalizeTarget: (target) => normalizeTargetHandler(target, helpers),
+  }
+}
+
+export const compatibilityAuthNormalizer = createAuthNormalizer()
+
+function defaultNormalizeTarget(
+  target: string,
+  helpers: Pick<AuthNormalizer, 'normalizeEmail' | 'normalizePhone'>,
+): string {
   const trimmed = target.trim()
 
   if (trimmed.includes('@')) {
-    return normalizeEmail(trimmed)
+    return helpers.normalizeEmail(trimmed)
   }
 
-  return normalizePhone(trimmed)
+  return helpers.normalizePhone(trimmed)
 }

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -6,6 +6,8 @@ import {
   addSeconds,
   asAuditEventId,
   asCredentialId,
+  compatibilityAuthNormalizer,
+  createAuthNormalizer,
   asIdentityId,
   asSessionId,
   asUserId,
@@ -59,6 +61,25 @@ describe('public utility coverage', () => {
     expect(normalizePhone(' +1 (555) 123-4567 ')).toBe('+15551234567')
     expect(normalizeTarget(' Alice@Example.COM ')).toBe('alice@example.com')
     expect(normalizeTarget(' +1 (555) 123-4567 ')).toBe('+15551234567')
+    expect(compatibilityAuthNormalizer.normalizeEmail(' Alice@Example.COM ')).toBe(
+      'alice@example.com',
+    )
+    expect(
+      createAuthNormalizer({
+        normalizeEmail: (email) => email.trim().toUpperCase(),
+        normalizePhone: (phone) => phone.replace(/\s+/g, '').trim(),
+        normalizeTarget: (target, helpers) =>
+          target.includes('@')
+            ? helpers.normalizeEmail(target)
+            : `tel:${helpers.normalizePhone(target)}`,
+      }).normalizeTarget(' 1 2 3 '),
+    ).toBe('tel:123')
+    expect(
+      createAuthNormalizer({
+        normalizeEmail: (email) => email.trim().toUpperCase(),
+        normalizePhone: (phone) => phone.replace(/\s+/g, '').trim(),
+      }).normalizeTarget(' Alice@Example.COM '),
+    ).toBe('ALICE@EXAMPLE.COM')
 
     const generatedSecret = generateSecret(8)
     const generatedOtpSecret = generateOtpSecret()

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,12 +2,19 @@ import {
   AuthIdentityStatus,
   asIdentityId,
   asUserId,
+  createAuthNormalizer,
+  invalidInput,
+  normalizeEmail,
+  type AuthNormalizer,
   type AuthIdentity,
   type ProviderIdentityAssertion,
   type User,
 } from '../src'
 
 export const now = new Date('2026-01-01T00:00:00.000Z')
+
+const strictEmailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u
+const strictE164Pattern = /^\+[1-9]\d{7,14}$/u
 
 export function assertion(
   input: Partial<ProviderIdentityAssertion> = {},
@@ -27,6 +34,37 @@ export function assertion(
 
 export function rateLimitKey(...parts: readonly string[]): string {
   return parts.join('\u0000')
+}
+
+export function createStrictNormalizer(): AuthNormalizer {
+  return createAuthNormalizer({
+    normalizeEmail(email) {
+      const normalized = normalizeEmail(email)
+
+      if (!normalized || !strictEmailPattern.test(normalized)) {
+        throw invalidInput('Email is invalid.')
+      }
+
+      return normalized
+    },
+    normalizePhone(phone) {
+      const trimmed = phone.trim()
+      const digits = trimmed.replace(/\D+/g, '')
+      const normalized = trimmed.startsWith('+')
+        ? `+${digits}`
+        : digits.length === 10
+          ? `+1${digits}`
+          : digits.length === 11 && digits.startsWith('1')
+            ? `+${digits}`
+            : ''
+
+      if (!strictE164Pattern.test(normalized)) {
+        throw invalidInput('Phone is invalid.')
+      }
+
+      return normalized
+    },
+  })
 }
 
 export function user(id = 'user-1'): User {

--- a/test/normalization.test.ts
+++ b/test/normalization.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { OtpChannel, UniAuthErrorCode, VerificationPurpose, createDefaultAuthPolicy } from '../src'
+import { createInMemoryAuthKit } from '../src/testing'
+import { assertion, createStrictNormalizer, now } from './helpers.js'
+
+describe('shared normalization boundary', () => {
+  it('uses one configured normalizer across provider assertions and repository lookups', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service, store } = createInMemoryAuthKit({
+      normalizer,
+      policy: createDefaultAuthPolicy({ allowAutoLink: true }),
+    })
+
+    const first = await service.signIn({
+      assertion: assertion({
+        provider: 'phone-first',
+        providerUserId: 'phone-first-user',
+        phone: '+1 (555) 123-4567',
+        phoneVerified: true,
+      }),
+      now,
+    })
+    const linked = await service.signIn({
+      assertion: assertion({
+        provider: 'oidc',
+        providerUserId: 'oidc-user',
+        phone: '5551234567',
+        phoneVerified: true,
+      }),
+      now,
+    })
+
+    expect(linked.user.id).toBe(first.user.id)
+    expect(linked.isNewUser).toBe(false)
+    expect(linked.isNewIdentity).toBe(true)
+    expect(linked.identity.phone).toBe('+15551234567')
+    await expect(store.identityRepo.findByVerifiedPhone('5551234567')).resolves.toHaveLength(2)
+  })
+
+  it('rejects invalid email before magic link and password side effects', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service, store, emailSender } = createInMemoryAuthKit({ normalizer })
+
+    await expect(
+      service.startEmailMagicLinkSignIn({
+        email: 'invalid-email',
+        createLink: ({ verificationId, secret }) =>
+          `/auth/magic?verification=${verificationId}&token=${secret}`,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is invalid.',
+    })
+    expect(store.listVerifications()).toHaveLength(0)
+    expect(emailSender.listMessages()).toHaveLength(0)
+
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'valid-owner',
+        email: 'owner@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.setPassword({
+        userId: signedIn.user.id,
+        email: 'bad',
+        password: 'new-password',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is invalid.',
+    })
+    await expect(
+      service.signInWithPassword({
+        email: 'bad',
+        password: 'new-password',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is invalid.',
+    })
+    expect(store.listCredentials()).toHaveLength(0)
+  })
+
+  it('rejects invalid phone and generic verification targets before persistence or delivery', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service, store, smsSender } = createInMemoryAuthKit({ normalizer })
+
+    await expect(
+      service.startOtpChallenge({
+        purpose: VerificationPurpose.SignIn,
+        channel: OtpChannel.Phone,
+        target: '123',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Phone is invalid.',
+    })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.Link,
+        target: 'invalid@',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is invalid.',
+    })
+
+    expect(store.listVerifications()).toHaveLength(0)
+    expect(smsSender.listMessages()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add one shared runtime-level auth normalizer with compatibility defaults
- route provider assertions, OTP, magic link, password, verification, and testing-kit lookups through the configured normalization boundary
- add strict-normalizer coverage and document runtime wiring for production normalization policy

Closes #73
