### PR TITLE
feat: add bulk user session revocation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ license, subscription, private contract, or other written permission.
 - Creates local session records after successful sign-in.
 - Exposes local session read-side helpers for token resolution, activity touch, and user session
   listing.
+- Supports bulk local session revocation for sign-out-all-devices style account-security flows.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
   when the configured `UnitOfWork` supports atomic rollback.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,7 @@ identities, and email/phone are optional identity attributes.
 - `mergeAccounts`
 - `createSession`
 - `revokeSession`
+- `revokeUserSessions`
 - `resolveSession`
 - `touchSession`
 - `getUserSessions`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,9 +193,12 @@ Tracking issues: #118.
 
 ## Next Release
 
-### v0.22 - Backlog To Be Defined
+### v0.22 - Bulk Session Revocation
 
-- Next stabilizing or integrator-facing scope after the user session read-side release.
+- Public bulk local session revocation through `revokeUserSessions(...)`.
+- Optional `exceptSessionId` support for sign-out-other-devices account-security flows.
+
+Tracking issues: #122.
 
 ## Versioning
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -275,6 +275,12 @@ Treat logout as two coordinated steps:
    - delete the bearer token from client state;
    - delete the mobile-stored session token.
 
+For sign-out-all-devices or device-management screens, applications can first call
+`authService.getUserSessions(userId)` and then revoke the active subset through
+`authService.revokeUserSessions({ userId, exceptSessionId })`. UniAuth still does not clear cookies
+or bearer stores for those clients; the application must remove the transport artifact on each
+device as it becomes aware of the revoked local session.
+
 ## Security Notes
 
 - Session transport is not part of the package public API surface; it is deployment policy.

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -52,6 +52,7 @@ describe('package exports', () => {
     expect(core.createAuthNormalizer).toBeTypeOf('function')
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')
     expect(core.createMaxWebAppProvider).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -14,6 +14,7 @@ import {
   getUserSessions,
   resolveSession,
   revokeSession,
+  revokeUserSessions,
   touchSession,
 } from './sessions.js'
 import { signIn } from './sign-in.js'
@@ -40,6 +41,8 @@ import type {
   LinkResult,
   MergeAccountsInput,
   MergeResult,
+  RevokeUserSessionsInput,
+  RevokeUserSessionsResult,
   ResolveSessionInput,
   Session,
   SessionId,
@@ -144,6 +147,10 @@ export class DefaultAuthService implements AuthService {
 
   async revokeSession(sessionId: SessionId): Promise<void> {
     return revokeSession(this.runtime, sessionId)
+  }
+
+  async revokeUserSessions(input: RevokeUserSessionsInput): Promise<RevokeUserSessionsResult> {
+    return revokeUserSessions(this.runtime, input)
   }
 
   async resolveSession(input: ResolveSessionInput): Promise<Session> {

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -4,6 +4,8 @@ import { audit, getActiveUser } from './support.js'
 import type {
   CreateSessionInput,
   CreateSessionResult,
+  RevokeUserSessionsInput,
+  RevokeUserSessionsResult,
   ResolveSessionInput,
   Session,
   SessionId,
@@ -32,20 +34,42 @@ export async function revokeSession(
 ): Promise<void> {
   await runtime.transaction.run(async () => {
     const now = runtime.clock.now()
-    const session = await runtime.repos.sessionRepo.findById(sessionId)
+    const session = await requireStoredSession(runtime, sessionId)
+    await revokeSessionRecord(runtime, session, now)
+  })
+}
 
-    if (!session) {
+export async function revokeUserSessions(
+  runtime: AuthServiceRuntime,
+  input: RevokeUserSessionsInput,
+): Promise<RevokeUserSessionsResult> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const user = await getActiveUser(runtime, input.userId)
+    const sessions = await runtime.repos.sessionRepo.listByUserId(user.id)
+
+    if (
+      input.exceptSessionId &&
+      !sessions.some((session) => session.id === input.exceptSessionId)
+    ) {
       throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
     }
 
-    await runtime.repos.sessionRepo.update(session.id, {
-      status: SessionStatus.Revoked,
-      revokedAt: now,
-    })
-    await audit(runtime, AuditEventType.SessionRevoked, now, {
-      userId: session.userId,
-      sessionId: session.id,
-    })
+    const revokedSessionIds: SessionId[] = []
+
+    for (const session of sessions) {
+      if (session.id === input.exceptSessionId || session.status !== SessionStatus.Active) {
+        continue
+      }
+
+      await revokeSessionRecord(runtime, session, now)
+      revokedSessionIds.push(session.id)
+    }
+
+    return {
+      userId: user.id,
+      revokedSessionIds,
+    }
   })
 }
 
@@ -166,4 +190,32 @@ async function requireActiveSession(
   }
 
   return session
+}
+
+async function requireStoredSession(
+  runtime: AuthServiceRuntime,
+  sessionId: SessionId,
+): Promise<Session> {
+  const session = await runtime.repos.sessionRepo.findById(sessionId)
+
+  if (!session) {
+    throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
+  }
+
+  return session
+}
+
+async function revokeSessionRecord(
+  runtime: AuthServiceRuntime,
+  session: Session,
+  now: Date,
+): Promise<void> {
+  await runtime.repos.sessionRepo.update(session.id, {
+    status: SessionStatus.Revoked,
+    revokedAt: now,
+  })
+  await audit(runtime, AuditEventType.SessionRevoked, now, {
+    userId: session.userId,
+    sessionId: session.id,
+  })
 }

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -89,6 +89,17 @@ export interface TouchSessionInput {
   readonly now?: Date
 }
 
+export interface RevokeUserSessionsInput {
+  readonly userId: UserId
+  readonly exceptSessionId?: SessionId
+  readonly now?: Date
+}
+
+export interface RevokeUserSessionsResult {
+  readonly userId: UserId
+  readonly revokedSessionIds: readonly SessionId[]
+}
+
 export interface CreateVerificationInput {
   readonly purpose: VerificationPurpose
   readonly target: string

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -12,6 +12,8 @@ import type {
   LinkResult,
   MergeAccountsInput,
   MergeResult,
+  RevokeUserSessionsInput,
+  RevokeUserSessionsResult,
   ResolveSessionInput,
   SignInInput,
   StartOtpChallengeInput,
@@ -72,6 +74,7 @@ export interface AuthService {
   unlink(input: UnlinkInput): Promise<void>
   mergeAccounts(input: MergeAccountsInput): Promise<MergeResult>
   revokeSession(sessionId: SessionId): Promise<void>
+  revokeUserSessions(input: RevokeUserSessionsInput): Promise<RevokeUserSessionsResult>
   resolveSession(input: ResolveSessionInput): Promise<Session>
   touchSession(input: TouchSessionInput): Promise<Session>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -113,6 +113,41 @@ describe('DefaultAuthService', () => {
     ).toBe(touched)
   })
 
+  it('bulk-revokes active user sessions while optionally keeping one session active', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+    const second = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const third = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 20),
+    })
+
+    const result = await service.revokeUserSessions({
+      userId: signedIn.user.id,
+      exceptSessionId: signedIn.session.id,
+      now: addSeconds(now, 30),
+    })
+
+    expect(result).toEqual({
+      userId: signedIn.user.id,
+      revokedSessionIds: [second.session.id, third.session.id],
+    })
+    expect(await service.getUserSessions(signedIn.user.id)).toMatchObject([
+      { id: signedIn.session.id, status: SessionStatus.Active },
+      { id: second.session.id, status: SessionStatus.Revoked },
+      { id: third.session.id, status: SessionStatus.Revoked },
+    ])
+    expect(
+      store
+        .listAuditEvents()
+        .filter((event) => event.type === AuditEventType.SessionRevoked)
+        .map((event) => event.sessionId),
+    ).toEqual([second.session.id, third.session.id])
+  })
+
   it('honors explicit zero TTL options in the in-memory testing kit', async () => {
     const { service } = createInMemoryAuthKit({
       clock: { now: () => now },
@@ -274,6 +309,25 @@ describe('DefaultAuthService', () => {
     })
 
     expect(finished.session.status).toBe(SessionStatus.Active)
+  })
+
+  it('uses the runtime clock when bulk-revoking user sessions', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({ assertion: assertion() })
+    const second = await service.createSession({
+      userId: signedIn.user.id,
+    })
+
+    expect(await service.revokeUserSessions({ userId: signedIn.user.id })).toEqual({
+      userId: signedIn.user.id,
+      revokedSessionIds: [signedIn.session.id, second.session.id],
+    })
+    expect(await service.getUserSessions(signedIn.user.id)).toMatchObject([
+      { id: signedIn.session.id, status: SessionStatus.Revoked, revokedAt: now },
+      { id: second.session.id, status: SessionStatus.Revoked, revokedAt: now },
+    ])
   })
 
   it('uses exact provider identity match before any profile matching', async () => {

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -285,6 +285,43 @@ describe('Postgres reference persistence', () => {
     ])
   })
 
+  it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {
+    const { service } = await createPostgresTestKit()
+    const first = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-bulk-revoke',
+        email: 'pg-bulk-revoke@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const second = await service.createSession({
+      userId: first.user.id,
+      now: addSeconds(now, 10),
+    })
+    const third = await service.createSession({
+      userId: first.user.id,
+      now: addSeconds(now, 20),
+    })
+
+    const result = await service.revokeUserSessions({
+      userId: first.user.id,
+      exceptSessionId: first.session.id,
+      now: addSeconds(now, 30),
+    })
+
+    expect(result).toEqual({
+      userId: first.user.id,
+      revokedSessionIds: [second.session.id, third.session.id],
+    })
+    expect(await service.getUserSessions(first.user.id)).toMatchObject([
+      { id: first.session.id, status: SessionStatus.Active },
+      { id: second.session.id, status: SessionStatus.Revoked },
+      { id: third.session.id, status: SessionStatus.Revoked },
+    ])
+  })
+
   it('applies the schema and supports repository round-trips', async () => {
     const { pool, store } = await createPostgresTestKit()
     const idGenerator = createSequentialIdGenerator('pg-repo')

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -211,6 +211,17 @@ describe('DefaultAuthService edge cases', () => {
     })
     expect(
       await defaultService
+        .revokeUserSessions({
+          userId: first.user.id,
+          exceptSessionId: asSessionId('missing-session'),
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    expect(
+      await defaultService
         .mergeAccounts({
           sourceUserId: asUserId('missing-source'),
           targetUserId: first.user.id,


### PR DESCRIPTION
## Summary
- add revokeUserSessions(...) to the public AuthService contract
- support exceptSessionId for sign-out-other-devices flows
- document the v0.22 scope and session revocation usage

## Verification
- npm run check

Closes #122