### PR TITLE
feat: add public user read-side API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ license, subscription, private contract, or other written permission.
 - Creates local session records after successful sign-in.
 - Exposes local session read-side helpers for token resolution, activity touch, and user session
   listing.
+- Exposes a narrow `getUser(userId)` helper for loading the active local user snapshot by id.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ identities, and email/phone are optional identity attributes.
 - `revokeUserSessions`
 - `resolveSession`
 - `touchSession`
+- `getUser`
 - `getUserSessions`
 - `createVerification`
 - `consumeVerification`

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -97,6 +97,7 @@ app.get(
   (request, response) => {
     response.status(200).json({
       userId: request.auth.userId,
+      email: request.auth.user.email ?? null,
       sessionRecordId: request.auth.session.id,
     })
   },
@@ -107,8 +108,10 @@ That middleware should:
 
 - extract the session token from `Authorization: Bearer ...` or the session cookie;
 - call `authService.resolveSession({ sessionToken })`;
+- load the active local user through `authService.getUser(session.userId)` when the request context
+  needs a user snapshot;
 - optionally call `authService.touchSession({ sessionId })`;
-- attach `{ userId, session }` to `request.auth`;
+- attach `{ userId, user, session }` to `request.auth`;
 - map invalid or missing local sessions to `401 Authentication required.`
 
 Express ownership notes:
@@ -165,6 +168,7 @@ app.get(
   async (request, reply) => {
     return reply.send({
       userId: request.auth.userId,
+      email: request.auth.user.email ?? null,
       sessionRecordId: request.auth.session.id,
     })
   },
@@ -175,8 +179,10 @@ That preHandler should:
 
 - read the bearer token from `request.headers.authorization` or the cookie from `request.cookies`;
 - resolve it through `authService.resolveSession(...)`;
+- load the current active local user through `authService.getUser(session.userId)` if the handler
+  needs it;
 - optionally update activity through `authService.touchSession(...)`;
-- attach `{ userId, session }` to `request.auth`;
+- attach `{ userId, user, session }` to `request.auth`;
 - send `401 Authentication required.` for invalid or revoked local sessions.
 
 Fastify ownership notes:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,9 +200,13 @@ Tracking issues: #122.
 
 ## Next Release
 
-### v0.23 - Backlog To Be Defined
+### v0.23 - User Read Side
 
-- Next stabilizing or integrator-facing scope after the bulk session revocation release.
+- Public `getUser(userId)` API for loading the active local user snapshot by id.
+- Integrator-facing support for middleware and account-screen flows that already use local
+  sessions and identities.
+
+Tracking issues: #127.
 
 ## Versioning
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -46,6 +46,12 @@ credential:
 const session = await authService.resolveSession({
   sessionToken: request.cookies.session,
 })
+const user = await authService.getUser(session.userId)
+
+return {
+  user,
+  session,
+}
 ```
 
 Applications that track recent activity can then explicitly update `lastSeenAt` through the public
@@ -64,10 +70,17 @@ asset fetch, health check, or background poll.
 
 ```ts
 import type { NextFunction, Request, Response } from 'express'
-import { UniAuthErrorCode, isUniAuthError, type AuthService, type Session } from '@alyldas/uniauth'
+import {
+  UniAuthErrorCode,
+  isUniAuthError,
+  type AuthService,
+  type Session,
+  type User,
+} from '@alyldas/uniauth'
 
 interface ExpressRequestAuth {
   readonly session: Session
+  readonly user: User
   readonly userId: Session['userId']
 }
 
@@ -92,9 +105,11 @@ export function createExpressSessionMiddleware(authService: AuthService) {
     try {
       const resolved = await authService.resolveSession({ sessionToken })
       const session = await authService.touchSession({ sessionId: resolved.id })
+      const user = await authService.getUser(session.userId)
 
       request.auth = {
         session,
+        user,
         userId: session.userId,
       }
       next()
@@ -150,10 +165,17 @@ skip `touchSession(...)` here and call it only on the authenticated routes that 
 
 ```ts
 import type { FastifyReply, FastifyRequest } from 'fastify'
-import { UniAuthErrorCode, isUniAuthError, type AuthService, type Session } from '@alyldas/uniauth'
+import {
+  UniAuthErrorCode,
+  isUniAuthError,
+  type AuthService,
+  type Session,
+  type User,
+} from '@alyldas/uniauth'
 
 interface FastifyRequestAuth {
   readonly session: Session
+  readonly user: User
   readonly userId: Session['userId']
 }
 
@@ -174,8 +196,10 @@ export function createFastifySessionPreHandler(authService: AuthService) {
 
     try {
       const resolved = await authService.resolveSession({ sessionToken })
+      const user = await authService.getUser(resolved.userId)
       request.auth = {
         session: resolved,
+        user,
         userId: resolved.userId,
       }
     } catch (error) {

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -9,6 +9,7 @@ import {
   createDefaultAuthPolicy,
   isUniAuthError,
   type Session,
+  type User,
   type UniAuthErrorCode as UniAuthErrorCodeType,
   type VerificationId,
 } from '@alyldas/uniauth'
@@ -41,6 +42,7 @@ interface DemoAccount {
 
 interface ExpressRequestAuth {
   readonly session: Session
+  readonly user: User
   readonly userId: Session['userId']
 }
 
@@ -147,7 +149,11 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
     }
 
     response.status(200).json({
-      userId: auth.userId,
+      user: {
+        id: auth.user.id,
+        email: auth.user.email ?? null,
+        displayName: auth.user.displayName ?? null,
+      },
       sessionRecordId: auth.session.id,
       sessionStatus: auth.session.status,
       lastSeenAt: auth.session.lastSeenAt?.toISOString() ?? null,
@@ -281,9 +287,11 @@ function createExpressSessionMiddleware(
       const session = options.touch
         ? await authService.touchSession({ sessionId: resolved.id })
         : resolved
+      const user = await authService.getUser(session.userId)
 
       request.auth = {
         session,
+        user,
         userId: session.userId,
       }
       next()

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -10,6 +10,7 @@ import {
   createDefaultAuthPolicy,
   isUniAuthError,
   type Session,
+  type User,
   type UniAuthErrorCode as UniAuthErrorCodeType,
   type VerificationId,
 } from '@alyldas/uniauth'
@@ -32,6 +33,7 @@ interface FastifyAuthExample {
 
 interface FastifyRequestAuth {
   readonly session: Session
+  readonly user: User
   readonly userId: Session['userId']
 }
 
@@ -144,7 +146,11 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
       }
 
       return reply.status(200).send({
-        userId: auth.userId,
+        user: {
+          id: auth.user.id,
+          email: auth.user.email ?? null,
+          displayName: auth.user.displayName ?? null,
+        },
         sessionRecordId: auth.session.id,
         sessionStatus: auth.session.status,
         lastSeenAt: auth.session.lastSeenAt?.toISOString() ?? null,
@@ -223,9 +229,11 @@ function createFastifySessionPreHandler(
       const session = options.touch
         ? await authService.touchSession({ sessionId: resolved.id })
         : resolved
+      const user = await authService.getUser(session.userId)
 
       request.auth = {
         session,
+        user,
         userId: session.userId,
       }
     } catch (error) {

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -52,6 +52,7 @@ describe('package exports', () => {
     expect(core.createAuthNormalizer).toBeTypeOf('function')
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getUser).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -18,6 +18,7 @@ import {
   touchSession,
 } from './sessions.js'
 import { signIn } from './sign-in.js'
+import { getUser } from './users.js'
 import { consumeVerification, createVerification } from './verifications.js'
 import type { AuthPolicy } from './policy.js'
 import type {
@@ -57,6 +58,7 @@ import type {
   StartOtpChallengeResult,
   TouchSessionInput,
   UnlinkInput,
+  User,
   UserId,
   Verification,
 } from '../domain/types.js'
@@ -159,6 +161,10 @@ export class DefaultAuthService implements AuthService {
 
   async touchSession(input: TouchSessionInput): Promise<Session> {
     return touchSession(this.runtime, input)
+  }
+
+  async getUser(userId: UserId): Promise<User> {
+    return getUser(this.runtime, userId)
   }
 
   async getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]> {

--- a/src/application/users.ts
+++ b/src/application/users.ts
@@ -1,0 +1,7 @@
+import type { AuthServiceRuntime } from './runtime.js'
+import { getActiveUser } from './support.js'
+import type { User, UserId } from '../domain/types.js'
+
+export async function getUser(runtime: AuthServiceRuntime, userId: UserId): Promise<User> {
+  return getActiveUser(runtime, userId)
+}

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1,4 +1,4 @@
-import type { AuthIdentity, Credential, Session, Verification } from './entities.js'
+import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
 import type {
   AuthResult,
   ConsumeVerificationInput,
@@ -77,6 +77,7 @@ export interface AuthService {
   revokeUserSessions(input: RevokeUserSessionsInput): Promise<RevokeUserSessionsResult>
   resolveSession(input: ResolveSessionInput): Promise<Session>
   touchSession(input: TouchSessionInput): Promise<Session>
+  getUser(userId: UserId): Promise<User>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
   getUserSessions(userId: UserId): Promise<readonly Session[]>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -84,6 +84,7 @@ describe('DefaultAuthService', () => {
     expect(result.sessionToken).toBeTypeOf('string')
     expect(result.sessionToken).not.toBe(result.session.id)
     expect(result.session.tokenHash).not.toBe(result.sessionToken)
+    expect(await service.getUser(result.user.id)).toBe(result.user)
     expect(await service.resolveSession({ sessionToken: result.sessionToken, now })).toBe(
       result.session,
     )

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -283,10 +283,14 @@ describe('Postgres reference persistence', () => {
       first.session.id,
       second.session.id,
     ])
+    expect(await service.getUser(first.user.id)).toMatchObject({
+      id: first.user.id,
+      email: 'pg-list-sessions@example.com',
+    })
   })
 
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {
-    const { service } = await createPostgresTestKit()
+    const { service, store } = await createPostgresTestKit()
     const first = await service.signIn({
       assertion: {
         provider: 'email',
@@ -320,6 +324,10 @@ describe('Postgres reference persistence', () => {
       { id: second.session.id, status: SessionStatus.Revoked },
       { id: third.session.id, status: SessionStatus.Revoked },
     ])
+    await store.userRepo.update(first.user.id, { disabledAt: addSeconds(now, 40) })
+    await expect(service.getUser(first.user.id)).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
   })
 
   it('applies the schema and supports repository round-trips', async () => {

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -83,6 +83,10 @@ describe('DefaultAuthService edge cases', () => {
     })
 
     expect(explicitSession.session.metadata).toEqual({ manual: true })
+    expect(await defaultService.getUser(first.user.id)).toMatchObject({
+      id: first.user.id,
+      email: 'alice@example.com',
+    })
     expect(await defaultService.getUserIdentities(first.user.id)).toHaveLength(1)
     expect(
       (await defaultService.getUserSessions(first.user.id)).map((session) => session.id),
@@ -199,6 +203,11 @@ describe('DefaultAuthService edge cases', () => {
     ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
 
     await defaultStore.userRepo.update(second.user.id, { disabledAt: now })
+    expect(
+      await defaultService.getUser(second.user.id).catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
     expect(
       await defaultService.getUserIdentities(second.user.id).catch((caught: unknown) => caught),
     ).toMatchObject({


### PR DESCRIPTION
## Summary
- add a public AuthService.getUser(userId) helper for active-user reads
- expose the new read-side helper in examples and middleware recipes
- align roadmap and package smoke coverage with the new public method

## Testing
- npm run build
- npm run typecheck
- npm run check

Closes #127