### PR TITLE
feat: add audit-event read-side API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ license, subscription, private contract, or other written permission.
 - Exposes a narrow `getUser(userId)` helper for loading the active local user snapshot by id.
 - Exposes read-side helpers for credential and verification lookups through the public service
   layer.
+- Exposes a public audit-event read-side API for trusted security timelines and support tooling.
 - Exposes safe projection helpers for account-security and verification-status read-side flows.
 - Exposes an aggregated `getAccountSecuritySnapshot(userId)` read-side API for account-security
   screens.
@@ -284,6 +285,15 @@ helpers instead of serializing raw entities directly:
 const snapshot = await service.getAccountSecuritySnapshot(userId)
 
 const verificationStatus = toVerificationStatusView(verification)
+```
+
+Trusted backend tooling can also inspect local audit history through the public service layer:
+
+```ts
+const events = await service.getAuditEvents({
+  userId,
+  limit: 20,
+})
 ```
 
 Messenger Mini App providers are SDK-free `AuthProvider` adapters for signed Telegram and MAX

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -5,6 +5,7 @@ Use the public read-side API when you need account-security pages such as:
 - sign-in method management;
 - current-device and other-device session lists;
 - sign-out-current-device or sign-out-other-devices flows;
+- trusted security timeline or audit-event inspection;
 - support-only verification inspection by id.
 
 UniAuth still does not own HTTP routes, UI, cookies, or client payload shaping. The application
@@ -72,6 +73,37 @@ Do not serialize:
 - `Credential.passwordHash`
 - `Session.tokenHash`
 - `Verification.secretHash`
+
+## Security Timeline
+
+For trusted backend security timelines or support inspection:
+
+```ts
+const events = await authService.getAuditEvents({
+  userId,
+  limit: 20,
+})
+```
+
+The service returns local `AuditEvent` records newest-first. Keep outward serialization
+application-owned and expose only the fields your support or admin surface actually needs.
+
+Typical server-safe outward shape:
+
+```ts
+return events.map((event) => ({
+  id: event.id,
+  type: event.type,
+  occurredAt: event.occurredAt.toISOString(),
+  userId: event.userId ?? null,
+  identityId: event.identityId ?? null,
+  sessionId: event.sessionId ?? null,
+  metadata: event.metadata ?? null,
+}))
+```
+
+Do not add secrets or credential material to audit metadata in application code. Keep the same
+trusted-backend assumption here as for verification inspection.
 
 ## Device Management
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ identities, and email/phone are optional identity attributes.
 - `getUser`
 - `getUserCredentials`
 - `getUserSessions`
+- `getAuditEvents`
 - `getAccountSecuritySnapshot`
 - `createVerification`
 - `getVerification`
@@ -50,6 +51,10 @@ It delegates authorization decisions to `AuthPolicy` and storage/provider/sender
 Core defines repository ports, credential ports, provider registry, sender ports, rate-limit port,
 password hashing port, audit log port, verification secret hashing extension point, and
 `UnitOfWork`.
+
+The audit log port is now read-capable as well as write-capable. Core still owns local security
+event creation, while trusted backend tooling can read the resulting `AuditEvent` timeline through
+the public service layer without reaching into adapter internals.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,10 +243,15 @@ Tracking issues: #149, #150, #151, #152.
 
 ## Next Release
 
-### v0.28 - Backlog To Be Defined
+### v0.28 - Audit Read Side and Security Recipes
 
-- Next backlog intentionally left open after the v0.27 maintenance batch landed on `main` without a
-  package release.
+- Public audit-event read-side API for trusted security timelines and support tooling.
+- Account-security action recipes for revoke, unlink, and password-management flows.
+- Additional regression coverage around password, verification-secret, and session-token hash-only
+  storage.
+- Support and admin inspection recipe built on the public read-side surface.
+
+Tracking issues: #162, #163, #164, #165.
 
 ## Versioning
 

--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -1,0 +1,39 @@
+import type { AuthServiceRuntime } from './runtime.js'
+import type { AuditEvent, AuditEventQuery } from '../domain/types.js'
+import { invalidInput } from '../errors.js'
+import { assertValidDate } from '../utils/time.js'
+
+const DefaultAuditEventLimit = 50
+
+export async function getAuditEvents(
+  runtime: AuthServiceRuntime,
+  input: AuditEventQuery = {},
+): Promise<readonly AuditEvent[]> {
+  const query = normalizeAuditEventQuery(input)
+  return runtime.repos.auditLogRepo.list(query)
+}
+
+function normalizeAuditEventQuery(input: AuditEventQuery): AuditEventQuery {
+  if (input.before !== undefined) {
+    assertValidDate(input.before, 'Audit event cursor time is invalid.')
+  }
+
+  const limit = input.limit ?? DefaultAuditEventLimit
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw invalidInput('Audit event limit must be a positive integer.')
+  }
+
+  if (input.type !== undefined) {
+    const type = input.type.trim()
+
+    if (!type) {
+      throw invalidInput('Audit event type is invalid.')
+    }
+  }
+
+  return {
+    ...input,
+    limit,
+  }
+}

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,4 +1,5 @@
 import { getAccountSecuritySnapshot } from './account-security.js'
+import { getAuditEvents } from './audit-events.js'
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import { finishEmailMagicLinkSignIn, startEmailMagicLinkSignIn } from './magic-link.js'
@@ -26,6 +27,8 @@ import type { AuthPolicy } from './policy.js'
 import type {
   AuthIdentity,
   AccountSecuritySnapshot,
+  AuditEvent,
+  AuditEventQuery,
   AuthResult,
   AuthService,
   ChangePasswordInput,
@@ -181,6 +184,10 @@ export class DefaultAuthService implements AuthService {
 
   async getUserSessions(userId: UserId): Promise<readonly Session[]> {
     return getUserSessions(this.runtime, userId)
+  }
+
+  async getAuditEvents(input?: AuditEventQuery): Promise<readonly AuditEvent[]> {
+    return getAuditEvents(this.runtime, input)
   }
 
   async getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot> {

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -24,3 +24,12 @@ export interface AuditEvent {
   readonly sessionId?: SessionId
   readonly metadata?: Record<string, unknown>
 }
+
+export interface AuditEventQuery {
+  readonly userId?: UserId
+  readonly identityId?: IdentityId
+  readonly sessionId?: SessionId
+  readonly type?: AuditEventType
+  readonly before?: Date
+  readonly limit?: number
+}

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1,5 +1,6 @@
 import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
 import type { AccountSecuritySnapshot } from './views.js'
+import type { AuditEvent, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
   ConsumeVerificationInput,
@@ -82,6 +83,7 @@ export interface AuthService {
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>
   getUserCredentials(userId: UserId): Promise<readonly Credential[]>
   getUserSessions(userId: UserId): Promise<readonly Session[]>
+  getAuditEvents(input?: AuditEventQuery): Promise<readonly AuditEvent[]>
   getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot>
   createSession(input: CreateSessionInput): Promise<CreateSessionResult>
   createVerification(input: CreateVerificationInput): Promise<CreateVerificationResult>

--- a/src/ports/repositories.ts
+++ b/src/ports/repositories.ts
@@ -1,5 +1,6 @@
 import type {
   AuditEvent,
+  AuditEventQuery,
   AuthIdentity,
   AuthIdentityProvider,
   Credential,
@@ -65,6 +66,7 @@ export interface SessionRepo {
 
 export interface AuditLogRepo {
   append(event: AuditEvent): Promise<void>
+  list(input?: AuditEventQuery): Promise<readonly AuditEvent[]>
 }
 
 export interface AuthServiceRepositories {

--- a/src/postgres/schema.ts
+++ b/src/postgres/schema.ts
@@ -84,7 +84,11 @@ const schemaStatements = [
     metadata jsonb
   )`,
   `create index if not exists uniauth_audit_events_user_idx on uniauth_audit_events (user_id)`,
