### PR TITLE
feat: add public user session listing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ license, subscription, private contract, or other written permission.
 - Maps Auth.js and Better Auth OAuth callback data into `ProviderIdentityAssertion` through the
   optional `@alyldas/uniauth/bridges` entry point.
 - Creates local session records after successful sign-in.
+- Exposes local session read-side helpers for token resolution, activity touch, and user session
+  listing.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
   when the configured `UnitOfWork` supports atomic rollback.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,7 @@ identities, and email/phone are optional identity attributes.
 - `revokeSession`
 - `resolveSession`
 - `touchSession`
+- `getUserSessions`
 - `createVerification`
 - `consumeVerification`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,9 +185,13 @@ Tracking issues: #105.
 
 ## Next Release
 
-### v0.21 - Backlog To Be Defined
+### v0.21 - User Session Read Side
 
-- Next stabilizing or integrator-facing scope after the session middleware recipes release.
+- Public `getUserSessions(userId)` API for listing local sessions of an active user.
+- Integrator-facing support for account-security, device-list, and session-management screens
+  without reaching into storage adapters directly.
+
+Tracking issues: #118.
 
 ## Versioning
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -52,6 +52,7 @@ describe('package exports', () => {
     expect(core.createAuthNormalizer).toBeTypeOf('function')
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')
     expect(core.createMaxWebAppProvider).toBeTypeOf('function')
     expect(core.createOAuthOidcProvider).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -9,7 +9,13 @@ import {
   startEmailPasswordRecovery,
 } from './passwords.js'
 import { type AuthServiceRuntime, createAuthServiceRuntime } from './runtime.js'
-import { createSession, resolveSession, revokeSession, touchSession } from './sessions.js'
+import {
+  createSession,
+  getUserSessions,
+  resolveSession,
+  revokeSession,
+  touchSession,
+} from './sessions.js'
 import { signIn } from './sign-in.js'
 import { consumeVerification, createVerification } from './verifications.js'
 import type { AuthPolicy } from './policy.js'
@@ -150,6 +156,10 @@ export class DefaultAuthService implements AuthService {
 
   async getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]> {
     return getUserIdentities(this.runtime, userId)
+  }
+
+  async getUserSessions(userId: UserId): Promise<readonly Session[]> {
+    return getUserSessions(this.runtime, userId)
   }
 
   async createSession(input: CreateSessionInput): Promise<CreateSessionResult> {

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -8,6 +8,7 @@ import type {
   Session,
   SessionId,
   TouchSessionInput,
+  UserId,
 } from '../domain/types.js'
 import { AuditEventType, SessionStatus } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
@@ -91,6 +92,14 @@ export async function touchSession(
       lastSeenAt: now,
     })
   })
+}
+
+export async function getUserSessions(
+  runtime: AuthServiceRuntime,
+  userId: UserId,
+): Promise<readonly Session[]> {
+  await getActiveUser(runtime, userId)
+  return runtime.repos.sessionRepo.listByUserId(userId)
 }
 
 export async function createSessionRecord(

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -75,6 +75,7 @@ export interface AuthService {
   resolveSession(input: ResolveSessionInput): Promise<Session>
   touchSession(input: TouchSessionInput): Promise<Session>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
+  getUserSessions(userId: UserId): Promise<readonly Session[]>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>
   createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult>
   consumeVerification(input: ConsumeVerificationInput): Promise<Verification>

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -262,6 +262,29 @@ describe('Postgres reference persistence', () => {
     })
   })
 
+  it('lists local sessions for an active user on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const first = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-list-sessions',
+        email: 'pg-list-sessions@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const second = await service.createSession({
+      userId: first.user.id,
+      now: addSeconds(now, 10),
+      metadata: { createdBy: 'test' },
+    })
+
+    expect((await service.getUserSessions(first.user.id)).map((session) => session.id)).toEqual([
+      first.session.id,
+      second.session.id,
+    ])
+  })
+
   it('applies the schema and supports repository round-trips', async () => {
     const { pool, store } = await createPostgresTestKit()
     const idGenerator = createSequentialIdGenerator('pg-repo')

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -54,7 +54,7 @@ describe('DefaultAuthService edge cases', () => {
     expect(blankProfile.identity.email).toBeUndefined()
     expect(blankProfile.identity.phone).toBeUndefined()
 
-    await defaultService.signIn({
+    const exact = await defaultService.signIn({
       assertion: assertion({
         provider: 'email',
         providerUserId: 'alice',
@@ -84,6 +84,9 @@ describe('DefaultAuthService edge cases', () => {
 
     expect(explicitSession.session.metadata).toEqual({ manual: true })
     expect(await defaultService.getUserIdentities(first.user.id)).toHaveLength(1)
+    expect(
+      (await defaultService.getUserSessions(first.user.id)).map((session) => session.id),
+    ).toEqual([first.session.id, exact.session.id, explicitSession.session.id])
     expect(
       await defaultService.resolveSession({ sessionToken: explicitSession.sessionToken, now }),
     ).toBe(explicitSession.session)
@@ -198,6 +201,11 @@ describe('DefaultAuthService edge cases', () => {
     await defaultStore.userRepo.update(second.user.id, { disabledAt: now })
     expect(
       await defaultService.getUserIdentities(second.user.id).catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    expect(
+      await defaultService.getUserSessions(second.user.id).catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.UserNotFound,
     })


### PR DESCRIPTION
## Summary
- add getUserSessions(userId) to the public AuthService contract
- cover the new read-side API through service and Postgres tests
- define v0.21 scope in the roadmap

## Verification
- npm run check

Closes #118