### PR TITLE
docs: sync roadmap after v0.28 maintenance batch

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,8 +242,6 @@ Tracking issues: #148.
 
 Tracking issues: #149, #150, #151, #152, #162.
 
-## Next Release
-
 ### v0.28 - Security Recipes and Regression Hardening
 
 - Account-security action recipes for revoke, unlink, and password-management flows.
@@ -252,6 +250,13 @@ Tracking issues: #149, #150, #151, #152, #162.
 - Support and admin inspection recipe built on the public read-side surface.
 
 Tracking issues: #163, #164, #165.
+
+## Next Release
+
+### v0.29 - Backlog To Be Defined
+
+- Next releasable feature batch to be defined after the completed v0.28 security docs and
+  regression hardening pass on `main`.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary\n- move the completed v0.28 security docs and regression hardening batch out of Next Release\n- leave v0.29 as the next backlog placeholder after the closed maintenance work\n- keep roadmap and GitHub release labels aligned with the current main branch state\n\n## Testing\n- npm run check