### PR TITLE
fix: restore normalization boundary semantics

### DIFF
--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -24,7 +24,13 @@ export async function startEmailMagicLinkSignIn(
   input: StartEmailMagicLinkSignInInput,
 ): Promise<StartEmailMagicLinkSignInResult> {
   const now = input.now ?? runtime.clock.now()
-  const email = runtime.normalizer.normalizeEmail(input.email)
+  const trimmedEmail = input.email.trim()
+
+  if (!trimmedEmail) {
+    throw invalidInput('Email is required.')
+  }
+
+  const email = runtime.normalizer.normalizeEmail(trimmedEmail)
 
   if (!email) {
     throw invalidInput('Email is required.')

--- a/src/application/otp-delivery.ts
+++ b/src/application/otp-delivery.ts
@@ -23,12 +23,26 @@ export function normalizeOtpTarget(
   channel: OtpChannelType,
   target: string,
 ): string {
+  const trimmed = target.trim()
+
+  if (!trimmed) {
+    if (channel === OtpChannel.Email) {
+      throw invalidInput('Email is required.')
+    }
+
+    if (channel === OtpChannel.Phone) {
+      throw invalidInput('Phone is required.')
+    }
+
+    throw invalidInput('OTP target is required.')
+  }
+
   const normalized =
     channel === OtpChannel.Email
-      ? runtime.normalizer.normalizeEmail(target)
+      ? runtime.normalizer.normalizeEmail(trimmed)
       : channel === OtpChannel.Phone
-        ? runtime.normalizer.normalizePhone(target)
-        : runtime.normalizer.normalizeTarget(target)
+        ? runtime.normalizer.normalizePhone(trimmed)
+        : runtime.normalizer.normalizeTarget(trimmed)
 
   if (normalized) {
     return normalized

--- a/src/application/passwords.ts
+++ b/src/application/passwords.ts
@@ -267,7 +267,13 @@ function normalizePasswordEmail(
   runtime: Pick<AuthServiceRuntime, 'normalizer'>,
   email: string,
 ): string {
-  const normalized = runtime.normalizer.normalizeEmail(email)
+  const trimmed = email.trim()
+
+  if (!trimmed) {
+    throw invalidInput('Email is required.')
+  }
+
+  const normalized = runtime.normalizer.normalizeEmail(trimmed)
 
   if (!normalized) {
     throw invalidInput('Email is required.')

--- a/src/application/sign-in.ts
+++ b/src/application/sign-in.ts
@@ -198,8 +198,8 @@ export function normalizeAssertion(
     throw invalidInput('Provider and provider user id are required.')
   }
 
-  const email = assertion.email ? runtime.normalizer.normalizeEmail(assertion.email) : undefined
-  const phone = assertion.phone ? runtime.normalizer.normalizePhone(assertion.phone) : undefined
+  const email = normalizeOptionalClaim(assertion.email, runtime.normalizer.normalizeEmail)
+  const phone = normalizeOptionalClaim(assertion.phone, runtime.normalizer.normalizePhone)
   const displayName = assertion.displayName?.trim() || undefined
 
   return {
@@ -221,6 +221,23 @@ export function normalizeAssertion(
     ...optionalProp('trust', normalizeProviderTrust(assertion.trust)),
     ...optionalProp('metadata', assertion.metadata),
   }
+}
+
+function normalizeOptionalClaim(
+  value: string | undefined,
+  normalize: (value: string) => string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return undefined
+  }
+
+  return normalize(trimmed)
 }
 
 function normalizeProviderTrust(

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -45,7 +45,13 @@ export async function createVerificationRecord(
   input: CreateVerificationRecordInput,
 ): Promise<CreateVerificationResult> {
   const secret = input.secret ?? generateSecret()
-  const target = runtime.normalizer.normalizeTarget(input.target)
+  const trimmedTarget = input.target.trim()
+
+  if (!trimmedTarget) {
+    throw invalidInput('Verification target is required.')
+  }
+
+  const target = runtime.normalizer.normalizeTarget(trimmedTarget)
 
   if (!target) {
     throw invalidInput('Verification target is required.')

--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -54,9 +54,21 @@ function defaultNormalizeTarget(
 ): string {
   const trimmed = target.trim()
 
+  if (!trimmed) {
+    return ''
+  }
+
   if (trimmed.includes('@')) {
     return helpers.normalizeEmail(trimmed)
   }
 
-  return helpers.normalizePhone(trimmed)
+  if (isPhoneLikeTarget(trimmed)) {
+    return helpers.normalizePhone(trimmed)
+  }
+
+  return trimmed
+}
+
+function isPhoneLikeTarget(target: string): boolean {
+  return /[0-9]/u.test(target) && /^[+\d\s().-]+$/u.test(target)
 }

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -61,6 +61,8 @@ describe('public utility coverage', () => {
     expect(normalizePhone(' +1 (555) 123-4567 ')).toBe('+15551234567')
     expect(normalizeTarget(' Alice@Example.COM ')).toBe('alice@example.com')
     expect(normalizeTarget(' +1 (555) 123-4567 ')).toBe('+15551234567')
+    expect(normalizeTarget(' opaque-token ')).toBe('opaque-token')
+    expect(normalizeTarget('   ')).toBe('')
     expect(compatibilityAuthNormalizer.normalizeEmail(' Alice@Example.COM ')).toBe(
       'alice@example.com',
     )

--- a/test/normalization.test.ts
+++ b/test/normalization.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { OtpChannel, UniAuthErrorCode, VerificationPurpose, createDefaultAuthPolicy } from '../src'
+import {
+  OtpChannel,
+  UniAuthErrorCode,
+  VerificationPurpose,
+  createAuthNormalizer,
+  createDefaultAuthPolicy,
+} from '../src'
+import { normalizeOtpTarget } from '../src/application/otp-delivery.js'
 import { createInMemoryAuthKit } from '../src/testing'
 import { assertion, createStrictNormalizer, now } from './helpers.js'
 
@@ -89,7 +96,150 @@ describe('shared normalization boundary', () => {
     expect(store.listCredentials()).toHaveLength(0)
   })
 
-  it('rejects invalid phone and generic verification targets before persistence or delivery', async () => {
+  it('treats blank optional provider claims as absent with a strict normalizer', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service } = createInMemoryAuthKit({ normalizer })
+
+    const blankProfile = await service.signIn({
+      assertion: {
+        provider: 'oauth',
+        providerUserId: 'blank-profile',
+        email: '   ',
+        emailVerified: true,
+        phone: '   ',
+        phoneVerified: true,
+        displayName: '   ',
+      },
+      now,
+    })
+
+    expect(blankProfile.user.email).toBeUndefined()
+    expect(blankProfile.user.phone).toBeUndefined()
+    expect(blankProfile.user.displayName).toBeUndefined()
+    expect(blankProfile.identity.email).toBeUndefined()
+    expect(blankProfile.identity.phone).toBeUndefined()
+  })
+
+  it('preserves required-input errors before strict normalization runs', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service, store, emailSender, smsSender } = createInMemoryAuthKit({ normalizer })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'owner',
+        email: 'owner@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.startEmailMagicLinkSignIn({
+        email: '   ',
+        createLink: ({ verificationId, secret }) =>
+          `/auth/magic?verification=${verificationId}&token=${secret}`,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is required.',
+    })
+    await expect(
+      service.setPassword({
+        userId: signedIn.user.id,
+        email: '   ',
+        password: 'new-password',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is required.',
+    })
+    await expect(
+      service.startOtpChallenge({
+        purpose: VerificationPurpose.SignIn,
+        channel: OtpChannel.Phone,
+        target: '   ',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Phone is required.',
+    })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.Link,
+        target: '   ',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification target is required.',
+    })
+
+    expect(store.listVerifications()).toHaveLength(0)
+    expect(emailSender.listMessages()).toHaveLength(0)
+    expect(smsSender.listMessages()).toHaveLength(0)
+  })
+
+  it('maps empty normalized values back to required-input errors', async () => {
+    const emptyNormalizer = createAuthNormalizer({
+      normalizeEmail: () => '',
+      normalizePhone: () => '',
+      normalizeTarget: () => '',
+    })
+    const { service } = createInMemoryAuthKit({ normalizer: emptyNormalizer })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'owner',
+        providerUserId: 'owner',
+      }),
+      now,
+    })
+
+    await expect(
+      service.startEmailMagicLinkSignIn({
+        email: 'owner@example.com',
+        createLink: () => '/auth/magic',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is required.',
+    })
+    await expect(
+      service.setPassword({
+        userId: signedIn.user.id,
+        email: 'owner@example.com',
+        password: 'new-password',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Email is required.',
+    })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.Link,
+        target: 'opaque-token',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification target is required.',
+    })
+    expect(() =>
+      normalizeOtpTarget({ normalizer: emptyNormalizer }, OtpChannel.Email, 'owner@example.com'),
+    ).toThrow('Email is required.')
+    expect(() =>
+      normalizeOtpTarget({ normalizer: emptyNormalizer }, OtpChannel.Phone, '+15551234567'),
+    ).toThrow('Phone is required.')
+    expect(() =>
+      normalizeOtpTarget({ normalizer: emptyNormalizer }, 'custom' as never, 'opaque-token'),
+    ).toThrow('OTP target is required.')
+  })
+
+  it('rejects invalid phone and invalid email targets before persistence or delivery', async () => {
     const normalizer = createStrictNormalizer()
     const { service, store, smsSender } = createInMemoryAuthKit({ normalizer })
 
@@ -117,5 +267,20 @@ describe('shared normalization boundary', () => {
 
     expect(store.listVerifications()).toHaveLength(0)
     expect(smsSender.listMessages()).toHaveLength(0)
+  })
+
+  it('keeps opaque verification targets generic under a strict normalizer', async () => {
+    const normalizer = createStrictNormalizer()
+    const { service, store } = createInMemoryAuthKit({ normalizer })
+
+    const created = await service.createVerification({
+      purpose: VerificationPurpose.Link,
+      target: ' opaque-token ',
+      secret: 'opaque-secret',
+      now,
+    })
+
+    expect(created.verification.target).toBe('opaque-token')
+    expect(store.listVerifications()[0]?.target).toBe('opaque-token')
   })
 })


### PR DESCRIPTION
## Summary
- restore generic verification targets under configurable normalizers
- ignore blank optional provider claims before strict normalization runs
- preserve required-input errors for blank local auth inputs and empty normalizer outputs

## Validation
- npm run check
