### PR TITLE
docs: add account-security action recipes

### DIFF
--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -105,34 +105,179 @@ return events.map((event) => ({
 Do not add secrets or credential material to audit metadata in application code. Keep the same
 trusted-backend assumption here as for verification inspection.
 
-## Device Management
+## Session Action Recipes
 
 For device-list or active-session screens:
 
 1. resolve the current local session from the transport;
 2. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
 3. present a sanitized session list;
-4. revoke one or many sessions through:
-   - `authService.revokeSession(sessionId)`
-   - `authService.revokeUserSessions({ userId, exceptSessionId })`
+4. keep revoke and logout responses application-owned.
 
-The application still owns cookie clearing, mobile token deletion, and client refresh behavior
-after a revoke.
+### Current Device Logout
 
-## Sign-In Method Management
+Treat sign-out of the current device as one backend write plus one transport cleanup:
+
+```ts
+await authService.revokeSession(request.auth.session.id)
+clearSessionCookie(response)
+```
+
+UniAuth changes only the local session record. The application still owns cookie clearing, bearer
+token deletion, mobile secure-storage deletion, redirect behavior, and neutral response payloads.
+
+### Sign Out Other Devices
+
+For "sign out other devices" or "sign out all devices except this one":
+
+```ts
+const result = await authService.revokeUserSessions({
+  userId: request.auth.userId,
+  exceptSessionId: request.auth.session.id,
+})
+
+return {
+  revokedSessionCount: result.revokedSessionIds.length,
+}
+```
+
+This is the narrowest server-side flow when the caller is already authenticated and the target user
+is the current account. It keeps the current transport alive while revoking the other local session
+records.
+
+### Revoke One Selected Device
+
+For per-device revoke actions, first prove ownership from the read-side snapshot and only then call
+`revokeSession(...)`:
+
+```ts
+const snapshot = await authService.getAccountSecuritySnapshot(request.auth.userId)
+const target = snapshot.sessions.find((session) => session.id === body.sessionId)
+
+if (!target) {
+  return response.status(404).json({ error: 'Session not found.' })
+}
+
+await authService.revokeSession(target.id)
+
+if (target.id === request.auth.session.id) {
+  clearSessionCookie(response)
+}
+
+return response.status(204).send()
+```
+
+The application decides whether a missing or foreign session should look like `404`, `204`, or a
+generic neutral response. UniAuth only enforces local session state.
+
+## Sign-In Method Action Recipes
 
 For sign-in method screens:
 
 1. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
 2. present provider ids, statuses, email or phone hints, and credential types;
-3. use `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new provider link flows for
-   mutations.
+3. compose mutations through `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new
+   provider link flows.
 
 Keep the same public security rules:
 
 - do not allow the last active sign-in method to disappear;
 - keep public HTTP responses neutral when mutation attempts fail;
 - require recent auth where your policy says it is required.
+
+### Unlink One Sign-In Method
+
+Resolve the current account snapshot first so the application knows which method the user selected,
+then unlink by `identityId`:
+
+```ts
+const snapshot = await authService.getAccountSecuritySnapshot(request.auth.userId)
+const targetIdentity = snapshot.identities.find((identity) => identity.id === body.identityId)
+
+if (!targetIdentity) {
+  return response.status(404).json({ error: 'Sign-in method not found.' })
+}
+
+await authService.unlink({
+  userId: request.auth.userId,
+  identityId: targetIdentity.id,
+  reAuthenticatedAt: request.auth.reAuthenticatedAt,
+})
+
+return response.status(204).send()
+```
+
+If policy or invariant checks reject the unlink, keep the outward response neutral enough for your
+surface. Core already protects the last remaining active sign-in method.
+
+### Add Or Replace A Local Password
+
+Use `setPassword(...)` when the account does not yet have a local password or when the application
+allows a provider-first account to add one from a trusted account-security screen:
+
+```ts
+const passwordEmail = snapshot.user.email
+
+if (!passwordEmail) {
+  return response.status(400).json({ error: 'Password setup requires a trusted email address.' })
+}
+
+await authService.setPassword({
+  userId: request.auth.userId,
+  email: passwordEmail,
+  password: body.newPassword,
+  reAuthenticatedAt: request.auth.reAuthenticatedAt,
+})
+```
+
+The application still owns password policy UX, strength hints, recent-auth requirements, and
+whether the route should even be offered when a password credential already exists. Feed
+`setPassword(...)` with a trusted account-owned email, not with an arbitrary unverified request
+field.
+
+### Change Password
+
+Use `changePassword(...)` when the current user already knows the existing password:
+
+```ts
+await authService.changePassword({
+  userId: request.auth.userId,
+  currentPassword: body.currentPassword,
+  newPassword: body.newPassword,
+  reAuthenticatedAt: request.auth.reAuthenticatedAt,
+})
+```
+
+Keep incorrect current-password responses neutral and leave session refresh, cookie rotation, or
+"sign out other devices after password change" policy in the application layer.
+
+### Password Recovery Handoff
+
+If the user cannot prove the current password, hand off from the authenticated or unauthenticated
+surface into the shared email recovery flow:
+
+```ts
+const recovery = await authService.startEmailPasswordRecovery({
+  email: body.email,
+  createLink(input) {
+    return `https://example.com/auth/recovery?verification=${input.verificationId}&token=${input.secret}`
+  },
+})
+```
+
+Then finish it from the recovery route:
+
+```ts
+await authService.finishEmailPasswordRecovery({
+  verificationId: body.verificationId,
+  secret: body.secret,
+  newPassword: body.newPassword,
+})
+```
+
+UniAuth keeps the verification lifecycle and hashed secret storage. The application still owns the
+delivery channel, the recovery URL, browser redirect choices, and whether recovery completion also
+creates or rotates a local session.
 
 ## Verification Inspection
 

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -14,8 +14,8 @@ Use this document for:
 
 Use [Session transport recipes](session-transport.md) for token extraction, cookie vs bearer
 transport, and request auth middleware/preHandler shape. Use
-[Account security recipes](account-security.md) for device lists, sign-in method screens, and safe
-read-side projections.
+[Account security recipes](account-security.md) for device lists, sign-in method screens, revoke
+flows, password-management handoff, and safe read-side projections.
 
 ## Shared Bootstrap
 
@@ -111,8 +111,8 @@ Express ownership notes:
   recovery start, and OTP start.
 - Keep route-neutral errors neutral at the HTTP layer too; do not translate invalid credentials into
   account existence hints.
-- For account-security screens, use [Account security recipes](account-security.md) and the
-  built-in safe projection helpers instead of reading adapter internals.
+- For account-security screens and mutations, use [Account security recipes](account-security.md)
+  and the built-in safe projection helpers instead of reading adapter internals.
 
 ## Fastify
 
@@ -160,7 +160,7 @@ Fastify ownership notes:
 - If delivery goes through queues, keep that inside your `EmailSender` or `SmsSender` adapters
   rather than introducing a Fastify-specific auth dispatcher.
 - For a fuller copyable token/session recipe, see [Session transport recipes](session-transport.md).
-- For sign-in-method and device-management screens, use
+- For sign-in-method, device-management, revoke, and password-change routes, use
   [Account security recipes](account-security.md).
 
 ## Nest

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -326,8 +326,8 @@ For sign-out-all-devices or device-management screens, applications can first ca
 or bearer stores for those clients; the application must remove the transport artifact on each
 device as it becomes aware of the revoked local session.
 
-For the account-security screen shape and safe outward projection, continue in
-[Account security recipes](account-security.md).
+For the account-security write-side recipes, safe outward projection, and sign-in-method management
+flows, continue in [Account security recipes](account-security.md).
 
 ## Security Notes
 


### PR DESCRIPTION
Closes #163\n\n## Summary\n- add one document-owned place for account-security mutation recipes\n- cover current-device logout, sign-out-other-devices, selected-session revoke, unlink, password change, and recovery handoff\n- keep backend and session docs as cross-links instead of duplicating write-side flows\n\n## Testing\n- npm run check