### PR TITLE
docs: sync roadmap after v0.26.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -221,15 +221,27 @@ Tracking issues: #131, #132, #133.
 
 Tracking issues: #137.
 
-## Next Release
-
 ### v0.26 - Account Security Aggregate Read Side
 
 - Public `getAccountSecuritySnapshot(userId)` API for one-shot account-security pages and API
   handlers.
 - Examples and docs moved from manual multi-call composition to the aggregate read-side method.
 
-Tracking issues: #148, #149, #150, #151, #152.
+Tracking issues: #148.
+
+## Next Release
+
+### v0.27 - Internal Decomposition and Docs Cleanup
+
+- Split Postgres persistence by repository slice so storage changes stay smaller and easier to
+  review.
+- Split core and Postgres integration suites by behavior so regressions are easier to localize.
+- Decompose provider sign-in orchestration into smaller internal steps without widening the public
+  API.
+- Reduce overlap across backend, session, and account-security guides after the new aggregate
+  read-side surface landed.
+
+Tracking issues: #149, #150, #151, #152.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move `v0.26` from next release to released in the roadmap
- define `v0.27` as the next internal cleanup track
- keep the remaining backlog items (`#149`-`#152`) aligned with the next release label after `v0.26.0`

## Why
`v0.26.0` is already published. Keeping `v0.26` in the roadmap as the active next release would immediately reintroduce planning drift between GitHub releases, issue labels, and repository docs.

## Validation
- `npm run check`
