### PR TITLE
feat: add session auth context resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ license, subscription, private contract, or other written permission.
 - Maps Auth.js and Better Auth OAuth callback data into `ProviderIdentityAssertion` through the
   optional `@alyldas/uniauth/bridges` entry point.
 - Creates local session records after successful sign-in.
-- Exposes local session read-side helpers for token resolution, activity touch, and user session
-  listing.
+- Exposes local session read-side helpers for token resolution, trusted session-context resolution,
+  activity touch, and user session listing.
 - Exposes a narrow `getUser(userId)` helper for loading the active local user snapshot by id.
 - Exposes read-side helpers for credential and verification lookups through the public service
   layer.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,7 @@ identities, and email/phone are optional identity attributes.
 - `revokeSession`
 - `revokeUserSessions`
 - `resolveSession`
+- `resolveSessionContext`
 - `touchSession`
 - `getUser`
 - `getUserCredentials`
@@ -57,6 +58,10 @@ password hashing port, audit log port, verification secret hashing extension poi
 The audit log port is now read-capable as well as write-capable. Core still owns local security
 event creation, while trusted backend tooling can read the resulting `AuditEvent` timeline through
 the public service layer without reaching into adapter internals.
+
+Session resolution remains transport-agnostic. Core can now collapse `sessionToken -> session + user`
+into one trusted read-side helper, while cookie parsing, bearer extraction, and request decoration
+stay application-owned.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -100,8 +100,9 @@ app.post('/auth/password/sign-in', async (req, res, next) => {
 })
 ```
 
-For Express session middleware shape, bearer-vs-cookie extraction, and `touchSession(...)`
-placement, use [Session transport recipes](session-transport.md). The runnable
+For Express session middleware shape, bearer-vs-cookie extraction, and the
+`resolveSessionContext({ sessionToken, touch })` helper, use
+[Session transport recipes](session-transport.md). The runnable
 [Express auth module example](../examples/express-auth/index.ts) already shows that middleware in
 context.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -266,10 +266,18 @@ Tracking issues: #176, #177.
 
 ## Next Release
 
-### v0.30 - Backlog To Be Defined
+### v0.30 - Session Auth Context Resolution
 
-- Next releasable feature batch to be defined after the completed v0.29 internal decomposition pass
-  on `main`.
+- Public `resolveSessionContext({ sessionToken, touch?, now? })` API for backend middleware and
+  request-auth assembly.
+- Neutral collapse of stale local auth state so disabled or missing users behind a still-present
+  session record do not leak a different failure shape.
+- Framework examples and session-transport recipes moved from manual `resolveSession` +
+  `getUser` orchestration to the aggregate helper.
+- Focused regression coverage for stale-session and disabled-user auth-context flows across
+  in-memory and Postgres-backed service setups.
+
+Tracking issues: #184, #185, #186.
 
 ## Versioning
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -58,10 +58,9 @@ resolve the token through UniAuth instead of treating `Session.id` as the client
 ```ts
 const sessionToken = unsealSessionToken(request.cookies.session)
 
