### PR TITLE
Fix CodeQL alert: seal example session cookies

### DIFF
--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -74,7 +74,7 @@ app.post('/auth/password/sign-in', async (req, res, next) => {
       password: req.body.password,
     })
 
-    res.cookie('session', result.sessionToken, {
+    res.cookie('session', sealSessionToken(result.sessionToken), {
       httpOnly: true,
       sameSite: 'lax',
       secure: true,
@@ -149,7 +149,7 @@ app.post('/auth/magic/finish', async (request, reply) => {
     secret: request.body.secret,
   })
 
-  reply.setCookie('session', result.sessionToken, {
+  reply.setCookie('session', sealSessionToken(result.sessionToken), {
     httpOnly: true,
     sameSite: 'lax',
     secure: true,
@@ -220,7 +220,7 @@ export class PasswordAuthController {
   ) {
     const result = await this.auth.signInWithPassword(body)
 
-    res.cookie('session', result.sessionToken, {
+    res.cookie('session', sealSessionToken(result.sessionToken), {
       httpOnly: true,
       sameSite: 'lax',
       secure: true,
@@ -256,7 +256,7 @@ export async function POST(request: Request) {
     secret: body.secret,
   })
 
-  cookies().set('session', result.sessionToken, {
+  cookies().set('session', sealSessionToken(result.sessionToken), {
     httpOnly: true,
     sameSite: 'lax',
     secure: true,
@@ -306,6 +306,7 @@ application-level concerns whenever a browser can trigger authenticated state ch
 
 Minimum expectations:
 
+- seal or encrypt raw bearer session tokens before storing them in browser cookies;
 - use `httpOnly`, `secure`, and explicit `sameSite` for session cookies;
 - scope cookies to the smallest practical path/domain;
 - protect browser POST routes with CSRF controls or same-site guarantees that actually match your

--- a/docs/messenger-providers.md
+++ b/docs/messenger-providers.md
@@ -114,7 +114,7 @@ Messenger providers stay app-owned at bootstrap and transport layers:
 - load bot tokens in server-only code;
 - register providers in the same bootstrap where `ProviderRegistry` and `AuthService` are created;
 - pass raw signed `initData` from your HTTP or RPC boundary into `finishInput.payload`;
-- issue browser cookies, redirects, and CSRF/state handling in the application layer after
+- issue sealed browser cookies, redirects, and CSRF/state handling in the application layer after
   `service.signIn(...)` returns a local session.
 
 ### Telegram Mini App Route
@@ -145,7 +145,7 @@ export async function postTelegramMiniAppSignIn(request: Request) {
     status: 200,
     sessionCookie: {
       name: 'session',
-      value: result.sessionToken,
+      value: sealSessionToken(result.sessionToken),
       httpOnly: true,
       secure: true,
       sameSite: 'lax',
@@ -186,7 +186,7 @@ export async function postMaxWebAppSignIn(request: Request) {
     status: 200,
     sessionCookie: {
       name: 'session',
-      value: result.sessionToken,
+      value: sealSessionToken(result.sessionToken),
       httpOnly: true,
       secure: true,
       sameSite: 'lax',

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -12,11 +12,12 @@ This document keeps the boundary explicit for three common transports:
 
 ## Browser Cookies
 
-Browser-first applications usually map `result.sessionToken` into a session cookie immediately after
-a successful finish flow.
+Browser-first applications usually map `result.sessionToken` into a sealed or encrypted session
+cookie immediately after a successful finish flow.
 
 Minimum expectations:
 
+- seal or encrypt the raw bearer token before writing the cookie value;
 - `httpOnly: true`;
 - `secure: true` in production;
 - explicit `sameSite`;
@@ -31,7 +32,7 @@ const result = await authService.finishOtpSignIn({
   secret: body.code,
 })
 
-response.cookie('session', result.sessionToken, {
+response.cookie('session', sealSessionToken(result.sessionToken), {
   httpOnly: true,
   secure: true,
   sameSite: 'lax',
@@ -39,12 +40,16 @@ response.cookie('session', result.sessionToken, {
 })
 ```
 
-On later requests, resolve the token through UniAuth instead of treating `Session.id` as the client
-credential:
+`sealSessionToken(...)` and `unsealSessionToken(...)` are application-owned helpers backed by key
+material from the deployment environment. The runnable examples in this repository use
+`UNIAUTH_EXAMPLE_SESSION_COOKIE_KEY` for that key material. On later requests, unseal the cookie and
+resolve the token through UniAuth instead of treating `Session.id` as the client credential:
 
 ```ts
+const sessionToken = unsealSessionToken(request.cookies.session)
+
 const session = await authService.resolveSession({
-  sessionToken: request.cookies.session,
+  sessionToken,
 })
 const user = await authService.getUser(session.userId)
 
@@ -95,7 +100,8 @@ declare global {
 export function createExpressSessionMiddleware(authService: AuthService) {
   return async (request: Request, response: Response, next: NextFunction): Promise<void> => {
     const sessionToken =
-      readBearerToken(request.headers.authorization) ?? readCookieToken(request.headers.cookie)
+      readBearerToken(request.headers.authorization) ??
+      unsealSessionToken(readCookieToken(request.headers.cookie))
 
     if (!sessionToken) {
       next()
@@ -188,7 +194,8 @@ declare module 'fastify' {
 export function createFastifySessionPreHandler(authService: AuthService) {
   return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
     const sessionToken =
-      readBearerToken(request.headers.authorization) ?? request.cookies.session?.trim()
+      readBearerToken(request.headers.authorization) ??
+      unsealSessionToken(request.cookies.session?.trim())
 
     if (!sessionToken) {
       return

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -28,6 +28,11 @@ import {
   readBearerToken,
   readCookieHeaderToken,
 } from '../shared/http.js'
+import {
+  assertSessionCookieSealingConfigured,
+  sealSessionCookieValue,
+  unsealSessionCookieValue,
+} from '../shared/session-cookie.js'
 import { serializeAccountSecuritySnapshot } from '../shared/views.js'
 
 interface ExpressAuthExample {
@@ -62,6 +67,8 @@ class RequestValidationError extends Error {
 }
 
 export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
+  assertSessionCookieSealingConfigured()
+
   const store = new InMemoryAuthStore()
   const emailSender = new ConsoleEmailSender('express')
   const authService = new DefaultAuthService({
@@ -295,7 +302,7 @@ function parseVerificationId(value: string): VerificationId {
 }
 
 function writeSessionCookie(response: Response, sessionToken: string): void {
-  response.cookie('session', sessionToken, {
+  response.cookie('session', sealSessionCookieValue(sessionToken), {
     httpOnly: true,
     sameSite: 'lax',
     secure: true,
@@ -353,7 +360,7 @@ function requireExpressSession(request: Request, response: Response, next: NextF
 function readExpressSessionToken(request: Request): string | undefined {
   return (
     readBearerToken(request.headers.authorization) ??
-    readCookieHeaderToken(request.headers.cookie, 'session')
+    unsealSessionCookieValue(readCookieHeaderToken(request.headers.cookie, 'session'))
   )
 }
 

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -25,6 +25,11 @@ import {
   readBearerToken,
   readCookieValue,
 } from '../shared/http.js'
+import {
+  assertSessionCookieSealingConfigured,
+  sealSessionCookieValue,
+  unsealSessionCookieValue,
+} from '../shared/session-cookie.js'
 import { serializeAccountSecuritySnapshot } from '../shared/views.js'
 
 interface FastifyAuthExample {
@@ -46,6 +51,8 @@ declare module 'fastify' {
 }
 
 export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
+  assertSessionCookieSealingConfigured()
+
   const store = new InMemoryAuthStore()
   const emailSender = new ConsoleEmailSender('fastify')
   const authService = new DefaultAuthService({
@@ -121,7 +128,7 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
         metadata: { transport: 'fastify', route: 'otp-finish' },
       })
 
-      reply.setCookie('session', result.sessionToken, {
+      reply.setCookie('session', sealSessionCookieValue(result.sessionToken), {
         httpOnly: true,
         sameSite: 'lax',
         secure: true,
@@ -289,7 +296,10 @@ async function requireFastifySession(request: FastifyRequest, reply: FastifyRepl
 }
 
 function readFastifySessionToken(request: FastifyRequest): string | undefined {
-  return readBearerToken(request.headers.authorization) ?? readCookieValue(request.cookies.session)
+  return (
+    readBearerToken(request.headers.authorization) ??
+    unsealSessionCookieValue(readCookieValue(request.cookies.session))
+  )
 }
 
 const neutralPublicErrorCodes = new Set<UniAuthErrorCodeType>([

--- a/examples/oauth-oidc/index.ts
+++ b/examples/oauth-oidc/index.ts
@@ -16,6 +16,10 @@ import {
   InMemoryProviderRegistry,
   InMemoryRateLimiter,
 } from '@alyldas/uniauth/testing'
+import {
+  assertSessionCookieSealingConfigured,
+  sealSessionCookieValue,
+} from '../shared/session-cookie.js'
 
 interface CallbackRequest {
   readonly query: {
@@ -177,10 +181,10 @@ function assertStateMatches(expected: string, received: string): void {
   }
 }
 
-function buildSessionCookie(sessionId: string): SessionCookie {
+function buildSessionCookie(sessionToken: string): SessionCookie {
   return {
     name: 'session',
-    value: sessionId,
+    value: sealSessionCookieValue(sessionToken),
     httpOnly: true,
     sameSite: 'lax',
     secure: true,
@@ -242,6 +246,8 @@ async function finishOidcCallback(request: CallbackRequest): Promise<RedirectRes
 }
 
 export async function runOAuthOidcExample(): Promise<void> {
+  assertSessionCookieSealingConfigured()
+
   const response = await finishOidcCallback({
     query: {
       code: 'demo-authorization-code',

--- a/examples/otp-backend/index.ts
+++ b/examples/otp-backend/index.ts
@@ -8,6 +8,10 @@ import {
   type VerificationId,
 } from '@alyldas/uniauth'
 import { InMemoryAuthStore, InMemoryRateLimiter } from '@alyldas/uniauth/testing'
+import {
+  assertSessionCookieSealingConfigured,
+  sealSessionCookieValue,
+} from '../shared/session-cookie.js'
 import { serializeVerificationStatusView } from '../shared/views.js'
 
 interface JsonRequest<TBody> {
@@ -68,10 +72,10 @@ const authService = new DefaultAuthService({
   rateLimiter: new InMemoryRateLimiter(),
 })
 
-function buildSessionCookie(sessionId: string): SessionCookie {
+function buildSessionCookie(sessionToken: string): SessionCookie {
   return {
     name: 'session',
-    value: sessionId,
+    value: sealSessionCookieValue(sessionToken),
     httpOnly: true,
     sameSite: 'lax',
     secure: true,
@@ -153,6 +157,8 @@ function parseVerificationId(value: string): VerificationId {
 }
 
 export async function runOtpBackendExample(): Promise<void> {
+  assertSessionCookieSealingConfigured()
+
   const startResponse = await postOtpStart({
     body: {
       email: 'alice@example.com',

--- a/examples/shared/session-cookie.ts
+++ b/examples/shared/session-cookie.ts
@@ -1,0 +1,74 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+const SESSION_COOKIE_KEY_ENV = 'UNIAUTH_EXAMPLE_SESSION_COOKIE_KEY'
+const SESSION_COOKIE_SEAL_VERSION = 'v1'
+const SESSION_COOKIE_CIPHER = 'aes-256-gcm'
+const SESSION_COOKIE_IV_BYTES = 12
+const SESSION_COOKIE_MIN_KEY_LENGTH = 32
+
+export function sealSessionCookieValue(sessionToken: string): string {
+  const iv = randomBytes(SESSION_COOKIE_IV_BYTES)
+  const cipher = createCipheriv(SESSION_COOKIE_CIPHER, readSessionCookieKey(), iv)
+  const encrypted = Buffer.concat([cipher.update(sessionToken, 'utf8'), cipher.final()])
+
+  return [
+    SESSION_COOKIE_SEAL_VERSION,
+    iv.toString('base64url'),
+    cipher.getAuthTag().toString('base64url'),
+    encrypted.toString('base64url'),
+  ].join('.')
+}
+
+export function unsealSessionCookieValue(value: string | undefined): string | undefined {
+  const sealedValue = value?.trim()
+
+  if (!sealedValue) {
+    return undefined
+  }
+
+  const [version, ivRaw, tagRaw, encryptedRaw, extra] = sealedValue.split('.')
+
+  if (
+    version !== SESSION_COOKIE_SEAL_VERSION ||
+    !ivRaw ||
+    !tagRaw ||
+    !encryptedRaw ||
+    extra !== undefined
+  ) {
+    return undefined
+  }
+
+  try {
+    const decipher = createDecipheriv(
+      SESSION_COOKIE_CIPHER,
+      readSessionCookieKey(),
+      Buffer.from(ivRaw, 'base64url'),
+    )
+    decipher.setAuthTag(Buffer.from(tagRaw, 'base64url'))
+
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(encryptedRaw, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8')
+
+    return decrypted || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function assertSessionCookieSealingConfigured(): void {
+  void readSessionCookieKey()
+}
+
+function readSessionCookieKey(): Buffer {
+  const keyMaterial = process.env[SESSION_COOKIE_KEY_ENV]?.trim()
+
+  if (!keyMaterial || keyMaterial.length < SESSION_COOKIE_MIN_KEY_LENGTH) {
+    throw new Error(
+      `${SESSION_COOKIE_KEY_ENV} must contain at least ${SESSION_COOKIE_MIN_KEY_LENGTH} random characters.`,
+    )
+  }
+
+  return createHash('sha256').update(keyMaterial).digest()
+}


### PR DESCRIPTION
## Summary
- add an AES-GCM session cookie sealing helper for runnable examples
- store sealed session cookie values in Express, Fastify, OTP backend, and OAuth/OIDC examples
- unseal cookie values before calling resolveSession while keeping Authorization bearer tokens unchanged
- update docs to recommend sealed cookie values instead of raw session tokens

## Root cause
The Express example wrote the raw UniAuth sessionToken directly into the session cookie. Even with HttpOnly, Secure, SameSite, and path attributes, CodeQL treats storing the bearer secret as a clear-text cookie value.

## Validation
- npm run check

Fixes #142