### PR TITLE
feat: add inspection audit windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ license, subscription, private contract, or other written permission.
 - Exposes safe projection helpers for account-security and verification-status read-side flows.
 - Exposes an aggregated `getAccountSecuritySnapshot(userId)` read-side API for account-security
   screens.
-- Exposes a trusted `getAccountInspectionSnapshot({ userId, auditLimit? })` aggregate read-side
+- Exposes a trusted `getAccountInspectionSnapshot({ userId, audit? })` aggregate read-side
   API for backend support and admin inspection flows.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
 - Uses explicit policy for auto-linking, unlinking, re-auth, and account merge decisions.
@@ -294,7 +294,9 @@ Trusted backend tooling can start from one trusted aggregate inspection helper:
 ```ts
 const inspection = await service.getAccountInspectionSnapshot({
   userId,
-  auditLimit: 20,
+  audit: {
+    limit: 20,
+  },
 })
 ```
 

--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -28,7 +28,9 @@ The preferred starting point is the trusted aggregate inspection helper:
 ```ts
 const inspection = await authService.getAccountInspectionSnapshot({
   userId,
-  auditLimit: 50,
+  audit: {
+    limit: 50,
+  },
 })
 ```
 
@@ -176,6 +178,19 @@ operator clients.
 
 ## Combined Inspection Service
 
+For a continuation-friendly next page, stay on the same aggregate helper and derive the cursor from
+the last already returned audit item:
+
+```ts
+const nextInspection = await authService.getAccountInspectionSnapshot({
+  userId,
+  audit: {
+    limit: 50,
+    before: toAuditEventCursor(inspection.auditEvents.at(-1)!),
+  },
+})
+```
+
 One practical server-side composition pattern is to build one trusted service function and let the
 framework layer own authorization and HTTP response shaping:
 
@@ -186,7 +201,9 @@ async function inspectAccountSecurity(input: {
 }) {
   const inspection = await authService.getAccountInspectionSnapshot({
     userId: input.userId,
-    auditLimit: 50,
+    audit: {
+      limit: 50,
+    },
   })
 
   const verificationStatus = input.verificationId

--- a/src/application/account-inspection.ts
+++ b/src/application/account-inspection.ts
@@ -12,9 +12,13 @@ export async function getAccountInspectionSnapshot(
   input: GetAccountInspectionSnapshotInput,
 ): Promise<AccountInspectionSnapshot> {
   const account = await getAccountSecuritySnapshot(runtime, input.userId)
+  const auditWindow = input.audit
+  const auditLimit = auditWindow?.limit ?? input.auditLimit
   const auditEvents = await getAuditEvents(runtime, {
     userId: account.user.id,
-    ...(input.auditLimit !== undefined ? { limit: input.auditLimit } : {}),
+    ...(auditWindow?.before ? { before: auditWindow.before } : {}),
+    ...(auditWindow?.after ? { after: auditWindow.after } : {}),
+    ...(auditLimit !== undefined ? { limit: auditLimit } : {}),
   })
 
   return toAccountInspectionSnapshot({

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -40,7 +40,7 @@ export interface AuditEventQuery {
   readonly limit?: number
 }
 
-export function toAuditEventCursor(event: AuditEvent): AuditEventCursor {
+export function toAuditEventCursor(event: Pick<AuditEvent, 'occurredAt' | 'id'>): AuditEventCursor {
   return {
     occurredAt: event.occurredAt,
     id: event.id,

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -5,6 +5,7 @@ import type {
   User,
   Verification,
 } from './entities.js'
+import type { AuditEventQuery } from './audit.js'
 import type { CredentialId, IdentityId, SessionId, UserId, VerificationId } from './ids.js'
 import type { OtpChannel, VerificationPurpose } from './kinds.js'
 import type { AuthIdentityProvider, FinishInput } from './providers.js'
@@ -111,9 +112,16 @@ export interface RevokeUserSessionsResult {
   readonly revokedSessionIds: readonly SessionId[]
 }
 
+export interface AccountInspectionAuditWindow {
+  readonly before?: AuditEventQuery['before']
+  readonly after?: AuditEventQuery['after']
+  readonly limit?: AuditEventQuery['limit']
+}
+
 export interface GetAccountInspectionSnapshotInput {
   readonly userId: UserId
   readonly auditLimit?: number
+  readonly audit?: AccountInspectionAuditWindow
 }
 
 export interface CreateVerificationInput {

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -358,6 +358,34 @@ describe('DefaultAuthService read side and sessions', () => {
     expect(
       (await service.getAccountInspectionSnapshot({ userId: signedIn.user.id })).auditEvents,
     ).toHaveLength(3)
+
+    const firstWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+    const continuationWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: toAuditEventCursor(firstWindow.auditEvents.at(-1)!),
+      },
+    })
+    const emptyWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(firstWindow.auditEvents[0]!),
+      },
+    })
+
+    expect(firstWindow.auditEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+    ])
+    expect(continuationWindow.auditEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionCreated,
+    ])
+    expect(emptyWindow.auditEvents).toEqual([])
   })
 
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -289,7 +289,6 @@ describe('InMemoryAuthStore', () => {
       await store.auditLogRepo.list({
         before: toAuditEventCursor({
           id: asAuditEventId('audit-3'),
-          type: AuditEventType.SessionCreated,
           occurredAt: addSeconds(now, 5),
         }),
       }),
@@ -301,7 +300,6 @@ describe('InMemoryAuthStore', () => {
       await store.auditLogRepo.list({
         after: toAuditEventCursor({
           id: asAuditEventId('audit-2'),
-          type: AuditEventType.SignIn,
           occurredAt: addSeconds(now, 5),
         }),
       }),

--- a/test/postgres/security-and-read-side.test.ts
+++ b/test/postgres/security-and-read-side.test.ts
@@ -476,6 +476,34 @@ describe('Postgres reference persistence security and read side', () => {
         },
       ],
     })
+
+    const firstWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+    const continuationWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: toAuditEventCursor(firstWindow.auditEvents.at(-1)!),
+      },
+    })
+    const emptyWindow = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(firstWindow.auditEvents[0]!),
+      },
+    })
+
+    expect(firstWindow.auditEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+    ])
+    expect(continuationWindow.auditEvents.map((event) => event.type)).toEqual([
+      AuditEventType.SessionCreated,
+    ])
+    expect(emptyWindow.auditEvents).toEqual([])
   })
 
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {


### PR DESCRIPTION
Closes #191

## Summary
- extend account inspection input with continuation-friendly audit windows
- keep aggregate inspection on the public API for trusted support/admin pagination
- cover default, continuation, and empty-window behavior on in-memory and Postgres