### PR TITLE
Fix CodeQL alert: harden in-memory password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ console.log(magicResult.identity.provider === EMAIL_MAGIC_LINK_PROVIDER_ID)
 
 Password credentials use a dedicated `CredentialRepo` and a `PasswordHasher` port. Production apps
 should provide an adapter backed by their chosen password hashing runtime and parameters; the
-in-memory testing kit only ships a deterministic test hasher.
+in-memory testing kit only ships a low-cost `scrypt` test hasher.
 
 ```ts
 const passwordHasher: PasswordHasher = {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ and query parameter conventions remain outside core.
 Password credentials use `CredentialRepo` for stored password hashes and `PasswordHasher` for
 hash/verify work. Core does not bundle a password hashing runtime; production applications pass an
 adapter backed by their chosen algorithm, parameters, and secret-loading policy, while the testing
-package provides only a deterministic test hasher. Password identity records use the local
+package provides only a low-cost `scrypt` test hasher. Password identity records use the local
 `password` provider so unlink and last-sign-in-method policy remains shared with other identities.
 
 Verification hashing is delegated to `SecretHasher`. The default hasher uses salted `scrypt` so
@@ -128,7 +128,7 @@ boundaries for link, unlink, merge, session, and verification flows.
 ## Testing Adapter
 
 `@alyldas/uniauth/testing` provides an in-memory implementation for tests, demos, and examples. It
-includes in-memory email and SMS senders, a rate limiter, and a deterministic password hasher so
+includes in-memory email and SMS senders, a rate limiter, and a low-cost `scrypt` password hasher so
 local auth flows can be exercised without SMTP, SMS, Redis, or password-hashing runtime setup. It is
 not a production persistence adapter. The public testing entry point stays stable while internal
 modules keep store/repository state, sender fakes, and support utilities separate so persistence

--- a/src/testing/in-memory/support.ts
+++ b/src/testing/in-memory/support.ts
@@ -4,7 +4,17 @@ import type {
   RateLimitDecision,
   RateLimiter,
 } from '../../ports.js'
-import { hashSecret } from '../../utils/secrets.js'
+import { createScryptSecretHasher } from '../../utils/secrets.js'
+
+const TEST_PASSWORD_HASH_PREFIX = 'test-password:'
+const testPasswordScryptHasher = createScryptSecretHasher({
+  cost: 16,
+  blockSize: 1,
+  parallelization: 1,
+  keyLength: 16,
+  saltByteLength: 8,
+  maxmem: 1024 * 1024,
+})
 
 export class InMemoryRateLimiter implements RateLimiter {
   private readonly attempts: RateLimitAttempt[] = []
@@ -30,10 +40,17 @@ export class InMemoryRateLimiter implements RateLimiter {
 
 export class InMemoryPasswordHasher implements PasswordHasher {
   async hash(password: string): Promise<string> {
-    return `test-password:${hashSecret(password)}`
+    return `${TEST_PASSWORD_HASH_PREFIX}${await testPasswordScryptHasher.hash(password)}`
   }
 
   async verify(password: string, passwordHash: string): Promise<boolean> {
-    return passwordHash === (await this.hash(password))
+    if (!passwordHash.startsWith(TEST_PASSWORD_HASH_PREFIX)) {
+      return false
+    }
+
+    return await testPasswordScryptHasher.verify(
+      password,
+      passwordHash.slice(TEST_PASSWORD_HASH_PREFIX.length),
+    )
   }
 }

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -18,7 +18,7 @@ import {
   type Session,
   type Verification,
 } from '../src'
-import { InMemoryAuthStore } from '../src/testing'
+import { InMemoryAuthStore, InMemoryPasswordHasher } from '../src/testing'
 import { identity, now, user } from './helpers.js'
 
 describe('InMemoryAuthStore', () => {
@@ -90,12 +90,13 @@ describe('InMemoryAuthStore', () => {
       providerUserId: 'oauth-alice-2',
     })
 
+    const passwordHasher = new InMemoryPasswordHasher()
     const credential: Credential = {
       id: asCredentialId('credential-1'),
       userId: createdUser.id,
       type: CredentialType.Password,
       subject: 'alice@example.com',
-      passwordHash: hashSecret('password'),
+      passwordHash: await passwordHasher.hash('password'),
       createdAt: now,
       updatedAt: now,
     }
@@ -105,7 +106,7 @@ describe('InMemoryAuthStore', () => {
       userId: otherUser.id,
       type: CredentialType.Password,
       subject: 'second@example.com',
-      passwordHash: hashSecret('password'),
+      passwordHash: await passwordHasher.hash('password'),
       createdAt: now,
       updatedAt: now,
     }
@@ -114,7 +115,7 @@ describe('InMemoryAuthStore', () => {
       userId: createdUser.id,
       type: CredentialType.Password,
       subject: 'same-user@example.com',
-      passwordHash: hashSecret('password'),
+      passwordHash: await passwordHasher.hash('password'),
       createdAt: now,
       updatedAt: now,
     }
@@ -135,10 +136,11 @@ describe('InMemoryAuthStore', () => {
       code: UniAuthErrorCode.CredentialAlreadyExists,
     })
     expect(await store.credentialRepo.create(secondCredential)).toBe(secondCredential)
+    const updatedPasswordHash = await passwordHasher.hash('new')
     expect(
-      await store.credentialRepo.update(credential.id, { passwordHash: hashSecret('new') }),
+      await store.credentialRepo.update(credential.id, { passwordHash: updatedPasswordHash }),
     ).toMatchObject({
-      passwordHash: hashSecret('new'),
+      passwordHash: updatedPasswordHash,
     })
     expect(
       await store.credentialRepo
@@ -289,5 +291,17 @@ describe('InMemoryAuthStore', () => {
     expect(store.listAuditEvents().map((event) => event.id)).toEqual([
       asAuditEventId('audit-nested'),
     ])
+  })
+
+  it('hashes in-memory passwords with the test scrypt adapter', async () => {
+    const passwordHasher = new InMemoryPasswordHasher()
+    const passwordHash = await passwordHasher.hash('correct-password')
+
+    expect(passwordHash).toMatch(/^test-password:scrypt:/)
+    expect(await passwordHasher.verify('correct-password', passwordHash)).toBe(true)
+    expect(await passwordHasher.verify('wrong-password', passwordHash)).toBe(false)
+    expect(await passwordHasher.verify('correct-password', 'sha256:not-a-password-hash')).toBe(
+      false,
+    )
   })
 })

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -52,7 +52,7 @@ describe('password credentials', () => {
     expect(credential.type).toBe(CredentialType.Password)
     expect(credential.subject).toBe('alice@example.com')
     expect(credential.passwordHash).not.toBe('correct horse battery staple')
-    expect(credential.passwordHash).toMatch(/^test-password:sha256:/)
+    expect(credential.passwordHash).toMatch(/^test-password:scrypt:/)
     expect(result.user.id).toBe(initial.user.id)
     expect(result.identity.provider).toBe(PASSWORD_PROVIDER_ID)
     expect(result.session.status).toBe(SessionStatus.Active)


### PR DESCRIPTION
## Summary
- replace the in-memory password helper's SHA-256 password hash path with a dedicated low-cost scrypt test hasher
- keep random token and verification hashing on the existing SecretHasher APIs
- update tests and docs so password fixtures use adapter-produced hashes and the expected format is test-password:scrypt

## Root cause
InMemoryPasswordHasher.hash() passed user password input into hashSecret(), which is a fast SHA-256 helper intended for random secrets and tokens. CodeQL correctly reported this as insufficient password hashing.

## Validation
- npm run check

Fixes #141