### PR TITLE
docs: sync roadmap after v0.22.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -191,14 +191,18 @@ Tracking issues: #105.
 
 Tracking issues: #118.
 
-## Next Release
-
 ### v0.22 - Bulk Session Revocation
 
 - Public bulk local session revocation through `revokeUserSessions(...)`.
 - Optional `exceptSessionId` support for sign-out-other-devices account-security flows.
 
 Tracking issues: #122.
+
+## Next Release
+
+### v0.23 - Backlog To Be Defined
+
+- Next stabilizing or integrator-facing scope after the bulk session revocation release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary\n- move v0.22 bulk session revocation into the released section\n- define v0.23 as the next-release placeholder\n- keep roadmap aligned with release labels after v0.22.0\n\n## Testing\n- npm run check