-const session = await authService.resolveSession({
+const { session, user } = await authService.resolveSessionContext({
   sessionToken,
 })
-const user = await authService.getUser(session.userId)
 
 return {
   user,
@@ -69,7 +68,11 @@ return {
 }
 ```
 
-Applications that track recent activity can then explicitly update `lastSeenAt` through the public
+`resolveSessionContext(...)` stays neutral for stale local auth state too: if the token resolves to
+an active session record but the linked local user is already disabled or missing, the helper still
+fails through the same `SessionNotFound` path expected by middleware.
+
+Applications that prefer explicit activity writes can still update `lastSeenAt` through the public
 service API:
 
 ```ts
@@ -119,9 +122,10 @@ export function createExpressSessionMiddleware(authService: AuthService) {
     }
 
     try {
-      const resolved = await authService.resolveSession({ sessionToken })
-      const session = await authService.touchSession({ sessionId: resolved.id })
-      const user = await authService.getUser(session.userId)
+      const { session, user } = await authService.resolveSessionContext({
+        sessionToken,
+        touch: true,
+      })
 
       request.auth = {
         session,
@@ -175,7 +179,7 @@ function readCookieToken(header: string | undefined): string | undefined {
 
 Attach the middleware only where browser/API auth context is needed, or pair it with a small
 `requireSession` guard for protected routes. If activity writes are too expensive for every request,
-skip `touchSession(...)` here and call it only on the authenticated routes that matter.
+set `touch: false` here and call `touchSession(...)` only on the authenticated routes that matter.
 
 ### Fastify preHandler Recipe
 
@@ -212,12 +216,13 @@ export function createFastifySessionPreHandler(authService: AuthService) {
     }
 
     try {
-      const resolved = await authService.resolveSession({ sessionToken })
-      const user = await authService.getUser(resolved.userId)
+      const { session, user } = await authService.resolveSessionContext({
+        sessionToken,
+      })
       request.auth = {
-        session: resolved,
+        session,
         user,
-        userId: resolved.userId,
+        userId: session.userId,
       }
     } catch (error) {
       if (
@@ -244,9 +249,9 @@ function readBearerToken(header: string | undefined): string | undefined {
 }
 ```
 
-Fastify users often keep `touchSession(...)` in a second protected-route hook or in the route
-handler itself, so lightweight public requests can resolve auth context without forcing an activity
-write every time.
+Fastify users often keep `touch: false` in the preHandler and call `touchSession(...)` in a second
+protected-route hook or in the route handler itself, so lightweight public requests can resolve auth
+context without forcing an activity write every time.
 
 If one authenticated request also needs device lists or sign-in methods, resolve the transport here
 and then hand off to `authService.getAccountSecuritySnapshot(userId)` as described in

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -314,11 +314,10 @@ function createExpressSessionMiddleware(
     }
 
     try {
-      const resolved = await authService.resolveSession({ sessionToken })
-      const session = options.touch
-        ? await authService.touchSession({ sessionId: resolved.id })
-        : resolved
-      const user = await authService.getUser(session.userId)
+      const { session, user } = await authService.resolveSessionContext({
+        sessionToken,
+        ...(options.touch !== undefined ? { touch: options.touch } : {}),
+      })
 
       request.auth = {
         session,

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -256,11 +256,10 @@ function createFastifySessionPreHandler(
     }
 
     try {
-      const resolved = await authService.resolveSession({ sessionToken })
-      const session = options.touch
-        ? await authService.touchSession({ sessionId: resolved.id })
-        : resolved
-      const user = await authService.getUser(session.userId)
+      const { session, user } = await authService.resolveSessionContext({
+        sessionToken,
+        ...(options.touch !== undefined ? { touch: options.touch } : {}),
+      })
 
       request.auth = {
         session,

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -56,6 +56,7 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.getUserCredentials).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getAccountInspectionSnapshot).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getAccountSecuritySnapshot).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.resolveSessionContext).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -13,6 +13,7 @@ import {
   startEmailPasswordRecovery,
 } from './passwords.js'
 import { type AuthServiceRuntime, createAuthServiceRuntime } from './runtime.js'
+import { resolveSessionContext } from './session-context.js'
 import {
   createSession,
   getUserSessions,
@@ -53,7 +54,9 @@ import type {
   MergeResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
+  ResolveSessionContextInput,
   ResolveSessionInput,
+  ResolvedSessionContext,
   Session,
   SessionId,
   SetPasswordInput,
@@ -167,6 +170,10 @@ export class DefaultAuthService implements AuthService {
 
   async resolveSession(input: ResolveSessionInput): Promise<Session> {
     return resolveSession(this.runtime, input)
+  }
+
+  async resolveSessionContext(input: ResolveSessionContextInput): Promise<ResolvedSessionContext> {
+    return resolveSessionContext(this.runtime, input)
   }
 
   async touchSession(input: TouchSessionInput): Promise<Session> {

--- a/src/application/session-context.ts
+++ b/src/application/session-context.ts
@@ -1,0 +1,43 @@
+import type { AuthServiceRuntime } from './runtime.js'
+import { optionalProp } from './optional.js'
+import { getActiveUser } from './support.js'
+import { resolveSession, touchSession } from './sessions.js'
+import type { ResolveSessionContextInput, ResolvedSessionContext } from '../domain/types.js'
+import { UniAuthError, UniAuthErrorCode, isUniAuthError } from '../errors.js'
+
+export async function resolveSessionContext(
+  runtime: AuthServiceRuntime,
+  input: ResolveSessionContextInput,
+): Promise<ResolvedSessionContext> {
+  const resolvedSession = await resolveSession(runtime, {
+    sessionToken: input.sessionToken,
+    ...optionalProp('now', input.now),
+  })
+  const user = await getResolvedSessionUser(runtime, resolvedSession.userId)
+  const session = input.touch
+    ? await touchSession(runtime, {
+        sessionId: resolvedSession.id,
+        ...optionalProp('now', input.now),
+      })
+    : resolvedSession
+
+  return {
+    session,
+    user,
+  }
+}
+
+async function getResolvedSessionUser(
+  runtime: AuthServiceRuntime,
+  userId: ResolvedSessionContext['user']['id'],
+): Promise<ResolvedSessionContext['user']> {
+  try {
+    return await getActiveUser(runtime, userId)
+  } catch (error) {
+    if (isUniAuthError(error) && error.code === UniAuthErrorCode.UserNotFound) {
+      throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
+    }
+
+    throw error
+  }
+}

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -89,6 +89,17 @@ export interface TouchSessionInput {
   readonly now?: Date
 }
 
+export interface ResolveSessionContextInput {
+  readonly sessionToken: string
+  readonly touch?: boolean
+  readonly now?: Date
+}
+
+export interface ResolvedSessionContext {
+  readonly session: Session
+  readonly user: User
+}
+
 export interface RevokeUserSessionsInput {
   readonly userId: UserId
   readonly exceptSessionId?: SessionId

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -17,7 +17,9 @@ import type {
   MergeResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
+  ResolveSessionContextInput,
   ResolveSessionInput,
+  ResolvedSessionContext,
   SignInInput,
   StartOtpChallengeInput,
   StartOtpChallengeResult,
@@ -79,6 +81,7 @@ export interface AuthService {
   revokeSession(sessionId: SessionId): Promise<void>
   revokeUserSessions(input: RevokeUserSessionsInput): Promise<RevokeUserSessionsResult>
   resolveSession(input: ResolveSessionInput): Promise<Session>
+  resolveSessionContext(input: ResolveSessionContextInput): Promise<ResolvedSessionContext>
   touchSession(input: TouchSessionInput): Promise<Session>
   getUser(userId: UserId): Promise<User>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -75,6 +75,39 @@ describe('DefaultAuthService read side and sessions', () => {
     )
   })
 
+  it('resolves a trusted session context and can optionally touch activity', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const result = await service.signIn({ assertion: assertion(), now })
+    const untouched = await service.resolveSessionContext({
+      sessionToken: result.sessionToken,
+      now,
+    })
+    const touchedAt = addSeconds(now, 60)
+    const touched = await service.resolveSessionContext({
+      sessionToken: result.sessionToken,
+      touch: true,
+      now: touchedAt,
+    })
+
+    expect(untouched).toEqual({
+      session: result.session,
+      user: result.user,
+    })
+    expect(touched).toEqual({
+      session: {
+        ...result.session,
+        lastSeenAt: touchedAt,
+      },
+      user: result.user,
+    })
+    expect(store.listSessions()).toEqual([
+      {
+        ...result.session,
+        lastSeenAt: touchedAt,
+      },
+    ])
+  })
+
   it('touches active sessions without rewinding last seen activity', async () => {
     const { service } = createInMemoryAuthKit()
     const result = await service.signIn({ assertion: assertion(), now })
@@ -91,6 +124,25 @@ describe('DefaultAuthService read side and sessions', () => {
         now: addSeconds(now, 30),
       }),
     ).toBe(touched)
+  })
+
+  it('treats disabled users behind an active session as a neutral session miss', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const result = await service.signIn({ assertion: assertion(), now })
+
+    await store.userRepo.update(result.user.id, { disabledAt: addSeconds(now, 10) })
+
+    await expect(
+      service.resolveSessionContext({
+        sessionToken: result.sessionToken,
+        touch: true,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+      message: 'Session was not found.',
+    })
+    expect(store.listSessions()).toEqual([result.session])
   })
 
   it('reads local credentials and verifications through the public service surface', async () => {

--- a/test/postgres/security-and-read-side.test.ts
+++ b/test/postgres/security-and-read-side.test.ts
@@ -174,6 +174,41 @@ describe('Postgres reference persistence security and read side', () => {
     })
   })
 
+  it('resolves a trusted session context on Postgres and can optionally touch activity', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-session-context',
+        email: 'pg-session-context@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const untouched = await service.resolveSessionContext({
+      sessionToken: signedIn.sessionToken,
+      now,
+    })
+    const touchedAt = addSeconds(now, 60)
+    const touched = await service.resolveSessionContext({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: touchedAt,
+    })
+
+    expect(untouched).toEqual({
+      session: signedIn.session,
+      user: signedIn.user,
+    })
+    expect(touched).toEqual({
+      session: {
+        ...signedIn.session,
+        lastSeenAt: touchedAt,
+      },
+      user: signedIn.user,
+    })
+  })
+
   it('lists local sessions for an active user on Postgres', async () => {
     const { service } = await createPostgresTestKit()
     const first = await service.signIn({
@@ -199,6 +234,35 @@ describe('Postgres reference persistence security and read side', () => {
       id: first.user.id,
       email: 'pg-list-sessions@example.com',
     })
+  })
+
+  it('treats disabled users behind an active Postgres session as a neutral session miss', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-disabled-session-context',
+        email: 'pg-disabled-session-context@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.resolveSessionContext({
+        sessionToken: signedIn.sessionToken,
+        touch: true,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+      message: 'Session was not found.',
+    })
+    expect(await store.sessionRepo.findById(signedIn.session.id)).toEqual(signedIn.session)
   })
 
   it('reads credentials and verifications through the public service surface on Postgres', async () => {

--- a/test/service-edges/sign-in-and-session-edge-cases.test.ts
+++ b/test/service-edges/sign-in-and-session-edge-cases.test.ts
@@ -14,6 +14,41 @@ import { InMemoryAuthStore, createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from '../helpers.js'
 
 describe('DefaultAuthService sign-in and session edge cases', () => {
+  it('rethrows unexpected user lookup failures from session-context resolution', async () => {
+    const store = new InMemoryAuthStore()
+    const setupService = new DefaultAuthService({ repos: store })
+    const result = await setupService.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'session-context-user-lookup-failure',
+      }),
+      now,
+    })
+    const lookupFailure = new Error('user lookup failed')
+    const service = new DefaultAuthService({
+      repos: {
+        userRepo: {
+          ...store.userRepo,
+          findById: async () => {
+            throw lookupFailure
+          },
+        },
+        identityRepo: store.identityRepo,
+        credentialRepo: store.credentialRepo,
+        verificationRepo: store.verificationRepo,
+        sessionRepo: store.sessionRepo,
+        auditLogRepo: store.auditLogRepo,
+      },
+    })
+
+    await expect(
+      service.resolveSessionContext({
+        sessionToken: result.sessionToken,
+        now,
+      }),
+    ).rejects.toBe(lookupFailure)
+  })
+
   it('covers uncommon sign-in, session, link, unlink, and read-side branches', async () => {
     const defaultStore = new InMemoryAuthStore()
     const defaultService = new DefaultAuthService({ repos: defaultStore })


### PR DESCRIPTION
## Summary

- add `resolveSessionContext({ sessionToken, touch?, now? })` to the public service surface
- collapse disabled or missing local users behind an active session into the neutral `SessionNotFound` path
- switch framework examples and session transport docs to the aggregate helper and add focused regressions

## Checks

- `npm run build`
- `npm run typecheck`
- `npm run check`

Closes #184
Closes #185
Closes #186
