### PR TITLE
docs: sync roadmap after v0.29.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -255,7 +255,7 @@ Tracking issues: #149, #150, #151, #152, #162.
 
 Tracking issues: #163, #164, #165, #175.
 
-### v0.29 - Internal Account and Test Decomposition
+### Post-v0.28 Maintenance Batch (Completed On Main Without Package Release)
 
 - Decompose the remaining account mutation flows into smaller internal modules with clearer
   ownership boundaries.
@@ -264,9 +264,7 @@ Tracking issues: #163, #164, #165, #175.
 
 Tracking issues: #176, #177.
 
-## Next Release
-
-### v0.30 - Session Auth Context Resolution
+### v0.29 - Session Auth Context Resolution
 
 - Public `resolveSessionContext({ sessionToken, touch?, now? })` API for backend middleware and
   request-auth assembly.
@@ -278,6 +276,12 @@ Tracking issues: #176, #177.
   in-memory and Postgres-backed service setups.
 
 Tracking issues: #184, #185, #186.
+
+## Next Release
+
+### v0.30 - Backlog To Be Defined
+
+- Next releasable feature batch to be defined after the `v0.29.0` session auth-context release.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

- move `v0.29` from next release into released after the published `v0.29.0` package
- keep the internal `#176/#177` batch documented as a non-release maintenance pass on `main`
- reset `v0.30` to the next placeholder after the session auth-context release

## Checks

- `npm run check`