+  `create index if not exists uniauth_audit_events_identity_idx on uniauth_audit_events (identity_id)`,
+  `create index if not exists uniauth_audit_events_session_idx on uniauth_audit_events (session_id)`,
   `create index if not exists uniauth_audit_events_occurred_idx on uniauth_audit_events (occurred_at)`,
+  `create index if not exists uniauth_audit_events_type_occurred_idx
+    on uniauth_audit_events (type, occurred_at desc)`,
 ] as const
 
 export const POSTGRES_AUTH_SCHEMA_SQL = `${schemaStatements.join(';\n\n')};\n`

--- a/src/postgres/store/audit.ts
+++ b/src/postgres/store/audit.ts
@@ -1,5 +1,6 @@
 import type { AuditLogRepo } from '../../ports.js'
-import type { PostgresStoreContext } from './shared.js'
+import { type AuditEventQuery } from '../../domain/types.js'
+import { type AuditEventRow, mapAuditEventRow, type PostgresStoreContext } from './shared.js'
 
 export function createAuditLogRepo(context: PostgresStoreContext): AuditLogRepo {
   return {
@@ -17,6 +18,53 @@ export function createAuditLogRepo(context: PostgresStoreContext): AuditLogRepo 
           event.sessionId ?? null,
           event.metadata ?? null,
         ],
+      )
+    },
+    list: async (input: AuditEventQuery = {}) => {
+      const filters: string[] = []
+      const values: unknown[] = []
+
+      if (input.userId) {
+        values.push(input.userId)
+        filters.push(`user_id = $${values.length}`)
+      }
+
+      if (input.identityId) {
+        values.push(input.identityId)
+        filters.push(`identity_id = $${values.length}`)
+      }
+
+      if (input.sessionId) {
+        values.push(input.sessionId)
+        filters.push(`session_id = $${values.length}`)
+      }
+
+      if (input.type) {
+        values.push(input.type)
+        filters.push(`type = $${values.length}`)
+      }
+
+      if (input.before) {
+        values.push(input.before)
+        filters.push(`occurred_at < $${values.length}`)
+      }
+
+      const whereClause = filters.length > 0 ? `where ${filters.join(' and ')}` : ''
+
+      if (input.limit !== undefined) {
+        values.push(input.limit)
+      }
+
+      const limitClause = input.limit !== undefined ? `limit $${values.length}` : ''
+
+      return context.queryRows<AuditEventRow, ReturnType<typeof mapAuditEventRow>>(
+        `select id, type, occurred_at, user_id, identity_id, session_id, metadata
+           from uniauth_audit_events
+           ${whereClause}
+           order by occurred_at desc, id desc
+           ${limitClause}`,
+        values,
+        (row) => mapAuditEventRow(row),
       )
     },
   }

