### PR TITLE
feat: add account security snapshot read-side API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ license, subscription, private contract, or other written permission.
 - Exposes read-side helpers for credential and verification lookups through the public service
   layer.
 - Exposes safe projection helpers for account-security and verification-status read-side flows.
+- Exposes an aggregated `getAccountSecuritySnapshot(userId)` read-side API for account-security
+  screens.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
 - Runs transaction-aware account merge over identities, credentials, sessions, and audit decisions
@@ -275,16 +277,11 @@ const result = await service.signIn({
 })
 ```
 
-For account-security or verification-status pages, prefer the safe projection helpers instead of
-serializing raw entities directly:
+For account-security or verification-status pages, prefer the built-in read-side and projection
+helpers instead of serializing raw entities directly:
 
 ```ts
-const snapshot = toAccountSecuritySnapshot({
-  user,
-  identities,
-  credentials,
-  sessions,
-})
+const snapshot = await service.getAccountSecuritySnapshot(userId)
 
 const verificationStatus = toVerificationStatusView(verification)
 ```

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -11,15 +11,10 @@ UniAuth still does not own HTTP routes, UI, cookies, or client payload shaping. 
 must decide what to expose and must not leak server-only fields such as `passwordHash`,
 `tokenHash`, or `secretHash`.
 
-Prefer the built-in safe projection helpers for these flows:
+Prefer the built-in read-side and projection helpers for these flows:
 
 ```ts
-const snapshot = toAccountSecuritySnapshot({
-  user,
-  identities,
-  credentials,
-  sessions,
-})
+const snapshot = await authService.getAccountSecuritySnapshot(userId)
 
 const verificationStatus = toVerificationStatusView(verification)
 ```
@@ -29,16 +24,7 @@ const verificationStatus = toVerificationStatusView(verification)
 The minimal server-side composition usually looks like this:
 
 ```ts
