### PR TITLE
feat: add session middleware recipes

### DIFF
--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -56,8 +56,8 @@ and release flow, see [Development](development.md) and the root [release checkl
 Use Express when you want explicit middleware order and fully manual response handling.
 
 See the runnable [Express auth module example](../examples/express-auth/index.ts) for a larger
-module-shaped variant that includes app-owned sender wiring, session cookie issuance, and neutral
-error mapping.
+module-shaped variant that includes app-owned sender wiring, session cookie issuance, session
+resolution middleware, and neutral error mapping.
 
 ```ts
 import express from 'express'
@@ -87,6 +87,30 @@ app.post('/auth/password/sign-in', async (req, res, next) => {
 })
 ```
 
+Express session middleware can stay equally thin:
+
+```ts
+app.get(
+  '/me',
+  createExpressSessionMiddleware(authService),
+  requireExpressSession,
+  (request, response) => {
+    response.status(200).json({
+      userId: request.auth.userId,
+      sessionRecordId: request.auth.session.id,
+    })
+  },
+)
+```
+
+That middleware should:
+
+- extract the session token from `Authorization: Bearer ...` or the session cookie;
+- call `authService.resolveSession({ sessionToken })`;
+- optionally call `authService.touchSession({ sessionId })`;
+- attach `{ userId, session }` to `request.auth`;
+- map invalid or missing local sessions to `401 Authentication required.`
+
 Express ownership notes:
 
 - Validate body shape before calling UniAuth.
@@ -101,8 +125,8 @@ Express ownership notes:
 Use Fastify when you want schema-driven request validation and plugin-based server composition.
 
 See the runnable [Fastify auth module example](../examples/fastify-auth/index.ts) for a
-module-shaped variant that keeps Fastify schemas, cookie transport, and app-owned sender adapters in
-the framework layer.
+module-shaped variant that keeps Fastify schemas, cookie transport, app-owned sender adapters, and
+session preHandlers in the framework layer.
 
 ```ts
 import Fastify from 'fastify'
@@ -130,12 +154,39 @@ app.post('/auth/magic/finish', async (request, reply) => {
 })
 ```
 
+Fastify session resolution fits naturally into a `preHandler`:
+
+```ts
+app.get(
+  '/me',
+  {
+    preHandler: [createFastifySessionPreHandler(authService), requireFastifySession],
+  },
+  async (request, reply) => {
+    return reply.send({
+      userId: request.auth.userId,
+      sessionRecordId: request.auth.session.id,
+    })
+  },
+)
+```
+
+That preHandler should:
+
+- read the bearer token from `request.headers.authorization` or the cookie from `request.cookies`;
+- resolve it through `authService.resolveSession(...)`;
+- optionally update activity through `authService.touchSession(...)`;
+- attach `{ userId, session }` to `request.auth`;
+- send `401 Authentication required.` for invalid or revoked local sessions.
+
 Fastify ownership notes:
 
 - Let Fastify schemas reject malformed input before it reaches UniAuth.
 - Keep cookie and CSRF plugins in the Fastify layer, not in sender/provider adapters.
 - If delivery goes through queues, keep that inside your `EmailSender` or `SmsSender` adapters
   rather than introducing a Fastify-specific auth dispatcher.
+- For a fuller copyable recipe, including token extraction helpers and failure mapping, see
+  [Session transport recipes](session-transport.md).
 
 ## Nest
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -60,6 +60,153 @@ await authService.touchSession({
 Keep this write policy application-owned. Touch on meaningful authenticated requests, not on every
 asset fetch, health check, or background poll.
 
+### Express Middleware Recipe
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+import { UniAuthErrorCode, isUniAuthError, type AuthService, type Session } from '@alyldas/uniauth'
+
+interface ExpressRequestAuth {
+  readonly session: Session
+  readonly userId: Session['userId']
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: ExpressRequestAuth
+    }
+  }
+}
+
+export function createExpressSessionMiddleware(authService: AuthService) {
+  return async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+    const sessionToken =
+      readBearerToken(request.headers.authorization) ?? readCookieToken(request.headers.cookie)
+
+    if (!sessionToken) {
+      next()
+      return
+    }
+
+    try {
+      const resolved = await authService.resolveSession({ sessionToken })
+      const session = await authService.touchSession({ sessionId: resolved.id })
+
+      request.auth = {
+        session,
+        userId: session.userId,
+      }
+      next()
+    } catch (error) {
+      if (
+        isUniAuthError(error) &&
+        (error.code === UniAuthErrorCode.InvalidInput ||
+          error.code === UniAuthErrorCode.SessionNotFound)
+      ) {
+        response.status(401).json({ error: 'Authentication required.' })
+        return
+      }
+
+      next(error)
+    }
+  }
+}
+
+function readBearerToken(header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  const [scheme, value] = header.split(/\s+/, 2)
+  return scheme?.toLowerCase() === 'bearer' && value?.trim() ? value.trim() : undefined
+}
+
+function readCookieToken(header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  for (const part of header.split(';')) {
+    const [name, ...rest] = part.split('=')
+
+    if (name.trim() !== 'session') {
+      continue
+    }
+
+    const value = rest.join('=').trim()
+    return value ? decodeURIComponent(value) : undefined
+  }
+
+  return undefined
+}
+```
+
+Attach the middleware only where browser/API auth context is needed, or pair it with a small
+`requireSession` guard for protected routes. If activity writes are too expensive for every request,
+skip `touchSession(...)` here and call it only on the authenticated routes that matter.
+
+### Fastify preHandler Recipe
+
+```ts
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { UniAuthErrorCode, isUniAuthError, type AuthService, type Session } from '@alyldas/uniauth'
+
+interface FastifyRequestAuth {
+  readonly session: Session
+  readonly userId: Session['userId']
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    auth?: FastifyRequestAuth
+  }
+}
+
+export function createFastifySessionPreHandler(authService: AuthService) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const sessionToken =
+      readBearerToken(request.headers.authorization) ?? request.cookies.session?.trim()
+
+    if (!sessionToken) {
+      return
+    }
+
+    try {
+      const resolved = await authService.resolveSession({ sessionToken })
+      request.auth = {
+        session: resolved,
+        userId: resolved.userId,
+      }
+    } catch (error) {
+      if (
+        isUniAuthError(error) &&
+        (error.code === UniAuthErrorCode.InvalidInput ||
+          error.code === UniAuthErrorCode.SessionNotFound)
+      ) {
+        await reply.status(401).send({ error: 'Authentication required.' })
+        return
+      }
+
+      throw error
+    }
+  }
+}
+
+function readBearerToken(header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  const [scheme, value] = header.split(/\s+/, 2)
+  return scheme?.toLowerCase() === 'bearer' && value?.trim() ? value.trim() : undefined
+}
+```
+
+Fastify users often keep `touchSession(...)` in a second protected-route hook or in the route
+handler itself, so lightweight public requests can resolve auth context without forcing an activity
+write every time.
+
 What stays application-owned:
 
 - CSRF protection for browser POST requests;
@@ -138,6 +285,8 @@ Treat logout as two coordinated steps:
 See also:
 
 - [Backend integration recipes](backend-recipes.md)
+- [Express auth module example](../examples/express-auth/index.ts)
+- [Fastify auth module example](../examples/fastify-auth/index.ts)
 - [Local auth flows](local-auth.md)
 - [Security model](security.md)
 - [Threat model](threat-model.md)

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -3,11 +3,13 @@ import express, { type Express, type NextFunction, type Request, type Response }
 import {
   DefaultAuthService,
   OtpChannel,
+  SessionStatus,
   UniAuthErrorCode,
   VerificationPurpose,
   createDefaultAuthPolicy,
   isUniAuthError,
   type EmailSender,
+  type Session,
   type UniAuthErrorCode as UniAuthErrorCodeType,
   type VerificationId,
 } from '@alyldas/uniauth'
@@ -27,6 +29,17 @@ interface ExpressAuthExample {
 interface DemoAccount {
   readonly email: string
   readonly password: string
+}
+
+interface ExpressRequestAuth {
+  readonly session: Session
+  readonly userId: Session['userId']
+}
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    auth?: ExpressRequestAuth
+  }
 }
 
 class RequestValidationError extends Error {
@@ -83,6 +96,10 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
   const app = express()
 
   app.use(express.json())
+
+  const sessionMiddleware = createExpressSessionMiddleware(authService, {
+    touch: true,
+  })
 
   app.post('/auth/password/sign-in', async (request, response, next) => {
     try {
@@ -145,6 +162,22 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
     }
   })
 
+  app.get('/me', sessionMiddleware, requireExpressSession, (request, response) => {
+    const auth = request.auth
+
+    if (!auth) {
+      response.status(401).json({ error: 'Authentication required.' })
+      return
+    }
+
+    response.status(200).json({
+      userId: auth.userId,
+      sessionRecordId: auth.session.id,
+      sessionStatus: auth.session.status,
+      lastSeenAt: auth.session.lastSeenAt?.toISOString() ?? null,
+    })
+  })
+
   app.use((error: unknown, _request: Request, response: Response, next: NextFunction): void => {
     if (response.headersSent) {
       next(error)
@@ -191,7 +224,12 @@ export async function runExpressAuthExample(): Promise<void> {
           framework: 'express',
           port,
           demoAccount: example.demoAccount,
-          routes: ['POST /auth/password/sign-in', 'POST /auth/otp/start', 'POST /auth/otp/finish'],
+          routes: [
+            'POST /auth/password/sign-in',
+            'POST /auth/otp/start',
+            'POST /auth/otp/finish',
+            'GET /me',
+          ],
           note: 'OTP codes are printed by the application-owned email sender.',
         },
         null,
@@ -248,6 +286,86 @@ function writeSessionCookie(response: Response, sessionToken: string): void {
   })
 }
 
+function createExpressSessionMiddleware(
+  authService: DefaultAuthService,
+  options: {
+    readonly touch?: boolean
+  } = {},
+) {
+  return async (request: Request, response: Response, next: NextFunction): Promise<void> => {
+    const sessionToken = readExpressSessionToken(request)
+
+    if (!sessionToken) {
+      next()
+      return
+    }
+
+    try {
+      const resolved = await authService.resolveSession({ sessionToken })
+      const session = options.touch
+        ? await authService.touchSession({ sessionId: resolved.id })
+        : resolved
+
+      request.auth = {
+        session,
+        userId: session.userId,
+      }
+      next()
+    } catch (error) {
+      if (isSessionContextError(error)) {
+        response.status(401).json({ error: 'Authentication required.' })
+        return
+      }
+
+      next(error)
+    }
+  }
+}
+
+function requireExpressSession(request: Request, response: Response, next: NextFunction): void {
+  if (!request.auth || request.auth.session.status !== SessionStatus.Active) {
+    response.status(401).json({ error: 'Authentication required.' })
+    return
+  }
+
+  next()
+}
+
+function readExpressSessionToken(request: Request): string | undefined {
+  return (
+    readBearerToken(request.headers.authorization) ??
+    readCookieToken(request.headers.cookie, 'session')
+  )
+}
+
+function readBearerToken(header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  const [scheme, value] = header.split(/\s+/, 2)
+  return scheme?.toLowerCase() === 'bearer' && value?.trim() ? value.trim() : undefined
+}
+
+function readCookieToken(header: string | undefined, name: string): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  for (const part of header.split(';')) {
+    const [rawName, ...rest] = part.split('=')
+
+    if (!rawName || rawName.trim() !== name) {
+      continue
+    }
+
+    const value = rest.join('=').trim()
+    return value ? decodeURIComponent(value) : undefined
+  }
+
+  return undefined
+}
+
 const neutralPublicErrorCodes = new Set<UniAuthErrorCodeType>([
   UniAuthErrorCode.InvalidCredentials,
   UniAuthErrorCode.InvalidInput,
@@ -259,6 +377,14 @@ const neutralPublicErrorCodes = new Set<UniAuthErrorCodeType>([
 
 function isNeutralPublicError(code: UniAuthErrorCodeType): boolean {
   return neutralPublicErrorCodes.has(code)
+}
+
+function isSessionContextError(error: unknown): boolean {
+  return (
+    isUniAuthError(error) &&
+    (error.code === UniAuthErrorCode.InvalidInput ||
+      error.code === UniAuthErrorCode.SessionNotFound)
+  )
 }
 
 function isPublicRequestError(error: unknown): boolean {

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -1,14 +1,16 @@
 import { fileURLToPath } from 'node:url'
 import cookie from '@fastify/cookie'
-import Fastify, { type FastifyInstance } from 'fastify'
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
 import {
   DefaultAuthService,
   OtpChannel,
+  SessionStatus,
   UniAuthErrorCode,
   VerificationPurpose,
   createDefaultAuthPolicy,
   isUniAuthError,
   type EmailSender,
+  type Session,
   type UniAuthErrorCode as UniAuthErrorCodeType,
   type VerificationId,
 } from '@alyldas/uniauth'
@@ -25,6 +27,17 @@ interface DeliveredEmail {
   readonly subject: string
   readonly text: string
   readonly metadata?: Record<string, unknown>
+}
+
+interface FastifyRequestAuth {
+  readonly session: Session
+  readonly userId: Session['userId']
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    auth?: FastifyRequestAuth
+  }
 }
 
 class ConsoleEmailSender implements EmailSender {
@@ -65,6 +78,10 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
   const app = Fastify()
 
   await app.register(cookie)
+  app.decorateRequest('auth')
+  const sessionPreHandler = createFastifySessionPreHandler(authService, {
+    touch: true,
+  })
 
   app.post<{
     Body: {
@@ -138,6 +155,27 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
     },
   )
 
+  app.get(
+    '/me',
+    {
+      preHandler: [sessionPreHandler, requireFastifySession],
+    },
+    async (request, reply) => {
+      const auth = request.auth
+
+      if (!auth) {
+        return reply.status(401).send({ error: 'Authentication required.' })
+      }
+
+      return reply.status(200).send({
+        userId: auth.userId,
+        sessionRecordId: auth.session.id,
+        sessionStatus: auth.session.status,
+        lastSeenAt: auth.session.lastSeenAt?.toISOString() ?? null,
+      })
+    },
+  )
+
   app.setErrorHandler((error, _request, reply) => {
     if (isFastifyPublicRequestError(error)) {
       reply.status(400).send({ error: 'Request cannot be completed.' })
@@ -178,7 +216,7 @@ export async function runFastifyAuthExample(): Promise<void> {
         type: 'demo-server',
         framework: 'fastify',
         port,
-        routes: ['POST /auth/otp/start', 'POST /auth/otp/finish'],
+        routes: ['POST /auth/otp/start', 'POST /auth/otp/finish', 'GET /me'],
         note: 'OTP codes are printed by the application-owned email sender.',
       },
       null,
@@ -191,8 +229,66 @@ function parseVerificationId(value: string): VerificationId {
   return value.trim() as VerificationId
 }
 
+function createFastifySessionPreHandler(
+  authService: DefaultAuthService,
+  options: {
+    readonly touch?: boolean
+  } = {},
+) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const sessionToken = readFastifySessionToken(request)
+
+    if (!sessionToken) {
+      return
+    }
+
+    try {
+      const resolved = await authService.resolveSession({ sessionToken })
+      const session = options.touch
+        ? await authService.touchSession({ sessionId: resolved.id })
+        : resolved
+
+      request.auth = {
+        session,
+        userId: session.userId,
+      }
+    } catch (error) {
+      if (isSessionContextError(error)) {
+        await reply.status(401).send({ error: 'Authentication required.' })
+        return
+      }
+
+      throw error
+    }
+  }
+}
+
+async function requireFastifySession(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!request.auth || request.auth.session.status !== SessionStatus.Active) {
+    await reply.status(401).send({ error: 'Authentication required.' })
+  }
+}
+
+function readFastifySessionToken(request: FastifyRequest): string | undefined {
+  return readBearerToken(request.headers.authorization) ?? readCookieValue(request.cookies.session)
+}
+
+function readBearerToken(header: string | undefined): string | undefined {
+  if (!header) {
+    return undefined
+  }
+
+  const [scheme, value] = header.split(/\s+/, 2)
+  return scheme?.toLowerCase() === 'bearer' && value?.trim() ? value.trim() : undefined
+}
+
+function readCookieValue(value: string | undefined): string | undefined {
+  return value?.trim() || undefined
+}
+
 const neutralPublicErrorCodes = new Set<UniAuthErrorCodeType>([
   UniAuthErrorCode.InvalidInput,
+  UniAuthErrorCode.SessionNotFound,
   UniAuthErrorCode.VerificationNotFound,
   UniAuthErrorCode.VerificationExpired,
   UniAuthErrorCode.VerificationConsumed,
@@ -201,6 +297,14 @@ const neutralPublicErrorCodes = new Set<UniAuthErrorCodeType>([
 
 function isNeutralPublicError(code: UniAuthErrorCodeType): boolean {
   return neutralPublicErrorCodes.has(code)
+}
+
+function isSessionContextError(error: unknown): boolean {
+  return (
+    isUniAuthError(error) &&
+    (error.code === UniAuthErrorCode.InvalidInput ||
+      error.code === UniAuthErrorCode.SessionNotFound)
+  )
 }
 
 function isFastifyPublicRequestError(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- add copyable Express and Fastify middleware recipes for resolving local UniAuth sessions
- update the runnable framework examples to attach  to request auth context
- document cookie and bearer extraction, failure mapping, and optional activity touch guidance

Closes #105