### PR TITLE
docs: sync roadmap after v0.21.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -183,8 +183,6 @@ Tracking issues: #106.
 
 Tracking issues: #105.
 
-## Next Release
-
 ### v0.21 - User Session Read Side
 
 - Public `getUserSessions(userId)` API for listing local sessions of an active user.
@@ -192,6 +190,12 @@ Tracking issues: #105.
   without reaching into storage adapters directly.
 
 Tracking issues: #118.
+
+## Next Release
+
+### v0.22 - Backlog To Be Defined
+
+- Next stabilizing or integrator-facing scope after the user session read-side release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.21 into the released roadmap section
- define v0.22 as the next placeholder release
- keep planning docs aligned with the published v0.21.0 release

## Verification
- npm run check