--- a/src/postgres/store/shared.ts
+++ b/src/postgres/store/shared.ts
@@ -1,4 +1,5 @@
 import {
+  asAuditEventId,
   asCredentialId,
   asIdentityId,
   asSessionId,
@@ -6,6 +7,8 @@ import {
   asVerificationId,
   ProviderTrustLevel,
   type AuthIdentity,
+  type AuditEvent,
+  type AuditEventType,
   type AuthIdentityProvider,
   type Credential,
   type CredentialType,
@@ -31,6 +34,16 @@ export interface UserRow {
   readonly created_at: Date | string
   readonly updated_at: Date | string
   readonly disabled_at: Date | string | null
+  readonly metadata: Record<string, unknown> | string | null
+}
+
+export interface AuditEventRow {
+  readonly id: string
+  readonly type: AuditEventType
+  readonly occurred_at: Date | string
+  readonly user_id: string | null
+  readonly identity_id: string | null
+  readonly session_id: string | null
   readonly metadata: Record<string, unknown> | string | null
 }
 
@@ -121,6 +134,18 @@ export function mapUserRow(row: UserRow): User {
     ...optionalProp('email', readString(row.email)),
     ...optionalProp('phone', readString(row.phone)),
     ...optionalProp('disabledAt', readOptionalDate(row.disabled_at)),
+    ...optionalProp('metadata', readJsonObject(row.metadata)),
+  }
+}
+
+export function mapAuditEventRow(row: AuditEventRow): AuditEvent {
+  return {
+    id: asAuditEventId(row.id),
+    type: row.type,
+    occurredAt: readDate(row.occurred_at),
+    ...optionalProp('userId', row.user_id ? asUserId(row.user_id) : undefined),
+    ...optionalProp('identityId', row.identity_id ? asIdentityId(row.identity_id) : undefined),
+    ...optionalProp('sessionId', row.session_id ? asSessionId(row.session_id) : undefined),
     ...optionalProp('metadata', readJsonObject(row.metadata)),
   }
 }

--- a/src/testing/in-memory/store.ts
+++ b/src/testing/in-memory/store.ts
@@ -259,6 +259,19 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
     append: async (event) => {
       this.auditEvents.push(event)
     },
+    list: async (input = {}) => {
+      const events = [...this.auditEvents]
+        .filter((event) => (input.userId ? event.userId === input.userId : true))
+        .filter((event) => (input.identityId ? event.identityId === input.identityId : true))
+        .filter((event) => (input.sessionId ? event.sessionId === input.sessionId : true))
+        .filter((event) => (input.type ? event.type === input.type : true))
+        .filter((event) =>
+          input.before ? event.occurredAt.getTime() < input.before.getTime() : true,
+        )
+        .sort(compareAuditEventsDescending)
+
+      return input.limit !== undefined ? events.slice(0, input.limit) : events
+    },
   }
 
   async run<T>(operation: () => Promise<T>): Promise<T> {
@@ -384,4 +397,14 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
     this.auditEvents.push(...snapshot.auditEvents)
   }
+}
+
+function compareAuditEventsDescending(left: AuditEvent, right: AuditEvent): number {
+  const occurredDifference = right.occurredAt.getTime() - left.occurredAt.getTime()
+
+  if (occurredDifference !== 0) {
+    return occurredDifference
+  }
+
+  return right.id.localeCompare(left.id)
 }

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -169,6 +169,69 @@ describe('DefaultAuthService read side and sessions', () => {
     })
   })
 
