### PR TITLE
feat: add session activity touch API

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,7 @@ identities, and email/phone are optional identity attributes.
 - `createSession`
 - `revokeSession`
 - `resolveSession`
+- `touchSession`
 - `createVerification`
 - `consumeVerification`
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -48,6 +48,18 @@ const session = await authService.resolveSession({
 })
 ```
 
+Applications that track recent activity can then explicitly update `lastSeenAt` through the public
+service API:
+
+```ts
+await authService.touchSession({
+  sessionId: session.id,
+})
+```
+
+Keep this write policy application-owned. Touch on meaningful authenticated requests, not on every
+asset fetch, health check, or background poll.
+
 What stays application-owned:
 
 - CSRF protection for browser POST requests;
@@ -81,6 +93,7 @@ What stays application-owned:
 - token forwarding rules between services;
 - gateway or edge header normalization;
 - server middleware that resolves the session token back into application auth context;
+- the policy for when a resolved session should also be touched for activity tracking;
 - log redaction so bearer session tokens do not leak into access logs.
 
 ## Mobile And Native Clients

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -52,6 +52,7 @@ describe('package exports', () => {
     expect(core.createAuthNormalizer).toBeTypeOf('function')
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')
     expect(core.createMaxWebAppProvider).toBeTypeOf('function')
     expect(core.createOAuthOidcProvider).toBeTypeOf('function')
     expect(core.createTelegramMiniAppProvider).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -9,7 +9,7 @@ import {
   startEmailPasswordRecovery,
 } from './passwords.js'
 import { type AuthServiceRuntime, createAuthServiceRuntime } from './runtime.js'
-import { createSession, resolveSession, revokeSession } from './sessions.js'
+import { createSession, resolveSession, revokeSession, touchSession } from './sessions.js'
 import { signIn } from './sign-in.js'
 import { consumeVerification, createVerification } from './verifications.js'
 import type { AuthPolicy } from './policy.js'
@@ -46,6 +46,7 @@ import type {
   StartEmailPasswordRecoveryResult,
   StartOtpChallengeInput,
   StartOtpChallengeResult,
+  TouchSessionInput,
   UnlinkInput,
   UserId,
   Verification,
@@ -141,6 +142,10 @@ export class DefaultAuthService implements AuthService {
 
   async resolveSession(input: ResolveSessionInput): Promise<Session> {
     return resolveSession(this.runtime, input)
+  }
+
+  async touchSession(input: TouchSessionInput): Promise<Session> {
+    return touchSession(this.runtime, input)
   }
 
   async getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]> {

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -7,6 +7,7 @@ import type {
   ResolveSessionInput,
   Session,
   SessionId,
+  TouchSessionInput,
 } from '../domain/types.js'
 import { AuditEventType, SessionStatus } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
@@ -71,6 +72,27 @@ export async function resolveSession(
   return session
 }
 
+export async function touchSession(
+  runtime: AuthServiceRuntime,
+  input: TouchSessionInput,
+): Promise<Session> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+
+    assertValidDate(now, 'Session activity time is invalid.')
+
+    const session = await requireActiveSession(runtime, input.sessionId, now)
+
+    if (session.lastSeenAt && session.lastSeenAt.getTime() >= now.getTime()) {
+      return session
+    }
+
+    return runtime.repos.sessionRepo.update(session.id, {
+      lastSeenAt: now,
+    })
+  })
+}
+
 export async function createSessionRecord(
   runtime: AuthServiceRuntime,
   input: CreateSessionInput & { readonly now: Date },
@@ -117,6 +139,24 @@ function resolveSessionExpiresAt(
   }
 
   return addSeconds(input.now, runtime.sessionTtlSeconds)
+}
+
+async function requireActiveSession(
+  runtime: AuthServiceRuntime,
+  sessionId: SessionId,
+  now: Date,
+): Promise<Session> {
+  const session = await runtime.repos.sessionRepo.findById(sessionId)
+
+  if (
+    !session ||
+    session.status !== SessionStatus.Active ||
+    session.expiresAt.getTime() <= now.getTime()
+  ) {
+    throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
+  }
+
+  return session
 }
 
 function assertValidDate(date: Date, message: string): void {

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -84,6 +84,11 @@ export interface ResolveSessionInput {
   readonly now?: Date
 }
 
+export interface TouchSessionInput {
+  readonly sessionId: SessionId
+  readonly now?: Date
+}
+
 export interface CreateVerificationInput {
   readonly purpose: VerificationPurpose
   readonly target: string

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -16,6 +16,7 @@ import type {
   SignInInput,
   StartOtpChallengeInput,
   StartOtpChallengeResult,
+  TouchSessionInput,
   UnlinkInput,
 } from './flows.js'
 import type {
@@ -72,6 +73,7 @@ export interface AuthService {
   mergeAccounts(input: MergeAccountsInput): Promise<MergeResult>
   revokeSession(sessionId: SessionId): Promise<void>
   resolveSession(input: ResolveSessionInput): Promise<Session>
+  touchSession(input: TouchSessionInput): Promise<Session>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>
   createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult>

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -95,6 +95,24 @@ describe('DefaultAuthService', () => {
     )
   })
 
+  it('touches active sessions without rewinding last seen activity', async () => {
+    const { service } = createInMemoryAuthKit()
+    const result = await service.signIn({ assertion: assertion(), now })
+    const touchedAt = addSeconds(now, 60)
+    const touched = await service.touchSession({
+      sessionId: result.session.id,
+      now: touchedAt,
+    })
+
+    expect(touched.lastSeenAt).toEqual(touchedAt)
+    expect(
+      await service.touchSession({
+        sessionId: result.session.id,
+        now: addSeconds(now, 30),
+      }),
+    ).toBe(touched)
+  })
+
   it('honors explicit zero TTL options in the in-memory testing kit', async () => {
     const { service } = createInMemoryAuthKit({
       clock: { now: () => now },
@@ -133,6 +151,14 @@ describe('DefaultAuthService', () => {
       code: UniAuthErrorCode.SessionNotFound,
     })
     await expect(
+      service.touchSession({
+        sessionId: expired.session.id,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
       service.createSession({
         userId: signedIn.user.id,
         expiresAt: addSeconds(now, -1),
@@ -163,6 +189,12 @@ describe('DefaultAuthService', () => {
       createInMemoryAuthKit({ sessionTtlSeconds: Number.NaN }).service.signIn({
         assertion: assertion(),
         now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(
+      service.touchSession({
+        sessionId: signedIn.session.id,
+        now: new Date('invalid'),
       }),
     ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
   })
@@ -224,6 +256,10 @@ describe('DefaultAuthService', () => {
     expect(await service.resolveSession({ sessionToken: signedIn.sessionToken })).toBe(
       signedIn.session,
     )
+    expect(await service.touchSession({ sessionId: signedIn.session.id })).toMatchObject({
+      id: signedIn.session.id,
+      lastSeenAt: now,
+    })
 
     const challenge = await service.startOtpChallenge({
       purpose: VerificationPurpose.SignIn,

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,6 +1,7 @@
 import { newDb } from 'pg-mem'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  addSeconds,
   type AuthPolicy,
   AuthIdentityStatus,
   ProviderTrustLevel,
@@ -230,6 +231,35 @@ describe('Postgres reference persistence', () => {
     })
 
     expect(await store.sessionRepo.listByUserId(signedIn.user.id)).toHaveLength(1)
+  })
+
+  it('touches active sessions on Postgres without rewinding last seen activity', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-touch-session',
+        email: 'pg-touch-session@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const touchedAt = addSeconds(now, 60)
+    const touched = await service.touchSession({
+      sessionId: signedIn.session.id,
+      now: touchedAt,
+    })
+
+    expect(touched.lastSeenAt).toEqual(touchedAt)
+    expect(
+      await service.touchSession({
+        sessionId: signedIn.session.id,
+        now: addSeconds(now, 30),
+      }),
+    ).toMatchObject({
+      id: signedIn.session.id,
+      lastSeenAt: touchedAt,
+    })
   })
 
   it('applies the schema and supports repository round-trips', async () => {

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -87,9 +87,26 @@ describe('DefaultAuthService edge cases', () => {
     expect(
       await defaultService.resolveSession({ sessionToken: explicitSession.sessionToken, now }),
     ).toBe(explicitSession.session)
+    expect(
+      await defaultService.touchSession({
+        sessionId: explicitSession.session.id,
+        now: addSeconds(now, 1),
+      }),
+    ).toMatchObject({
+      id: explicitSession.session.id,
+      lastSeenAt: addSeconds(now, 1),
+    })
     await defaultService.revokeSession(explicitSession.session.id)
     await expect(
       defaultService.resolveSession({ sessionToken: explicitSession.sessionToken, now }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      defaultService.touchSession({
+        sessionId: explicitSession.session.id,
+        now: addSeconds(now, 2),
+      }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.SessionNotFound,
     })


### PR DESCRIPTION
## Summary
- add public touchSession service API for activity tracking
- update in-memory and Postgres coverage for active, expired, and non-rewind session cases
- document application-owned session touch policy in the transport and architecture docs

Closes #104