-const user = await authService.getUser(userId)
-const identities = await authService.getUserIdentities(userId)
-const credentials = await authService.getUserCredentials(userId)
-const sessions = await authService.getUserSessions(userId)
-const snapshot = toAccountSecuritySnapshot({
-  user,
-  identities,
-  credentials,
-  sessions,
-})
+const snapshot = await authService.getAccountSecuritySnapshot(userId)
 ```
 
 Keep the response client-safe:
@@ -87,7 +73,7 @@ Do not serialize:
 For device-list or active-session screens:
 
 1. resolve the current local session from the transport;
-2. load all local sessions through `authService.getUserSessions(userId)`;
+2. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
 3. present a sanitized session list;
 4. revoke one or many sessions through:
    - `authService.revokeSession(sessionId)`
@@ -100,10 +86,9 @@ after a revoke.
 
 For sign-in method screens:
 
-1. load identities through `authService.getUserIdentities(userId)`;
-2. load credentials through `authService.getUserCredentials(userId)`;
-3. present provider ids, statuses, email or phone hints, and credential types;
-4. use `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new provider link flows for
+1. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
+2. present provider ids, statuses, email or phone hints, and credential types;
+3. use `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new provider link flows for
    mutations.
 
 Keep the same public security rules:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ identities, and email/phone are optional identity attributes.
 - `getUser`
 - `getUserCredentials`
 - `getUserSessions`
+- `getAccountSecuritySnapshot`
 - `createVerification`
 - `getVerification`
 - `toAccountSecuritySnapshot`

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -125,6 +125,8 @@ Express ownership notes:
 - For account-security screens that list sign-in methods or devices, prefer the dedicated
   [Account security recipes](account-security.md) and the built-in safe projection helpers instead
   of reading adapter internals.
+- Prefer `authService.getAccountSecuritySnapshot(userId)` when one request needs the whole
+  account-security view.
 
 ## Fastify
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -223,9 +223,13 @@ Tracking issues: #137.
 
 ## Next Release
 
-### v0.26 - Backlog To Be Defined
+### v0.26 - Account Security Aggregate Read Side
 
-- Next stabilizing or integrator-facing scope after the safe read-side projections release.
+- Public `getAccountSecuritySnapshot(userId)` API for one-shot account-security pages and API
+  handlers.
+- Examples and docs moved from manual multi-call composition to the aggregate read-side method.
+
+Tracking issues: #148, #149, #150, #151, #152.
 
 ## Versioning
 

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -8,7 +8,6 @@ import {
   VerificationPurpose,
   createDefaultAuthPolicy,
   isUniAuthError,
-  toAccountSecuritySnapshot,
   type Session,
   type User,
   type UniAuthErrorCode as UniAuthErrorCodeType,
@@ -182,17 +181,7 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
           return
         }
 
-        const [identities, credentials, sessions] = await Promise.all([
-          authService.getUserIdentities(auth.user.id),
-          authService.getUserCredentials(auth.user.id),
-          authService.getUserSessions(auth.user.id),
-        ])
-        const snapshot = toAccountSecuritySnapshot({
-          user: auth.user,
-          identities,
-          credentials,
-          sessions,
-        })
+        const snapshot = await authService.getAccountSecuritySnapshot(auth.user.id)
 
         response.status(200).json(serializeAccountSecuritySnapshot(snapshot))
       } catch (error) {

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -9,7 +9,6 @@ import {
   VerificationPurpose,
   createDefaultAuthPolicy,
   isUniAuthError,
-  toAccountSecuritySnapshot,
   type Session,
   type User,
   type UniAuthErrorCode as UniAuthErrorCodeType,
@@ -179,17 +178,7 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
         return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
       }
 
-      const [identities, credentials, sessions] = await Promise.all([
-        authService.getUserIdentities(auth.user.id),
-        authService.getUserCredentials(auth.user.id),
-        authService.getUserSessions(auth.user.id),
-      ])
-      const snapshot = toAccountSecuritySnapshot({
-        user: auth.user,
-        identities,
-        credentials,
-        sessions,
-      })
+      const snapshot = await authService.getAccountSecuritySnapshot(auth.user.id)
 
       return reply.status(200).send(serializeAccountSecuritySnapshot(snapshot))
     },

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -54,6 +54,7 @@ describe('package exports', () => {
     expect(core.createScryptSecretHasher).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUser).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserCredentials).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getAccountSecuritySnapshot).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')

--- a/src/application/account-security.ts
+++ b/src/application/account-security.ts
@@ -1,0 +1,26 @@
+import type { AuthServiceRuntime } from './runtime.js'
+import { getActiveUser } from './support.js'
+import {
+  toAccountSecuritySnapshot,
+  type AccountSecuritySnapshot,
+  type UserId,
+} from '../domain/types.js'
+
+export async function getAccountSecuritySnapshot(
+  runtime: AuthServiceRuntime,
+  userId: UserId,
+): Promise<AccountSecuritySnapshot> {
+  const user = await getActiveUser(runtime, userId)
+  const [identities, credentials, sessions] = await Promise.all([
+    runtime.repos.identityRepo.listByUserId(user.id),
+    runtime.repos.credentialRepo.listByUserId(user.id),
+    runtime.repos.sessionRepo.listByUserId(user.id),
+  ])
+
+  return toAccountSecuritySnapshot({
+    user,
+    identities,
+    credentials,
+    sessions,
+  })
+}

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,3 +1,4 @@
+import { getAccountSecuritySnapshot } from './account-security.js'
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import { finishEmailMagicLinkSignIn, startEmailMagicLinkSignIn } from './magic-link.js'
@@ -24,6 +25,7 @@ import { consumeVerification, createVerification, getVerification } from './veri
 import type { AuthPolicy } from './policy.js'
 import type {
   AuthIdentity,
+  AccountSecuritySnapshot,
   AuthResult,
   AuthService,
   ChangePasswordInput,
@@ -179,6 +181,10 @@ export class DefaultAuthService implements AuthService {
 
   async getUserSessions(userId: UserId): Promise<readonly Session[]> {
     return getUserSessions(this.runtime, userId)
+  }
+
+  async getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot> {
+    return getAccountSecuritySnapshot(this.runtime, userId)
   }
 
   async createSession(input: CreateSessionInput): Promise<CreateSessionResult> {

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1,4 +1,5 @@
 import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
+import type { AccountSecuritySnapshot } from './views.js'
 import type {
   AuthResult,
   ConsumeVerificationInput,
@@ -81,6 +82,7 @@ export interface AuthService {
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
   getUserCredentials(userId: UserId): Promise<readonly Credential[]>
   getUserSessions(userId: UserId): Promise<readonly Session[]>
+  getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>
   createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult>
   getVerification(verificationId: VerificationId): Promise<Verification>

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -5,6 +5,7 @@ import {
   DefaultAuthService,
   EMAIL_OTP_PROVIDER_ID,
   OtpChannel,
+  PASSWORD_PROVIDER_ID,
   PHONE_OTP_PROVIDER_ID,
   createDefaultAuthPolicy,
   getUniAuthAttributionNotice,
@@ -142,6 +143,52 @@ describe('DefaultAuthService', () => {
     expect(await service.getVerification(createdVerification.verification.id)).toEqual(
       createdVerification.verification,
     )
+    expect(await service.getAccountSecuritySnapshot(signedIn.user.id)).toEqual({
+      user: {
+        id: signedIn.user.id,
+        email: 'credential-reader@example.com',
+        displayName: 'Alice',
+        createdAt: signedIn.user.createdAt,
+        updatedAt: signedIn.user.updatedAt,
+      },
+      identities: [
+        {
+          id: signedIn.identity.id,
+          provider: signedIn.identity.provider,
+          status: signedIn.identity.status,
+          email: 'credential-reader@example.com',
+          emailVerified: true,
+          createdAt: signedIn.identity.createdAt,
+          updatedAt: signedIn.identity.updatedAt,
+        },
+        {
+          provider: PASSWORD_PROVIDER_ID,
+          status: 'active',
+          email: 'credential-reader@example.com',
+          emailVerified: true,
+          id: expect.any(String),
+          createdAt: credential.createdAt,
+          updatedAt: credential.updatedAt,
+        },
+      ],
+      credentials: [
+        {
+          id: credential.id,
+          type: credential.type,
+          subject: credential.subject,
+          createdAt: credential.createdAt,
+          updatedAt: credential.updatedAt,
+        },
+      ],
+      sessions: [
+        {
+          id: signedIn.session.id,
+          status: signedIn.session.status,
+          createdAt: signedIn.session.createdAt,
+          expiresAt: signedIn.session.expiresAt,
+        },
+      ],
+    })
   })
 
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -4,6 +4,7 @@ import {
   addSeconds,
   type AuthPolicy,
   AuthIdentityStatus,
+  PASSWORD_PROVIDER_ID,
   ProviderTrustLevel,
   SessionStatus,
   UniAuthErrorCode,
@@ -317,6 +318,51 @@ describe('Postgres reference persistence', () => {
     expect(await service.getVerification(createdVerification.verification.id)).toEqual(
       createdVerification.verification,
     )
+    expect(await service.getAccountSecuritySnapshot(signedIn.user.id)).toEqual({
+      user: {
+        id: signedIn.user.id,
+        email: 'pg-read-side-credential@example.com',
+        createdAt: signedIn.user.createdAt,
+        updatedAt: signedIn.user.updatedAt,
+      },
+      identities: [
+        {
+          id: signedIn.identity.id,
+          provider: signedIn.identity.provider,
+          status: signedIn.identity.status,
+          email: 'pg-read-side-credential@example.com',
+          emailVerified: true,
+          createdAt: signedIn.identity.createdAt,
+          updatedAt: signedIn.identity.updatedAt,
+        },
+        {
+          provider: PASSWORD_PROVIDER_ID,
+          status: 'active',
+          email: 'pg-read-side-credential@example.com',
+          emailVerified: true,
+          id: expect.any(String),
+          createdAt: credential.createdAt,
+          updatedAt: credential.updatedAt,
+        },
+      ],
+      credentials: [
+        {
+          id: credential.id,
+          type: credential.type,
+          subject: credential.subject,
+          createdAt: credential.createdAt,
+          updatedAt: credential.updatedAt,
+        },
+      ],
+      sessions: [
+        {
+          id: signedIn.session.id,
+          status: signedIn.session.status,
+          createdAt: signedIn.session.createdAt,
+          expiresAt: signedIn.session.expiresAt,
+        },
+      ],
+    })
   })
 
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -226,6 +226,13 @@ describe('DefaultAuthService edge cases', () => {
     })
     expect(
       await defaultService
+        .getAccountSecuritySnapshot(second.user.id)
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    expect(
+      await defaultService
         .getVerification(asVerificationId('missing-verification'))
         .catch((caught: unknown) => caught),
     ).toMatchObject({


### PR DESCRIPTION
## Summary
- add `AuthService.getAccountSecuritySnapshot(userId)` as a one-shot account-security read-side API
- move Express and Fastify account-security examples from manual multi-call composition to the aggregate service method
- extend smoke, core, Postgres, and service-edge coverage for the new public surface

## Why
Account-security screens were still forced to orchestrate multiple read-side calls (`getUser*`) and then manually compose a safe snapshot. The package already had safe projection helpers, but the public service surface still leaked orchestration boilerplate into applications. This change moves that composition into the service layer without widening mutation scope or exposing raw storage internals.

## Implementation details
- add `src/application/account-security.ts` with runtime-level orchestration over active user, identities, credentials, and sessions
- extend `AuthService` and `DefaultAuthService` with `getAccountSecuritySnapshot(userId)`
- keep `toAccountSecuritySnapshot(...)` public for lower-level composition, but update docs and runnable examples to prefer the aggregate API for full account-security pages
- document the new `v0.26` release track and move backend/account-security guidance to the new method where a complete snapshot is needed in one request

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run check`

Closes #148
