### PR TITLE
docs: sync roadmap after v0.20.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -177,13 +177,17 @@ Tracking issues: #104.
 
 Tracking issues: #106.
 
-## Next Release
-
 ### v0.20 - Session Middleware Recipes
 
 - Express and Fastify middleware recipes for mapping `sessionToken` into request auth context.
 
 Tracking issues: #105.
+
+## Next Release
+
+### v0.21 - Backlog To Be Defined
+
+- Next stabilizing or integrator-facing scope after the session middleware recipes release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.20 into released roadmap history
- create v0.21 backlog placeholder after the session middleware recipes release
- keep release labels aligned now that open issues are empty