### PR TITLE
docs: sync roadmap after v0.24.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,8 +206,6 @@ Tracking issues: #122.
 
 Tracking issues: #127.
 
-## Next Release
-
 ### v0.24 - Account Security Read Side
 
 - Public `getUserCredentials(userId)` and `getVerification(verificationId)` APIs.
@@ -215,6 +213,12 @@ Tracking issues: #127.
   service layer.
 
 Tracking issues: #131, #132, #133.
+
+## Next Release
+
+### v0.25 - Backlog To Be Defined
+
+- Next stabilizing or integrator-facing scope after the account-security read-side release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.24 account-security read-side work into the released section
- define v0.25 as the next-release placeholder
- keep roadmap aligned with release labels after v0.24.0

## Testing
- npm run check