### PR TITLE
test: harden audit pagination parity

### DIFF
--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -191,18 +191,21 @@ const nextInspection = await authService.getAccountInspectionSnapshot({
 })
 ```
 
-One practical server-side composition pattern is to build one trusted service function and let the
+One practical server-side composition pattern is to keep pagination state explicit and let the
 framework layer own authorization and HTTP response shaping:
 
 ```ts
 async function inspectAccountSecurity(input: {
   readonly userId: string
   readonly verificationId?: string
+  readonly before?: ReturnType<typeof toAuditEventCursor>
+  readonly limit?: number
 }) {
   const inspection = await authService.getAccountInspectionSnapshot({
     userId: input.userId,
     audit: {
-      limit: 50,
+      limit: input.limit ?? 50,
+      ...(input.before ? { before: input.before } : {}),
     },
   })
 
@@ -212,6 +215,10 @@ async function inspectAccountSecurity(input: {
 
   return {
     inspection,
+    nextAuditCursor:
+      inspection.auditEvents.length > 0
+        ? toAuditEventCursor(inspection.auditEvents.at(-1)!)
+        : undefined,
     verificationStatus,
   }
 }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,3 +1,4 @@
 import './core/read-side-and-sessions.test.js'
+import './core/audit-pagination.test.js'
 import './core/otp-and-verifications.test.js'
 import './core/policies-and-merge.test.js'

--- a/test/core/audit-pagination.test.ts
+++ b/test/core/audit-pagination.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { AuditEventType, VerificationPurpose, addSeconds, toAuditEventCursor } from '../../src'
+import { createInMemoryAuthKit } from '../../src/testing'
+import { assertion, now } from './support.js'
+
+describe('DefaultAuthService audit pagination parity', () => {
+  it('keeps raw audit pagination and aggregate inspection windows aligned in-memory', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'audit-page-reader',
+        email: 'audit-page-reader@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'audit-page-reader@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    const rawFirstPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+
+    expect(rawFirstPage.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+    ])
+    expect(inspectionFirstPage.auditEvents.map((event) => event.id)).toEqual(
+      rawFirstPage.map((event) => event.id),
+    )
+
+    const rawNextPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      before: toAuditEventCursor(rawFirstPage.at(-1)!),
+      limit: 2,
+    })
+    const inspectionNextPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: toAuditEventCursor(inspectionFirstPage.auditEvents.at(-1)!),
+      },
+    })
+
+    expect(rawNextPage.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
+    expect(inspectionNextPage.auditEvents.map((event) => event.id)).toEqual(
+      rawNextPage.map((event) => event.id),
+    )
+
+    const rawEmptyPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      after: toAuditEventCursor(rawFirstPage[0]!),
+      limit: 2,
+    })
+    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
+      },
+    })
+
+    expect(rawEmptyPage).toEqual([])
+    expect(inspectionEmptyPage.auditEvents).toEqual([])
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,2 +1,3 @@
 import './postgres/security-and-read-side.test.js'
+import './postgres/audit-pagination.test.js'
 import './postgres/persistence-and-merge.test.js'

--- a/test/postgres/audit-pagination.test.ts
+++ b/test/postgres/audit-pagination.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { AuditEventType, VerificationPurpose, addSeconds, toAuditEventCursor } from '../../src'
+import { createPostgresTestKit, now } from './support.js'
+
+describe('Postgres audit pagination parity', () => {
+  it('keeps raw audit pagination and aggregate inspection windows aligned on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-audit-page-reader',
+        email: 'pg-audit-page-reader@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'pg-audit-page-reader@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    const rawFirstPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+
+    expect(rawFirstPage.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.SignIn,
+    ])
+    expect(inspectionFirstPage.auditEvents.map((event) => event.id)).toEqual(
+      rawFirstPage.map((event) => event.id),
+    )
+
+    const rawNextPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      before: toAuditEventCursor(rawFirstPage.at(-1)!),
+      limit: 2,
+    })
+    const inspectionNextPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: toAuditEventCursor(inspectionFirstPage.auditEvents.at(-1)!),
+      },
+    })
+
+    expect(rawNextPage.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
+    expect(inspectionNextPage.auditEvents.map((event) => event.id)).toEqual(
+      rawNextPage.map((event) => event.id),
+    )
+
+    const rawEmptyPage = await service.getAuditEvents({
+      userId: signedIn.user.id,
+      after: toAuditEventCursor(rawFirstPage[0]!),
+      limit: 2,
+    })
+    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
+      },
+    })
+
+    expect(rawEmptyPage).toEqual([])
+    expect(inspectionEmptyPage.auditEvents).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #192

## Summary
- add focused raw-vs-aggregate audit pagination parity tests for in-memory and Postgres
- cover continuation and empty-window behavior on the trusted inspection helper
- document a canonical support inspection recipe with explicit next-audit cursors