+  it('reads audit events through the public service surface with newest-first filtering', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'audit-reader',
+        email: 'audit-reader@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const verification = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'audit-reader@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    const allEvents = await service.getAuditEvents()
+    const userEvents = await service.getAuditEvents({ userId: signedIn.user.id, limit: 3 })
+    const sessionEvents = await service.getAuditEvents({ sessionId: signedIn.session.id, limit: 2 })
+    const olderUserEvents = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      before: addSeconds(now, 1),
+      limit: 5,
+    })
+
+    expect(allEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.VerificationCreated,
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
+    expect(userEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
+    expect(sessionEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+    ])
+    expect(olderUserEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
+    expect(
+      await service.getAuditEvents({
+        type: AuditEventType.VerificationCreated,
+        limit: 5,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        type: AuditEventType.VerificationCreated,
+        metadata: {
+          purpose: VerificationPurpose.SignIn,
+          verificationId: verification.verification.id,
+        },
+      }),
+    ])
+  })
+
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {
     const { service, store } = createInMemoryAuthKit()
     const signedIn = await service.signIn({ assertion: assertion(), now })
@@ -256,6 +319,24 @@ describe('DefaultAuthService read side and sessions', () => {
         now,
       }),
     ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(service.getAuditEvents({ limit: 0 })).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        before: new Date(Number.NaN),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        // @ts-expect-error runtime validation for untyped callers
+        type: '   ',
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
     await expect(
       service.createSession({
         userId: signedIn.user.id,

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -242,13 +242,37 @@ describe('InMemoryAuthStore', () => {
       type: AuditEventType.PolicyDenied,
       occurredAt: now,
     })
+    await store.auditLogRepo.append({
+      id: asAuditEventId('audit-2'),
+      type: AuditEventType.SignIn,
+      occurredAt: addSeconds(now, 5),
+      userId: createdUser.id,
+      identityId: emailIdentity.id,
+      sessionId: session.id,
+    })
 
     expect(store.listUsers()).toHaveLength(2)
     expect(store.listIdentities()).toHaveLength(2)
     expect(store.listCredentials()).toHaveLength(2)
     expect(store.listVerifications()).toHaveLength(1)
     expect(store.listSessions()).toHaveLength(2)
-    expect(store.listAuditEvents()).toHaveLength(1)
+    expect(store.listAuditEvents()).toHaveLength(2)
+    expect(await store.auditLogRepo.list()).toEqual([
+      expect.objectContaining({ id: asAuditEventId('audit-2') }),
+      expect.objectContaining({ id: asAuditEventId('audit-1') }),
+    ])
+    expect(
+      await store.auditLogRepo.list({
+        userId: createdUser.id,
+        limit: 5,
+      }),
+    ).toEqual([expect.objectContaining({ id: asAuditEventId('audit-2') })])
+    expect(
+      await store.auditLogRepo.list({
+        identityId: emailIdentity.id,
+        sessionId: session.id,
+      }),
+    ).toEqual([expect.objectContaining({ id: asAuditEventId('audit-2') })])
   })
 
   it('rolls back outer state while allowing nested transaction reuse', async () => {

--- a/test/postgres/security-and-read-side.test.ts
+++ b/test/postgres/security-and-read-side.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AuditEventType,
   PASSWORD_PROVIDER_ID,
   SessionStatus,
   UniAuthErrorCode,
@@ -273,6 +274,68 @@ describe('Postgres reference persistence security and read side', () => {
         },
       ],
     })
+  })
+
+  it('reads audit events through the public service surface on Postgres', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-audit-reader',
+        email: 'pg-audit-reader@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'pg-audit-reader@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    expect((await service.getAuditEvents()).map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.VerificationCreated,
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
+    expect(
+      (
+        await service.getAuditEvents({
+          userId: signedIn.user.id,
+          limit: 3,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SessionRevoked, AuditEventType.SignIn, AuditEventType.SessionCreated])
+    expect(
+      (
+        await service.getAuditEvents({
+          sessionId: signedIn.session.id,
+          limit: 2,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SessionRevoked, AuditEventType.SignIn])
+    expect(
+      (
+        await service.getAuditEvents({
+          identityId: signedIn.identity.id,
+          type: AuditEventType.SignIn,
+          before: addSeconds(now, 1),
+          limit: 5,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SignIn])
+    expect(
+      (
+        await store.auditLogRepo.list({
+          identityId: signedIn.identity.id,
+          type: AuditEventType.SignIn,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SignIn])
   })
 
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {

--- a/test/service-edges.test.ts
+++ b/test/service-edges.test.ts
@@ -437,6 +437,7 @@ describe('DefaultAuthService edge cases', () => {
           append: async () => {
             throw auditFailure
           },
+          list: async () => [],
         },
       },
       transaction: store,


### PR DESCRIPTION
## Summary
- add a public audit-event read-side API on AuthService with storage-agnostic filtering and newest-first ordering
- support the new audit query contract in both the in-memory store and the reference Postgres adapter
- document the new security-timeline read side and cover it with core, Postgres, and repository tests

Closes #162