### PR TITLE
docs: add support and admin inspection recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ contact `alyldas@ya.ru`.
 - [OTP delivery boundary](docs/otp-delivery.md)
 - [Normalization boundary](docs/normalization.md)
 - [Session transport recipes](docs/session-transport.md)
+- [Support and admin inspection recipe](docs/support-inspection.md)
 - [Messenger providers](docs/messenger-providers.md)
 - [OAuth / OIDC providers](docs/oauth-oidc.md)
 - [Provider token persistence](docs/provider-token-persistence.md)

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -105,6 +105,9 @@ return events.map((event) => ({
 Do not add secrets or credential material to audit metadata in application code. Keep the same
 trusted-backend assumption here as for verification inspection.
 
+For a larger trusted support or admin inspection surface that combines snapshot, audit, and
+verification reads, continue in [Support and admin inspection recipe](support-inspection.md).
+
 ## Session Action Recipes
 
 For device-list or active-session screens:
@@ -316,3 +319,4 @@ Do not send `secretHash` to browsers, mobile clients, or untrusted callers.
 - [OTP backend wiring example](../examples/otp-backend/index.ts)
 - [Session transport recipes](session-transport.md)
 - [Backend integration recipes](backend-recipes.md)
+- [Support and admin inspection recipe](support-inspection.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,3 +198,5 @@ are small reference contracts. If the ecosystem grows into multiple maintained a
 can move to a monorepo with packages for storage, providers, and framework-specific HTTP wiring.
 
 For framework-level HTTP composition examples, see [Backend integration recipes](backend-recipes.md).
+For trusted backend inspection composition on top of the read-side surface, see
+[Support and admin inspection recipe](support-inspection.md).

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -16,6 +16,8 @@ Use [Session transport recipes](session-transport.md) for token extraction, cook
 transport, and request auth middleware/preHandler shape. Use
 [Account security recipes](account-security.md) for device lists, sign-in method screens, revoke
 flows, password-management handoff, and safe read-side projections.
+Use [Support and admin inspection recipe](support-inspection.md) for trusted operator tooling that
+stays server-only.
 
 ## Shared Bootstrap
 

--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -1,0 +1,194 @@
+# Support and Admin Inspection Recipe
+
+Use this document for trusted backend support or admin tooling that needs to inspect one account,
+one verification, or one audit timeline without reaching into adapter internals.
+
+UniAuth still does not own operator authorization, HTTP routes, response pagination, or which
+fields a support surface is allowed to expose. Keep this recipe server-only and application-owned.
+
+Use [Account security recipes](account-security.md) for end-user account settings, revoke flows,
+unlink, and password-management actions. Use this document when a trusted backend operator needs a
+read-only inspection surface.
+
+## Trusted Boundary
+
+Before calling any UniAuth read-side method here, the application should already have decided:
+
+- who is allowed to inspect user security state;
+- which `userId`, `verificationId`, or audit filter the operator may target;
+- which fields can leave the server;
+- how inspection access is logged or audited on the application side.
+
+Do not call these flows directly from browsers or mobile clients.
+
+## Base Account Inspection
+
+The preferred starting point is the aggregated safe snapshot:
+
+```ts
+const snapshot = await authService.getAccountSecuritySnapshot(userId)
+```
+
+That one call already gives a trusted server-side view of:
+
+- user profile fields that are safe for account-security surfaces;
+- linked identities and provider trust hints;
+- local credentials without password hashes;
+- local sessions without bearer token hashes.
+
+Typical outward shape for a trusted support endpoint:
+
+```ts
+return {
+  user: {
+    id: snapshot.user.id,
+    email: snapshot.user.email ?? null,
+    phone: snapshot.user.phone ?? null,
+    displayName: snapshot.user.displayName ?? null,
+    disabledAt: snapshot.user.disabledAt?.toISOString() ?? null,
+  },
+  identities: snapshot.identities.map((identity) => ({
+    id: identity.id,
+    provider: identity.provider,
+    status: identity.status,
+    email: identity.email ?? null,
+    emailVerified: identity.emailVerified ?? null,
+    phone: identity.phone ?? null,
+    phoneVerified: identity.phoneVerified ?? null,
+    trustLevel: identity.trustLevel ?? null,
+  })),
+  credentials: snapshot.credentials.map((credential) => ({
+    id: credential.id,
+    type: credential.type,
+    subject: credential.subject,
+    createdAt: credential.createdAt.toISOString(),
+    updatedAt: credential.updatedAt.toISOString(),
+  })),
+  sessions: snapshot.sessions.map((session) => ({
+    id: session.id,
+    status: session.status,
+    createdAt: session.createdAt.toISOString(),
+    expiresAt: session.expiresAt.toISOString(),
+    lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
+    revokedAt: session.revokedAt?.toISOString() ?? null,
+  })),
+}
+```
+
+## Narrow Drill-Down Reads
+
+If the operator surface needs one narrower panel instead of the whole snapshot, UniAuth also
+exposes the individual read-side calls:
+
+```ts
+const user = await authService.getUser(userId)
+const sessions = await authService.getUserSessions(userId)
+const credentials = await authService.getUserCredentials(userId)
+```
+
+Use the aggregate snapshot as the default. Reach for these narrower reads only when the surrounding
+tooling truly needs independent pagination, separate caching, or a reduced payload.
+
+## Audit Timeline Inspection
+
+For a trusted security timeline:
+
+```ts
+const auditEvents = await authService.getAuditEvents({
+  userId,
+  limit: 50,
+})
+```
+
+Serialize only the operator-facing fields you actually need:
+
+```ts
+return auditEvents.map((event) => ({
+  id: event.id,
+  type: event.type,
+  occurredAt: event.occurredAt.toISOString(),
+  userId: event.userId ?? null,
+  identityId: event.identityId ?? null,
+  sessionId: event.sessionId ?? null,
+  metadata: event.metadata ?? null,
+}))
+```
+
+Do not copy secrets, password material, or raw bearer tokens into audit metadata at the application
+layer. Keep the audit timeline trusted-backend only, just like the account snapshot.
+
+## Verification Inspection
+
+When support or admin tooling needs to inspect one verification by id:
+
+```ts
+const verification = await authService.getVerification(verificationId)
+const verificationStatus = toVerificationStatusView(verification)
+```
+
+Typical outward shape:
+
+```ts
+return {
+  id: verificationStatus.id,
+  purpose: verificationStatus.purpose,
+  status: verificationStatus.status,
+  expiresAt: verificationStatus.expiresAt.toISOString(),
+  consumedAt: verificationStatus.consumedAt?.toISOString() ?? null,
+}
+```
+
+Do not expose `secretHash`, raw OTP values, magic-link secrets, or internal routing assumptions to
+operator clients.
+
+## Combined Inspection Service
+
+One practical server-side composition pattern is to build one trusted service function and let the
+framework layer own authorization and HTTP response shaping:
+
+```ts
+async function inspectAccountSecurity(input: {
+  readonly userId: string
+  readonly verificationId?: string
+}) {
+  const [snapshot, auditEvents] = await Promise.all([
+    authService.getAccountSecuritySnapshot(input.userId),
+    authService.getAuditEvents({ userId: input.userId, limit: 50 }),
+  ])
+
+  const verificationStatus = input.verificationId
+    ? toVerificationStatusView(await authService.getVerification(input.verificationId))
+    : undefined
+
+  return {
+    snapshot,
+    auditEvents,
+    verificationStatus,
+  }
+}
+```
+
+Keep outward serialization and operator authorization outside this helper. UniAuth only owns the
+local account-security state and verification lifecycle.
+
+## Action Handoff
+
+Support tooling often needs read-only inspection first and a privileged follow-up action second. Do
+not hide that distinction.
+
+Recommended split:
+
+1. inspect through the read-side methods in this document;
+2. decide in the application whether the operator may trigger a privileged action;
+3. run the actual revoke, unlink, or password-management flow through the service methods described
+   in [Account security recipes](account-security.md).
+
+This keeps inspection and mutation authorization explicit instead of coupling support reads to
+write-side power.
+
+## Related Documents
+
+- [Account security recipes](account-security.md)
+- [Session transport recipes](session-transport.md)
+- [Backend integration recipes](backend-recipes.md)
+- [Security model](security.md)


### PR DESCRIPTION
Closes #164\n\n## Summary\n- add a dedicated trusted-backend inspection document\n- show how to compose account snapshot, audit timeline, narrow reads, and verification inspection\n- keep operator authorization and outward serialization explicitly application-owned\n\n## Testing\n- npm run check