### PR TITLE
feat: add audit timeline cursor queries

### DIFF
--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -88,6 +88,22 @@ const events = await authService.getAuditEvents({
 The service returns local `AuditEvent` records newest-first. Keep outward serialization
 application-owned and expose only the fields your support or admin surface actually needs.
 
+For continuation-based trusted pagination, keep the cursor application-owned and derive it from the
+last event you already returned:
+
+```ts
+const firstPage = await authService.getAuditEvents({
+  userId,
+  limit: 20,
+})
+
+const nextPage = await authService.getAuditEvents({
+  userId,
+  before: toAuditEventCursor(firstPage.at(-1)!),
+  limit: 20,
+})
+```
+
 Typical server-safe outward shape:
 
 ```ts

--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -116,6 +116,22 @@ const auditEvents = await authService.getAuditEvents({
 })
 ```
 
+For continuation-friendly trusted pagination, derive the cursor from the last item you already
+returned and keep it server-owned:
+
+```ts
+const firstPage = await authService.getAuditEvents({
+  userId,
+  limit: 50,
+})
+
+const nextPage = await authService.getAuditEvents({
+  userId,
+  before: toAuditEventCursor(firstPage.at(-1)!),
+  limit: 50,
+})
+```
+
 Serialize only the operator-facing fields you actually need:
 
 ```ts

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -64,6 +64,7 @@ describe('package exports', () => {
     expect(core.toAccountInspectionSnapshot).toBeTypeOf('function')
     expect(core.toAccountSecuritySnapshot).toBeTypeOf('function')
     expect(core.toAuditEventView).toBeTypeOf('function')
+    expect(core.toAuditEventCursor).toBeTypeOf('function')
     expect(core.toAccountSecurityCredentialView).toBeTypeOf('function')
     expect(core.toVerificationStatusView).toBeTypeOf('function')
     expect(core.createMaxWebAppProvider).toBeTypeOf('function')

--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -1,5 +1,5 @@
 import type { AuthServiceRuntime } from './runtime.js'
-import type { AuditEvent, AuditEventQuery } from '../domain/types.js'
+import type { AuditEvent, AuditEventCursor, AuditEventQuery } from '../domain/types.js'
 import { invalidInput } from '../errors.js'
 import { assertValidDate } from '../utils/time.js'
 
@@ -14,9 +14,8 @@ export async function getAuditEvents(
 }
 
 function normalizeAuditEventQuery(input: AuditEventQuery): AuditEventQuery {
-  if (input.before !== undefined) {
-    assertValidDate(input.before, 'Audit event cursor time is invalid.')
-  }
+  const before = input.before ? normalizeAuditEventCursor(input.before) : undefined
+  const after = input.after ? normalizeAuditEventCursor(input.after) : undefined
 
   const limit = input.limit ?? DefaultAuditEventLimit
 
@@ -34,6 +33,37 @@ function normalizeAuditEventQuery(input: AuditEventQuery): AuditEventQuery {
 
   return {
     ...input,
+    ...(before ? { before } : {}),
+    ...(after ? { after } : {}),
     limit,
+  }
+}
+
+function normalizeAuditEventCursor(input: AuditEventCursor): AuditEventCursor {
+  if (!(input && typeof input === 'object')) {
+    throw invalidInput('Audit event cursor is invalid.')
+  }
+
+  const occurredAt = input.occurredAt
+
+  if (!(occurredAt instanceof Date)) {
+    throw invalidInput('Audit event cursor time is invalid.')
+  }
+
+  assertValidDate(occurredAt, 'Audit event cursor time is invalid.')
+
+  if (typeof input.id !== 'string') {
+    throw invalidInput('Audit event cursor id is invalid.')
+  }
+
+  const id = input.id.trim()
+
+  if (!id) {
+    throw invalidInput('Audit event cursor id is invalid.')
+  }
+
+  return {
+    occurredAt,
+    id: id as AuditEventCursor['id'],
   }
 }

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -25,11 +25,24 @@ export interface AuditEvent {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface AuditEventCursor {
+  readonly occurredAt: Date
+  readonly id: AuditEventId
+}
+
 export interface AuditEventQuery {
   readonly userId?: UserId
   readonly identityId?: IdentityId
   readonly sessionId?: SessionId
   readonly type?: AuditEventType
-  readonly before?: Date
+  readonly before?: AuditEventCursor
+  readonly after?: AuditEventCursor
   readonly limit?: number
+}
+
+export function toAuditEventCursor(event: AuditEvent): AuditEventCursor {
+  return {
+    occurredAt: event.occurredAt,
+    id: event.id,
+  }
 }

--- a/src/postgres/store/audit.ts
+++ b/src/postgres/store/audit.ts
@@ -45,8 +45,23 @@ export function createAuditLogRepo(context: PostgresStoreContext): AuditLogRepo 
       }
 
       if (input.before) {
-        values.push(input.before)
-        filters.push(`occurred_at < $${values.length}`)
+        values.push(input.before.occurredAt)
+        const beforeOccurredIndex = values.length
+        values.push(input.before.id)
+        const beforeIdIndex = values.length
+        filters.push(
+          `(occurred_at < $${beforeOccurredIndex} or (occurred_at = $${beforeOccurredIndex} and id < $${beforeIdIndex}))`,
+        )
+      }
+
+      if (input.after) {
+        values.push(input.after.occurredAt)
+        const afterOccurredIndex = values.length
+        values.push(input.after.id)
+        const afterIdIndex = values.length
+        filters.push(
+          `(occurred_at > $${afterOccurredIndex} or (occurred_at = $${afterOccurredIndex} and id > $${afterIdIndex}))`,
+        )
       }
 
       const whereClause = filters.length > 0 ? `where ${filters.join(' and ')}` : ''

--- a/src/testing/in-memory/store.ts
+++ b/src/testing/in-memory/store.ts
@@ -265,9 +265,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
         .filter((event) => (input.identityId ? event.identityId === input.identityId : true))
         .filter((event) => (input.sessionId ? event.sessionId === input.sessionId : true))
         .filter((event) => (input.type ? event.type === input.type : true))
-        .filter((event) =>
-          input.before ? event.occurredAt.getTime() < input.before.getTime() : true,
-        )
+        .filter((event) => (input.before ? isOlderThanAuditCursor(event, input.before) : true))
+        .filter((event) => (input.after ? isNewerThanAuditCursor(event, input.after) : true))
         .sort(compareAuditEventsDescending)
 
       return input.limit !== undefined ? events.slice(0, input.limit) : events
@@ -407,4 +406,30 @@ function compareAuditEventsDescending(left: AuditEvent, right: AuditEvent): numb
   }
 
   return right.id.localeCompare(left.id)
+}
+
+function isOlderThanAuditCursor(
+  event: AuditEvent,
+  cursor: { readonly occurredAt: Date; readonly id: AuditEvent['id'] },
+): boolean {
+  const occurredDifference = event.occurredAt.getTime() - cursor.occurredAt.getTime()
+
+  if (occurredDifference !== 0) {
+    return occurredDifference < 0
+  }
+
+  return event.id.localeCompare(cursor.id) < 0
+}
+
+function isNewerThanAuditCursor(
+  event: AuditEvent,
+  cursor: { readonly occurredAt: Date; readonly id: AuditEvent['id'] },
+): boolean {
+  const occurredDifference = event.occurredAt.getTime() - cursor.occurredAt.getTime()
+
+  if (occurredDifference !== 0) {
+    return occurredDifference > 0
+  }
+
+  return event.id.localeCompare(cursor.id) > 0
 }

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -9,7 +9,9 @@ import {
   UniAuthErrorCode,
   VerificationPurpose,
   addSeconds,
+  asAuditEventId,
   getUniAuthAttributionNotice,
+  toAuditEventCursor,
 } from '../../src'
 import { createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from './support.js'
@@ -245,7 +247,17 @@ describe('DefaultAuthService read side and sessions', () => {
     const sessionEvents = await service.getAuditEvents({ sessionId: signedIn.session.id, limit: 2 })
     const olderUserEvents = await service.getAuditEvents({
       userId: signedIn.user.id,
-      before: addSeconds(now, 1),
+      before: toAuditEventCursor(allEvents[0]!),
+      limit: 5,
+    })
+    const sameTimestampOlderEvents = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      before: toAuditEventCursor(userEvents[1]!),
+      limit: 5,
+    })
+    const sameTimestampNewerEvents = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      after: toAuditEventCursor(userEvents[2]!),
       limit: 5,
     })
 
@@ -267,6 +279,13 @@ describe('DefaultAuthService read side and sessions', () => {
     expect(olderUserEvents.map((event) => event.type)).toEqual([
       AuditEventType.SignIn,
       AuditEventType.SessionCreated,
+    ])
+    expect(sameTimestampOlderEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionCreated,
+    ])
+    expect(sameTimestampNewerEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
     ])
     expect(
       await service.getAuditEvents({
@@ -433,7 +452,47 @@ describe('DefaultAuthService read side and sessions', () => {
     })
     await expect(
       service.getAuditEvents({
-        before: new Date(Number.NaN),
+        before: {
+          occurredAt: new Date(Number.NaN),
+          id: asAuditEventId('audit-cursor'),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        // @ts-expect-error runtime validation for legacy callers
+        before: new Date(),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        // @ts-expect-error runtime validation for untyped callers
+        before: 123,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        before: {
+          occurredAt: now,
+          id: asAuditEventId('   '),
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.getAuditEvents({
+        before: {
+          occurredAt: now,
+          // @ts-expect-error runtime validation for untyped callers
+          id: 123,
+        },
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -14,6 +14,7 @@ import {
   asVerificationId,
   CredentialType,
   hashSecret,
+  toAuditEventCursor,
   type Credential,
   type Session,
   type Verification,
@@ -250,14 +251,22 @@ describe('InMemoryAuthStore', () => {
       identityId: emailIdentity.id,
       sessionId: session.id,
     })
+    await store.auditLogRepo.append({
+      id: asAuditEventId('audit-3'),
+      type: AuditEventType.SessionCreated,
+      occurredAt: addSeconds(now, 5),
+      userId: createdUser.id,
+      sessionId: session.id,
+    })
 
     expect(store.listUsers()).toHaveLength(2)
     expect(store.listIdentities()).toHaveLength(2)
     expect(store.listCredentials()).toHaveLength(2)
     expect(store.listVerifications()).toHaveLength(1)
     expect(store.listSessions()).toHaveLength(2)
-    expect(store.listAuditEvents()).toHaveLength(2)
+    expect(store.listAuditEvents()).toHaveLength(3)
     expect(await store.auditLogRepo.list()).toEqual([
+      expect.objectContaining({ id: asAuditEventId('audit-3') }),
       expect.objectContaining({ id: asAuditEventId('audit-2') }),
       expect.objectContaining({ id: asAuditEventId('audit-1') }),
     ])
@@ -266,13 +275,37 @@ describe('InMemoryAuthStore', () => {
         userId: createdUser.id,
         limit: 5,
       }),
-    ).toEqual([expect.objectContaining({ id: asAuditEventId('audit-2') })])
+    ).toEqual([
+      expect.objectContaining({ id: asAuditEventId('audit-3') }),
+      expect.objectContaining({ id: asAuditEventId('audit-2') }),
+    ])
     expect(
       await store.auditLogRepo.list({
         identityId: emailIdentity.id,
         sessionId: session.id,
       }),
     ).toEqual([expect.objectContaining({ id: asAuditEventId('audit-2') })])
+    expect(
+      await store.auditLogRepo.list({
+        before: toAuditEventCursor({
+          id: asAuditEventId('audit-3'),
+          type: AuditEventType.SessionCreated,
+          occurredAt: addSeconds(now, 5),
+        }),
+      }),
+    ).toEqual([
+      expect.objectContaining({ id: asAuditEventId('audit-2') }),
+      expect.objectContaining({ id: asAuditEventId('audit-1') }),
+    ])
+    expect(
+      await store.auditLogRepo.list({
+        after: toAuditEventCursor({
+          id: asAuditEventId('audit-2'),
+          type: AuditEventType.SignIn,
+          occurredAt: addSeconds(now, 5),
+        }),
+      }),
+    ).toEqual([expect.objectContaining({ id: asAuditEventId('audit-3') })])
   })
 
   it('rolls back outer state while allowing nested transaction reuse', async () => {

--- a/test/postgres/security-and-read-side.test.ts
+++ b/test/postgres/security-and-read-side.test.ts
@@ -7,6 +7,7 @@ import {
   VerificationPurpose,
   addSeconds,
   createDefaultAuthPolicy,
+  toAuditEventCursor,
 } from '../../src'
 import { createPostgresTestKit, now } from './support.js'
 
@@ -360,20 +361,23 @@ describe('Postgres reference persistence security and read side', () => {
     })
     await service.revokeSession(signedIn.session.id)
 
-    expect((await service.getAuditEvents()).map((event) => event.type)).toEqual([
+    const allEvents = await service.getAuditEvents()
+    const userEvents = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      limit: 3,
+    })
+
+    expect(allEvents.map((event) => event.type)).toEqual([
       AuditEventType.SessionRevoked,
       AuditEventType.VerificationCreated,
       AuditEventType.SignIn,
       AuditEventType.SessionCreated,
     ])
-    expect(
-      (
-        await service.getAuditEvents({
-          userId: signedIn.user.id,
-          limit: 3,
-        })
-      ).map((event) => event.type),
-    ).toEqual([AuditEventType.SessionRevoked, AuditEventType.SignIn, AuditEventType.SessionCreated])
+    expect(userEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
     expect(
       (
         await service.getAuditEvents({
@@ -387,11 +391,29 @@ describe('Postgres reference persistence security and read side', () => {
         await service.getAuditEvents({
           identityId: signedIn.identity.id,
           type: AuditEventType.SignIn,
-          before: addSeconds(now, 1),
+          before: toAuditEventCursor(allEvents[0]!),
           limit: 5,
         })
       ).map((event) => event.type),
     ).toEqual([AuditEventType.SignIn])
+    expect(
+      (
+        await service.getAuditEvents({
+          userId: signedIn.user.id,
+          before: toAuditEventCursor(userEvents[1]!),
+          limit: 5,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SessionCreated])
+    expect(
+      (
+        await service.getAuditEvents({
+          userId: signedIn.user.id,
+          after: toAuditEventCursor(userEvents[2]!),
+          limit: 5,
+        })
+      ).map((event) => event.type),
+    ).toEqual([AuditEventType.SessionRevoked, AuditEventType.SignIn])
     expect(
       (
         await store.auditLogRepo.list({


### PR DESCRIPTION
Closes #190

## Summary
- add stable composite before/after cursors for audit timeline reads
- keep in-memory and Postgres audit ordering and pagination semantics aligned
- document continuation-friendly trusted audit timeline reads