### PR TITLE
docs: sync roadmap after v0.17.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,8 +152,6 @@ Tracking issues: #86, #87, #88.
 
 Tracking issues: #93, #94, #95.
 
-## Next Release
-
 ### v0.17 - Session Read API and Secret Storage Hardening
 
 - Public session read-side API through `AuthService.resolveSession`.
@@ -163,6 +161,16 @@ Tracking issues: #93, #94, #95.
 - Package gate alignment between local `npm run check` and CI, including dependency audit.
 
 Tracking issues: #99.
+
+## Next Release
+
+### v0.18 - Backlog To Be Defined
+
+- No tracking issues are assigned yet.
+- The next release will be defined after the next concrete feature or hardening slice is promoted
+  into GitHub issues.
+
+Tracking issues: none.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.17 from Next Release to Released after the published v0.17.0 tag
- create the v0.18 placeholder section in the roadmap
- sync GitHub release labels with the new post-release state