### PR TITLE
feat: add example applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ contact `alyldas@ya.ru`.
 ## Examples
 
 - [Basic Node example](examples/basic-node/index.ts)
+- [Link and unlink example](examples/link-unlink/index.ts)
+- [Provider finish example](examples/provider-finish/index.ts)
 
 ## Documentation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,8 +133,9 @@ Tracking issues: #28, #29, #43, #44, #73.
 - Backend recipes for Express, Fastify, Nest, and Next.
 - Public domain and service contract source-module decomposition.
 - Password auth use-case decomposition.
+- Additional runnable examples for link/unlink and provider-finish wiring.
 
-Tracking issues: #45, #46, #48.
+Tracking issues: #45, #46, #48, #83.
 
 ## Examples Backlog
 

--- a/examples/link-unlink/index.ts
+++ b/examples/link-unlink/index.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url'
+import { createDefaultAuthPolicy } from '@alyldas/uniauth'
+import { createInMemoryAuthKit } from '@alyldas/uniauth/testing'
+
+export async function runLinkUnlinkExample(): Promise<void> {
+  const { service } = createInMemoryAuthKit({
+    policy: createDefaultAuthPolicy({ allowAutoLink: false }),
+  })
+
+  const primary = await service.signIn({
+    assertion: {
+      provider: 'email',
+      providerUserId: 'alice@example.com',
+      email: 'alice@example.com',
+      emailVerified: true,
+      displayName: 'Alice Example',
+    },
+  })
+  const linked = await service.link({
+    userId: primary.user.id,
+    assertion: {
+      provider: 'github',
+      providerUserId: 'github-alice',
+      email: 'alice@example.com',
+      emailVerified: true,
+    },
+  })
+
+  const beforeUnlink = await service.getUserIdentities(primary.user.id)
+  await service.unlink({
+    userId: primary.user.id,
+    identityId: linked.identity.id,
+  })
+  const afterUnlink = await service.getUserIdentities(primary.user.id)
+
+  console.log({
+    userId: primary.user.id,
+    linkedIdentityId: linked.identity.id,
+    beforeProviders: beforeUnlink.map((identity) => identity.provider),
+    afterProviders: afterUnlink.map((identity) => identity.provider),
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runLinkUnlinkExample()
+}

--- a/examples/provider-finish/index.ts
+++ b/examples/provider-finish/index.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'node:url'
+import { createDefaultAuthPolicy } from '@alyldas/uniauth'
+import { StaticAuthProvider, createInMemoryAuthKit } from '@alyldas/uniauth/testing'
+
+export async function runProviderFinishExample(): Promise<void> {
+  const { providerRegistry, service } = createInMemoryAuthKit({
+    policy: createDefaultAuthPolicy({ allowAutoLink: true }),
+  })
+  const provider = new StaticAuthProvider('oidc-demo', {
+    providerUserId: 'oidc-demo-user',
+    email: 'alice@example.com',
+    emailVerified: true,
+    displayName: 'Alice Example',
+  })
+
+  providerRegistry.register(provider)
+
+  const result = await service.signIn({
+    provider: 'oidc-demo',
+    finishInput: {
+      code: 'demo-code',
+      state: 'demo-state',
+      metadata: { redirectUri: 'https://app.example.test/callback' },
+    },
+  })
+
+  console.log({
+    userId: result.user.id,
+    identityId: result.identity.id,
+    provider: result.identity.provider,
+    providerUserId: result.identity.providerUserId,
+    sessionId: result.session.id,
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runProviderFinishExample()
+}


### PR DESCRIPTION
## Summary
- add runnable link/unlink and provider-finish example applications under `examples/`
- update the README examples section
- track the new example work in the v0.14 roadmap

## Validation
- npm run check

Closes #83
