### PR TITLE
feat: add provider wiring examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,8 @@ contact `alyldas@ya.ru`.
 
 - [Basic Node example](examples/basic-node/index.ts)
 - [Link and unlink example](examples/link-unlink/index.ts)
+- [OTP backend wiring example](examples/otp-backend/index.ts)
+- [OAuth / OIDC wiring example](examples/oauth-oidc/index.ts)
 - [Provider finish example](examples/provider-finish/index.ts)
 
 ## Documentation

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -219,6 +219,14 @@ Recommended shape:
 
 This keeps pool lifecycle, transactions, and migration ownership out of request handlers.
 
+## Repository Examples
+
+The repository keeps small transport-facing examples alongside these framework notes:
+
+- [OTP backend wiring example](../examples/otp-backend/index.ts)
+- [OAuth / OIDC wiring example](../examples/oauth-oidc/index.ts)
+- [Messenger provider wiring notes](messenger-providers.md)
+
 ## Cookie And CSRF Rules
 
 UniAuth does not issue browser cookies or validate CSRF tokens. Treat these as mandatory

--- a/docs/messenger-providers.md
+++ b/docs/messenger-providers.md
@@ -107,6 +107,101 @@ await service.signIn({
 `createMaxWebAppProvider` extracts `WebAppData` when the payload contains that parameter. If the
 payload is already direct `initData`, it validates it as-is.
 
+## Wiring Examples
+
+Messenger providers stay app-owned at bootstrap and transport layers:
+
+- load bot tokens in server-only code;
+- register providers in the same bootstrap where `ProviderRegistry` and `AuthService` are created;
+- pass raw signed `initData` from your HTTP or RPC boundary into `finishInput.payload`;
+- issue browser cookies, redirects, and CSRF/state handling in the application layer after
+  `service.signIn(...)` returns a local session.
+
+### Telegram Mini App Route
+
+```ts
+import { TELEGRAM_MINI_APP_PROVIDER_ID, createTelegramMiniAppProvider } from '@alyldas/uniauth'
+import { authService, providerRegistry } from './auth-bootstrap.js'
+
+providerRegistry.register(
+  createTelegramMiniAppProvider({
+    botToken: process.env.TELEGRAM_BOT_TOKEN!,
+    maxAgeSeconds: 60 * 5,
+  }),
+)
+
+export async function postTelegramMiniAppSignIn(request: Request) {
+  const body = await request.json()
+  const result = await authService.signIn({
+    provider: TELEGRAM_MINI_APP_PROVIDER_ID,
+    finishInput: {
+      payload: {
+        initData: body.initData,
+      },
+    },
+  })
+
+  return {
+    status: 200,
+    sessionCookie: {
+      name: 'session',
+      value: result.session.id,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    },
+    body: {
+      userId: result.user.id,
+    },
+  }
+}
+```
+
+### MAX WebApp Route
+
+```ts
+import { MAX_WEBAPP_PROVIDER_ID, createMaxWebAppProvider } from '@alyldas/uniauth'
+import { authService, providerRegistry } from './auth-bootstrap.js'
+
+providerRegistry.register(
+  createMaxWebAppProvider({
+    botToken: process.env.MAX_BOT_TOKEN!,
+    maxAgeSeconds: 60 * 5,
+  }),
+)
+
+export async function postMaxWebAppSignIn(request: Request) {
+  const body = await request.json()
+  const result = await authService.signIn({
+    provider: MAX_WEBAPP_PROVIDER_ID,
+    finishInput: {
+      payload: {
+        url: body.url,
+      },
+    },
+  })
+
+  return {
+    status: 200,
+    sessionCookie: {
+      name: 'session',
+      value: result.session.id,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    },
+    body: {
+      userId: result.user.id,
+    },
+  }
+}
+```
+
+For framework-specific cookie, CSRF, and redirect handling around these providers, see
+[Backend integration recipes](backend-recipes.md).
+
 ## Security Notes
 
 - Keep bot tokens in application bootstrap code. UniAuth never reads environment variables itself.

--- a/docs/oauth-oidc.md
+++ b/docs/oauth-oidc.md
@@ -85,6 +85,10 @@ await service.signIn({
 })
 ```
 
+See the runnable [OAuth / OIDC wiring example](../examples/oauth-oidc/index.ts) for a small
+callback-shaped transport example that keeps state, PKCE verifier storage, redirect URI handling,
+and session cookie issuance application-owned.
+
 The built-in mapper uses `profile.subject` as `providerUserId`, maps verified email and phone claims,
 and copies only reduced profile metadata such as issuer, preferred username, picture URL, locale, and
 explicit app-provided profile metadata. It does not copy access tokens or ID tokens into assertion

--- a/docs/otp-delivery.md
+++ b/docs/otp-delivery.md
@@ -42,6 +42,10 @@ sequenceDiagram
 The sender can deliver directly or enqueue work. From core's point of view both are the same
 contract: `send(...)` is an app-owned side effect after verification persistence.
 
+For a small HTTP-facing composition example around `startOtpChallenge(...)`,
+`finishOtpSignIn(...)`, app-owned sender wiring, and session-cookie issuance, see
+[OTP backend wiring example](../examples/otp-backend/index.ts).
+
 ## What Core Owns
 
 UniAuth owns only the generic auth semantics:

--- a/examples/oauth-oidc/index.ts
+++ b/examples/oauth-oidc/index.ts
@@ -1,0 +1,203 @@
+import { fileURLToPath } from 'node:url'
+import {
+  DefaultAuthService,
+  createOAuthOidcProvider,
+  type OAuthOidcAuthorizationCodeExchangeInput,
+  type OAuthOidcClient,
+  type OAuthOidcFetchProfileInput,
+} from '@alyldas/uniauth'
+import {
+  InMemoryAuthStore,
+  InMemoryProviderRegistry,
+  InMemoryRateLimiter,
+} from '@alyldas/uniauth/testing'
+
+interface CallbackRequest {
+  readonly query: {
+    readonly code: string
+    readonly state: string
+  }
+  readonly cookies: {
+    readonly oidcState: string
+    readonly oidcCodeVerifier: string
+    readonly oidcRedirectUri: string
+  }
+}
+
+interface SessionCookie {
+  readonly name: 'session'
+  readonly value: string
+  readonly httpOnly: true
+  readonly sameSite: 'lax'
+  readonly secure: true
+  readonly path: '/'
+}
+
+interface ClearedCookie {
+  readonly name: string
+  readonly value: ''
+  readonly maxAge: 0
+  readonly path: '/'
+}
+
+interface RedirectResponse {
+  readonly status: 302
+  readonly location: '/app'
+  readonly body: {
+    readonly userId: string
+    readonly identityId: string
+    readonly provider: string
+  }
+  readonly cookies: readonly [SessionCookie, ClearedCookie, ClearedCookie, ClearedCookie]
+}
+
+class DemoOidcClient implements OAuthOidcClient {
+  private readonly exchangeInputs: OAuthOidcAuthorizationCodeExchangeInput[] = []
+  private readonly profileInputs: OAuthOidcFetchProfileInput[] = []
+
+  async exchangeCode(
+    input: OAuthOidcAuthorizationCodeExchangeInput,
+  ): Promise<{ accessToken: string; tokenType: string; scopes: readonly string[] }> {
+    this.exchangeInputs.push(input)
+
+    return {
+      accessToken: `demo-access-token-for:${input.code}`,
+      tokenType: 'Bearer',
+      scopes: ['openid', 'email', 'profile'],
+    }
+  }
+
+  async fetchProfile(input: OAuthOidcFetchProfileInput): Promise<{
+    subject: string
+    email: string
+    emailVerified: true
+    displayName: string
+    issuer: string
+    preferredUsername: string
+  }> {
+    this.profileInputs.push(input)
+
+    return {
+      subject: 'oidc-user-123',
+      email: 'alice@example.com',
+      emailVerified: true,
+      displayName: 'Alice Example',
+      issuer: 'https://issuer.example.test',
+      preferredUsername: 'alice',
+    }
+  }
+
+  listExchangeInputs(): readonly OAuthOidcAuthorizationCodeExchangeInput[] {
+    return [...this.exchangeInputs]
+  }
+
+  listProfileInputs(): readonly OAuthOidcFetchProfileInput[] {
+    return [...this.profileInputs]
+  }
+}
+
+const store = new InMemoryAuthStore()
+const providerRegistry = new InMemoryProviderRegistry()
+const oidcClient = new DemoOidcClient()
+
+providerRegistry.register(
+  createOAuthOidcProvider({
+    providerId: 'demo-oidc',
+    client: oidcClient,
+  }),
+)
+
+const authService = new DefaultAuthService({
+  repos: store,
+  transaction: store,
+  providerRegistry,
+  rateLimiter: new InMemoryRateLimiter(),
+})
+
+function assertStateMatches(expected: string, received: string): void {
+  if (expected !== received) {
+    throw new Error('OAuth state mismatch.')
+  }
+}
+
+function buildSessionCookie(sessionId: string): SessionCookie {
+  return {
+    name: 'session',
+    value: sessionId,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+  }
+}
+
+function clearCookie(name: string): ClearedCookie {
+  return {
+    name,
+    value: '',
+    maxAge: 0,
+    path: '/',
+  }
+}
+
+async function finishOidcCallback(request: CallbackRequest): Promise<RedirectResponse> {
+  // State, PKCE, and redirect URI storage stay application-owned.
+  assertStateMatches(request.cookies.oidcState, request.query.state)
+
+  const result = await authService.signIn({
+    provider: 'demo-oidc',
+    finishInput: {
+      code: request.query.code,
+      state: request.query.state,
+      payload: {
+        redirectUri: request.cookies.oidcRedirectUri,
+        codeVerifier: request.cookies.oidcCodeVerifier,
+      },
+    },
+  })
+
+  return {
+    status: 302,
+    location: '/app',
+    body: {
+      userId: result.user.id,
+      identityId: result.identity.id,
+      provider: result.identity.provider,
+    },
+    cookies: [
+      buildSessionCookie(result.session.id),
+      clearCookie('oidcState'),
+      clearCookie('oidcCodeVerifier'),
+      clearCookie('oidcRedirectUri'),
+    ],
+  }
+}
+
+export async function runOAuthOidcExample(): Promise<void> {
+  const response = await finishOidcCallback({
+    query: {
+      code: 'demo-authorization-code',
+      state: 'state-123',
+    },
+    cookies: {
+      oidcState: 'state-123',
+      oidcCodeVerifier: 'pkce-verifier-123',
+      oidcRedirectUri: 'https://app.example.test/auth/callback',
+    },
+  })
+
+  console.log({
+    status: response.status,
+    location: response.location,
+    sessionCookie: response.cookies[0],
+    clearedCookies: response.cookies.slice(1),
+    exchangeInput: oidcClient.listExchangeInputs().at(-1),
+    profileInput: oidcClient.listProfileInputs().at(-1),
+    userId: response.body.userId,
+    identityId: response.body.identityId,
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runOAuthOidcExample()
+}

--- a/examples/otp-backend/index.ts
+++ b/examples/otp-backend/index.ts
@@ -1,0 +1,173 @@
+import { fileURLToPath } from 'node:url'
+import {
+  DefaultAuthService,
+  OtpChannel,
+  VerificationPurpose,
+  type EmailSender,
+  type VerificationId,
+} from '@alyldas/uniauth'
+import { InMemoryAuthStore, InMemoryRateLimiter } from '@alyldas/uniauth/testing'
+
+interface JsonRequest<TBody> {
+  readonly body: TBody
+}
+
+interface SessionCookie {
+  readonly name: 'session'
+  readonly value: string
+  readonly httpOnly: true
+  readonly sameSite: 'lax'
+  readonly secure: true
+  readonly path: '/'
+}
+
+interface JsonResponse<TBody> {
+  readonly status: number
+  readonly body: TBody
+  readonly cookies?: readonly SessionCookie[]
+}
+
+interface StartOtpBody {
+  readonly email: string
+}
+
+interface FinishOtpBody {
+  readonly verificationId: string
+  readonly code: string
+}
+
+interface DeliveredEmail {
+  readonly to: string
+  readonly subject: string
+  readonly text: string
+  readonly metadata?: Record<string, unknown>
+}
+
+class AppOwnedEmailSender implements EmailSender {
+  private readonly messages: DeliveredEmail[] = []
+
+  async sendEmail(input: DeliveredEmail): Promise<void> {
+    // Production code would enqueue SMTP/vendor work here.
+    this.messages.push(input)
+  }
+
+  listMessages(): readonly DeliveredEmail[] {
+    return [...this.messages]
+  }
+}
+
+const store = new InMemoryAuthStore()
+const emailSender = new AppOwnedEmailSender()
+
+const authService = new DefaultAuthService({
+  repos: store,
+  transaction: store,
+  emailSender,
+  rateLimiter: new InMemoryRateLimiter(),
+})
+
+function buildSessionCookie(sessionId: string): SessionCookie {
+  return {
+    name: 'session',
+    value: sessionId,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+  }
+}
+
+async function postOtpStart(
+  request: JsonRequest<StartOtpBody>,
+): Promise<JsonResponse<{ verificationId: string; delivery: OtpChannel }>> {
+  const challenge = await authService.startOtpChallenge({
+    purpose: VerificationPurpose.SignIn,
+    channel: OtpChannel.Email,
+    target: request.body.email,
+  })
+
+  return {
+    status: 202,
+    body: {
+      verificationId: challenge.verificationId,
+      delivery: challenge.delivery,
+    },
+  }
+}
+
+async function postOtpFinish(
+  request: JsonRequest<FinishOtpBody>,
+): Promise<JsonResponse<{ userId: string; sessionId: string }>> {
+  const result = await authService.finishOtpSignIn({
+    verificationId: parseVerificationId(request.body.verificationId),
+    secret: request.body.code,
+  })
+
+  return {
+    status: 200,
+    body: {
+      userId: result.user.id,
+      sessionId: result.session.id,
+    },
+    cookies: [buildSessionCookie(result.session.id)],
+  }
+}
+
+function extractOtpCode(message: DeliveredEmail): string {
+  const match = /\b(\d{4,8})\b/u.exec(message.text)
+
+  if (!match) {
+    throw new Error('OTP code was not found in the delivered email.')
+  }
+
+  const code = match[1]
+
+  if (!code) {
+    throw new Error('OTP code capture group is missing.')
+  }
+
+  return code
+}
+
+function parseVerificationId(value: string): VerificationId {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    throw new Error('verificationId is required.')
+  }
+
+  return trimmed as VerificationId
+}
+
+export async function runOtpBackendExample(): Promise<void> {
+  const startResponse = await postOtpStart({
+    body: {
+      email: 'alice@example.com',
+    },
+  })
+  const deliveredEmail = emailSender.listMessages().at(-1)
+
+  if (!deliveredEmail) {
+    throw new Error('Expected the application-owned sender to capture one email message.')
+  }
+
+  const finishResponse = await postOtpFinish({
+    body: {
+      verificationId: startResponse.body.verificationId,
+      code: extractOtpCode(deliveredEmail),
+    },
+  })
+
+  console.log({
+    startStatus: startResponse.status,
+    deliveredTo: deliveredEmail.to,
+    deliveredText: deliveredEmail.text,
+    finishStatus: finishResponse.status,
+    sessionCookie: finishResponse.cookies?.[0],
+    userId: finishResponse.body.userId,
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runOtpBackendExample()
+}


### PR DESCRIPTION
## Summary
- add a runnable OTP backend wiring example with explicit sender and session-cookie ownership
- add a runnable OAuth/OIDC callback wiring example using the public provider factory
- document Telegram Mini App and MAX WebApp server wiring and link the new examples from the docs

Closes #86
Closes #87
Closes #88