### PR TITLE
feat: add account security read-side APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ license, subscription, private contract, or other written permission.
 - Exposes local session read-side helpers for token resolution, activity touch, and user session
   listing.
 - Exposes a narrow `getUser(userId)` helper for loading the active local user snapshot by id.
+- Exposes read-side helpers for credential and verification lookups through the public service
+  layer.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
@@ -517,6 +519,7 @@ contact `alyldas@ya.ru`.
 - [Development](docs/development.md)
 - [Architecture](docs/architecture.md)
 - [Backend integration recipes](docs/backend-recipes.md)
+- [Account security recipes](docs/account-security.md)
 - [Auth bridges](docs/bridges.md)
 - [Security model](docs/security.md)
 - [Threat model](docs/threat-model.md)

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -1,0 +1,130 @@
+# Account Security Recipes
+
+Use the public read-side API when you need account-security pages such as:
+
+- sign-in method management;
+- current-device and other-device session lists;
+- sign-out-current-device or sign-out-other-devices flows;
+- support-only verification inspection by id.
+
+UniAuth still does not own HTTP routes, UI, cookies, or client payload shaping. The application
+must decide what to expose and must not leak server-only fields such as `passwordHash`,
+`tokenHash`, or `secretHash`.
+
+## Recommended Read-Side Shape
+
+The minimal server-side composition usually looks like this:
+
+```ts
+const user = await authService.getUser(userId)
+const identities = await authService.getUserIdentities(userId)
+const credentials = await authService.getUserCredentials(userId)
+const sessions = await authService.getUserSessions(userId)
+```
+
+Keep the response client-safe:
+
+```ts
+return {
+  user: {
+    id: user.id,
+    email: user.email ?? null,
+    displayName: user.displayName ?? null,
+  },
+  identities: identities.map((identity) => ({
+    id: identity.id,
+    provider: identity.provider,
+    status: identity.status,
+    email: identity.email ?? null,
+    phone: identity.phone ?? null,
+  })),
+  credentials: credentials.map((credential) => ({
+    id: credential.id,
+    type: credential.type,
+    subject: credential.subject,
+    createdAt: credential.createdAt.toISOString(),
+    updatedAt: credential.updatedAt.toISOString(),
+  })),
+  sessions: sessions.map((session) => ({
+    id: session.id,
+    status: session.status,
+    createdAt: session.createdAt.toISOString(),
+    expiresAt: session.expiresAt.toISOString(),
+    lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
+    revokedAt: session.revokedAt?.toISOString() ?? null,
+  })),
+}
+```
+
+Do not serialize:
+
+- `Credential.passwordHash`
+- `Session.tokenHash`
+- `Verification.secretHash`
+
+## Device Management
+
+For device-list or active-session screens:
+
+1. resolve the current local session from the transport;
+2. load all local sessions through `authService.getUserSessions(userId)`;
+3. present a sanitized session list;
+4. revoke one or many sessions through:
+   - `authService.revokeSession(sessionId)`
+   - `authService.revokeUserSessions({ userId, exceptSessionId })`
+
+The application still owns cookie clearing, mobile token deletion, and client refresh behavior
+after a revoke.
+
+## Sign-In Method Management
+
+For sign-in method screens:
+
+1. load identities through `authService.getUserIdentities(userId)`;
+2. load credentials through `authService.getUserCredentials(userId)`;
+3. present provider ids, statuses, email or phone hints, and credential types;
+4. use `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new provider link flows for
+   mutations.
+
+Keep the same public security rules:
+
+- do not allow the last active sign-in method to disappear;
+- keep public HTTP responses neutral when mutation attempts fail;
+- require recent auth where your policy says it is required.
+
+## Verification Inspection
+
+UniAuth now exposes:
+
+```ts
+const verification = await authService.getVerification(verificationId)
+```
+
+Use it for:
+
+- polling one OTP or magic-link challenge from a trusted backend;
+- support tooling that needs to inspect whether a verification is still pending, consumed, or
+  expired;
+- server-side orchestration that needs `purpose`, `status`, and `expiresAt`.
+
+When exposing this outward, serialize only safe fields:
+
+```ts
+return {
+  id: verification.id,
+  purpose: verification.purpose,
+  status: verification.status,
+  expiresAt: verification.expiresAt.toISOString(),
+  consumedAt: verification.consumedAt?.toISOString() ?? null,
+}
+```
+
+Do not send `secretHash` to browsers, mobile clients, or untrusted callers.
+
+## Example References
+
+- [Express auth module example](../examples/express-auth/index.ts)
+- [Fastify auth module example](../examples/fastify-auth/index.ts)
+- [OTP backend wiring example](../examples/otp-backend/index.ts)
+- [Session transport recipes](session-transport.md)
+- [Backend integration recipes](backend-recipes.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,8 +34,10 @@ identities, and email/phone are optional identity attributes.
 - `resolveSession`
 - `touchSession`
 - `getUser`
+- `getUserCredentials`
 - `getUserSessions`
 - `createVerification`
+- `getVerification`
 - `consumeVerification`
 
 It delegates authorization decisions to `AuthPolicy` and storage/provider/sender work to ports.

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -122,6 +122,8 @@ Express ownership notes:
   recovery start, and OTP start.
 - Keep route-neutral errors neutral at the HTTP layer too; do not translate invalid credentials into
   account existence hints.
+- For account-security screens that list sign-in methods or devices, prefer the dedicated
+  [Account security recipes](account-security.md) instead of reading adapter internals.
 
 ## Fastify
 
@@ -193,6 +195,8 @@ Fastify ownership notes:
   rather than introducing a Fastify-specific auth dispatcher.
 - For a fuller copyable recipe, including token extraction helpers and failure mapping, see
   [Session transport recipes](session-transport.md).
+- For sign-in-method and device-management screens, compose the public read-side methods described
+  in [Account security recipes](account-security.md).
 
 ## Nest
 

--- a/docs/otp-delivery.md
+++ b/docs/otp-delivery.md
@@ -46,6 +46,10 @@ For a small HTTP-facing composition example around `startOtpChallenge(...)`,
 `finishOtpSignIn(...)`, app-owned sender wiring, and session-cookie issuance, see
 [OTP backend wiring example](../examples/otp-backend/index.ts).
 
+Applications that need to poll or inspect one verification record after creation can do that
+through the public `authService.getVerification(verificationId)` read-side helper. Keep any
+serialized response narrow and never expose `secretHash` outside trusted server-side tooling.
+
 ## What Core Owns
 
 UniAuth owns only the generic auth semantics:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -208,9 +208,13 @@ Tracking issues: #127.
 
 ## Next Release
 
-### v0.24 - Backlog To Be Defined
+### v0.24 - Account Security Read Side
 
-- Next stabilizing or integrator-facing scope after the user read-side release.
+- Public `getUserCredentials(userId)` and `getVerification(verificationId)` APIs.
+- Account-security recipes for sign-in-method and device-management screens on top of the public
+  service layer.
+
+Tracking issues: #131, #132, #133.
 
 ## Versioning
 

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -6,6 +6,7 @@ import {
   SessionStatus,
   UniAuthErrorCode,
   VerificationPurpose,
+  type Credential,
   createDefaultAuthPolicy,
   isUniAuthError,
   type Session,
@@ -160,6 +161,54 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
     })
   })
 
+  app.get(
+    '/account/security',
+    sessionMiddleware,
+    requireExpressSession,
+    async (request, response, next) => {
+      try {
+        const auth = request.auth
+
+        if (!auth) {
+          response.status(401).json({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+          return
+        }
+
+        const [identities, credentials, sessions] = await Promise.all([
+          authService.getUserIdentities(auth.user.id),
+          authService.getUserCredentials(auth.user.id),
+          authService.getUserSessions(auth.user.id),
+        ])
+
+        response.status(200).json({
+          user: {
+            id: auth.user.id,
+            email: auth.user.email ?? null,
+            displayName: auth.user.displayName ?? null,
+          },
+          identities: identities.map((identity) => ({
+            id: identity.id,
+            provider: identity.provider,
+            status: identity.status,
+            email: identity.email ?? null,
+            phone: identity.phone ?? null,
+          })),
+          credentials: credentials.map((credential) => serializeCredentialForClient(credential)),
+          sessions: sessions.map((session) => ({
+            id: session.id,
+            status: session.status,
+            createdAt: session.createdAt.toISOString(),
+            expiresAt: session.expiresAt.toISOString(),
+            lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
+            revokedAt: session.revokedAt?.toISOString() ?? null,
+          })),
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
   app.use((error: unknown, _request: Request, response: Response, next: NextFunction): void => {
     if (response.headersSent) {
       next(error)
@@ -211,6 +260,7 @@ export async function runExpressAuthExample(): Promise<void> {
             'POST /auth/otp/start',
             'POST /auth/otp/finish',
             'GET /me',
+            'GET /account/security',
           ],
           note: 'OTP codes are printed by the application-owned email sender.',
         },
@@ -266,6 +316,16 @@ function writeSessionCookie(response: Response, sessionToken: string): void {
     secure: true,
     path: '/',
   })
+}
+
+function serializeCredentialForClient(credential: Credential) {
+  return {
+    id: credential.id,
+    type: credential.type,
+    subject: credential.subject,
+    createdAt: credential.createdAt.toISOString(),
+    updatedAt: credential.updatedAt.toISOString(),
+  }
 }
 
 function createExpressSessionMiddleware(

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -7,6 +7,7 @@ import {
   SessionStatus,
   UniAuthErrorCode,
   VerificationPurpose,
+  type Credential,
   createDefaultAuthPolicy,
   isUniAuthError,
   type Session,
@@ -158,6 +159,50 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
     },
   )
 
+  app.get(
+    '/account/security',
+    {
+      preHandler: [sessionPreHandler, requireFastifySession],
+    },
+    async (request, reply) => {
+      const auth = request.auth
+
+      if (!auth) {
+        return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+      }
+
+      const [identities, credentials, sessions] = await Promise.all([
+        authService.getUserIdentities(auth.user.id),
+        authService.getUserCredentials(auth.user.id),
+        authService.getUserSessions(auth.user.id),
+      ])
+
+      return reply.status(200).send({
+        user: {
+          id: auth.user.id,
+          email: auth.user.email ?? null,
+          displayName: auth.user.displayName ?? null,
+        },
+        identities: identities.map((identity) => ({
+          id: identity.id,
+          provider: identity.provider,
+          status: identity.status,
+          email: identity.email ?? null,
+          phone: identity.phone ?? null,
+        })),
+        credentials: credentials.map((credential) => serializeCredentialForClient(credential)),
+        sessions: sessions.map((session) => ({
+          id: session.id,
+          status: session.status,
+          createdAt: session.createdAt.toISOString(),
+          expiresAt: session.expiresAt.toISOString(),
+          lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
+          revokedAt: session.revokedAt?.toISOString() ?? null,
+        })),
+      })
+    },
+  )
+
   app.setErrorHandler((error, _request, reply) => {
     if (isFastifyPublicRequestError(error)) {
       reply.status(400).send({ error: REQUEST_CANNOT_BE_COMPLETED_MESSAGE })
@@ -198,7 +243,12 @@ export async function runFastifyAuthExample(): Promise<void> {
         type: 'demo-server',
         framework: 'fastify',
         port,
-        routes: ['POST /auth/otp/start', 'POST /auth/otp/finish', 'GET /me'],
+        routes: [
+          'POST /auth/otp/start',
+          'POST /auth/otp/finish',
+          'GET /me',
+          'GET /account/security',
+        ],
         note: 'OTP codes are printed by the application-owned email sender.',
       },
       null,
@@ -278,6 +328,16 @@ function isFastifyPublicRequestError(error: unknown): boolean {
   const candidate = error as { statusCode?: unknown; validation?: unknown }
 
   return candidate.statusCode === 400 || candidate.validation !== undefined
+}
+
+function serializeCredentialForClient(credential: Credential) {
+  return {
+    id: credential.id,
+    type: credential.type,
+    subject: credential.subject,
+    createdAt: credential.createdAt.toISOString(),
+    updatedAt: credential.updatedAt.toISOString(),
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/examples/otp-backend/index.ts
+++ b/examples/otp-backend/index.ts
@@ -4,6 +4,7 @@ import {
   OtpChannel,
   VerificationPurpose,
   type EmailSender,
+  type Verification,
   type VerificationId,
 } from '@alyldas/uniauth'
 import { InMemoryAuthStore, InMemoryRateLimiter } from '@alyldas/uniauth/testing'
@@ -113,6 +114,29 @@ async function postOtpFinish(
   }
 }
 
+async function getVerificationStatus(verificationId: VerificationId): Promise<
+  JsonResponse<{
+    verificationId: string
+    purpose: Verification['purpose']
+    status: Verification['status']
+    expiresAt: string
+    consumedAt: string | null
+  }>
+> {
+  const verification = await authService.getVerification(verificationId)
+
+  return {
+    status: 200,
+    body: {
+      verificationId: verification.id,
+      purpose: verification.purpose,
+      status: verification.status,
+      expiresAt: verification.expiresAt.toISOString(),
+      consumedAt: verification.consumedAt?.toISOString() ?? null,
+    },
+  }
+}
+
 function extractOtpCode(message: DeliveredEmail): string {
   const match = /\b(\d{4,8})\b/u.exec(message.text)
 
@@ -151,18 +175,26 @@ export async function runOtpBackendExample(): Promise<void> {
     throw new Error('Expected the application-owned sender to capture one email message.')
   }
 
+  const pendingVerification = await getVerificationStatus(
+    parseVerificationId(startResponse.body.verificationId),
+  )
   const finishResponse = await postOtpFinish({
     body: {
       verificationId: startResponse.body.verificationId,
       code: extractOtpCode(deliveredEmail),
     },
   })
+  const consumedVerification = await getVerificationStatus(
+    parseVerificationId(startResponse.body.verificationId),
+  )
 
   console.log({
     startStatus: startResponse.status,
+    pendingVerification: pendingVerification.body,
     deliveredTo: deliveredEmail.to,
     deliveredText: deliveredEmail.text,
     finishStatus: finishResponse.status,
+    consumedVerification: consumedVerification.body,
     sessionCookie: finishResponse.cookies?.[0],
     userId: finishResponse.body.userId,
   })

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -53,6 +53,8 @@ describe('package exports', () => {
     expect(core.createHmacSecretHasher).toBeTypeOf('function')
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUser).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getUserCredentials).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,4 +1,5 @@
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
+import { getUserCredentials } from './credentials.js'
 import { finishEmailMagicLinkSignIn, startEmailMagicLinkSignIn } from './magic-link.js'
 import { finishOtpChallenge, finishOtpSignIn, startOtpChallenge } from './otp.js'
 import {
@@ -19,7 +20,7 @@ import {
 } from './sessions.js'
 import { signIn } from './sign-in.js'
 import { getUser } from './users.js'
-import { consumeVerification, createVerification } from './verifications.js'
+import { consumeVerification, createVerification, getVerification } from './verifications.js'
 import type { AuthPolicy } from './policy.js'
 import type {
   AuthIdentity,
@@ -61,6 +62,7 @@ import type {
   User,
   UserId,
   Verification,
+  VerificationId,
 } from '../domain/types.js'
 import type {
   AuthServiceInfrastructure,
@@ -171,6 +173,10 @@ export class DefaultAuthService implements AuthService {
     return getUserIdentities(this.runtime, userId)
   }
 
+  async getUserCredentials(userId: UserId): Promise<readonly Credential[]> {
+    return getUserCredentials(this.runtime, userId)
+  }
+
   async getUserSessions(userId: UserId): Promise<readonly Session[]> {
     return getUserSessions(this.runtime, userId)
   }
@@ -181,6 +187,10 @@ export class DefaultAuthService implements AuthService {
 
   async createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult> {
     return createVerification(this.runtime, input)
+  }
+
+  async getVerification(verificationId: VerificationId): Promise<Verification> {
+    return getVerification(this.runtime, verificationId)
   }
 
   async consumeVerification(input: ConsumeVerificationInput): Promise<Verification> {

--- a/src/application/credentials.ts
+++ b/src/application/credentials.ts
@@ -1,0 +1,11 @@
+import type { AuthServiceRuntime } from './runtime.js'
+import { getActiveUser } from './support.js'
+import type { Credential, UserId } from '../domain/types.js'
+
+export async function getUserCredentials(
+  runtime: AuthServiceRuntime,
+  userId: UserId,
+): Promise<readonly Credential[]> {
+  await getActiveUser(runtime, userId)
+  return runtime.repos.credentialRepo.listByUserId(userId)
+}

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -31,6 +31,19 @@ export async function createVerification(
   })
 }
 
+export async function getVerification(
+  runtime: AuthServiceRuntime,
+  verificationId: Verification['id'],
+): Promise<Verification> {
+  const verification = await runtime.repos.verificationRepo.findById(verificationId)
+
+  if (!verification) {
+    throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+  }
+
+  return verification
+}
+
 export async function consumeVerification(
   runtime: AuthServiceRuntime,
   input: ConsumeVerificationInput,

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -79,8 +79,10 @@ export interface AuthService {
   touchSession(input: TouchSessionInput): Promise<Session>
   getUser(userId: UserId): Promise<User>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
+  getUserCredentials(userId: UserId): Promise<readonly Credential[]>
   getUserSessions(userId: UserId): Promise<readonly Session[]>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>
   createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult>
+  getVerification(verificationId: VerificationId): Promise<Verification>
   consumeVerification(input: ConsumeVerificationInput): Promise<Verification>
 }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -114,6 +114,36 @@ describe('DefaultAuthService', () => {
     ).toBe(touched)
   })
 
+  it('reads local credentials and verifications through the public service surface', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'credential-reader',
+        email: 'credential-reader@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const credential = await service.setPassword({
+      userId: signedIn.user.id,
+      email: 'credential-reader@example.com',
+      password: 'secret-password',
+      now,
+    })
+    const createdVerification = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'credential-reader@example.com',
+      secret: '123456',
+      now,
+    })
+
+    expect(await service.getUserCredentials(signedIn.user.id)).toEqual([credential])
+    expect(await service.getVerification(createdVerification.verification.id)).toEqual(
+      createdVerification.verification,
+    )
+  })
+
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {
     const { service, store } = createInMemoryAuthKit()
     const signedIn = await service.signIn({ assertion: assertion(), now })

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -289,6 +289,36 @@ describe('Postgres reference persistence', () => {
     })
   })
 
+  it('reads credentials and verifications through the public service surface on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-read-side-credential',
+        email: 'pg-read-side-credential@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const credential = await service.setPassword({
+      userId: signedIn.user.id,
+      email: 'pg-read-side-credential@example.com',
+      password: 'pg-password',
+      now: addSeconds(now, 1),
+    })
+    const createdVerification = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'pg-read-side-credential@example.com',
+      secret: '654321',
+      now: addSeconds(now, 2),
+    })
+
+    expect(await service.getUserCredentials(signedIn.user.id)).toEqual([credential])
+    expect(await service.getVerification(createdVerification.verification.id)).toEqual(
+      createdVerification.verification,
+    )
+  })
+
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {
     const { service, store } = await createPostgresTestKit()
     const first = await service.signIn({

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -8,6 +8,7 @@ import {
   asIdentityId,
   asSessionId,
   asUserId,
+  asVerificationId,
   createDefaultAuthPolicy,
 } from '../src'
 import { InMemoryAuthStore, InMemoryPasswordHasher, createInMemoryAuthKit } from '../src/testing'
@@ -217,6 +218,18 @@ describe('DefaultAuthService edge cases', () => {
       await defaultService.getUserSessions(second.user.id).catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.UserNotFound,
+    })
+    expect(
+      await defaultService.getUserCredentials(second.user.id).catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    expect(
+      await defaultService
+        .getVerification(asVerificationId('missing-verification'))
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
     })
     expect(
       await defaultService


### PR DESCRIPTION
## Summary
- add public getUserCredentials(userId) and getVerification(verificationId) service helpers
- add account-security and verification-status integration recipes
- extend Express, Fastify, and OTP examples to use the new read-side surface

## Testing
- npm run build
- npm run typecheck
- npm run check

Closes #131
Closes #132
Closes #133