### PR TITLE
feat: add audit event page API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ license, subscription, private contract, or other written permission.
 - Exposes a narrow `getUser(userId)` helper for loading the active local user snapshot by id.
 - Exposes read-side helpers for credential and verification lookups through the public service
   layer.
-- Exposes a public audit-event read-side API for trusted security timelines and support tooling.
+- Exposes public audit-event slice and page read-side APIs for trusted security timelines and
+  support tooling.
 - Exposes safe projection helpers for account-security and verification-status read-side flows.
 - Exposes an aggregated `getAccountSecuritySnapshot(userId)` read-side API for account-security
   screens.
@@ -301,7 +302,8 @@ const inspection = await service.getAccountInspectionSnapshot({
 ```
 
 If the surrounding tooling truly needs raw audit entities, custom filters, or metadata-aware
-serialization, `getAuditEvents(...)` remains available as the narrower read-side primitive.
+serialization, `getAuditEvents(...)` and `getAuditEventPage(...)` remain available as the narrower
+read-side primitives.
 
 Messenger Mini App providers are SDK-free `AuthProvider` adapters for signed Telegram and MAX
 launch data. See [Messenger providers](docs/messenger-providers.md).

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -79,10 +79,12 @@ Do not serialize:
 For trusted backend security timelines or support inspection:
 
 ```ts
-const events = await authService.getAuditEvents({
+const page = await authService.getAuditEventPage({
   userId,
   limit: 20,
 })
+
+const events = page.events
 ```
 
 The service returns local `AuditEvent` records newest-first. Keep outward serialization
@@ -92,14 +94,14 @@ For continuation-based trusted pagination, keep the cursor application-owned and
 last event you already returned:
 
 ```ts
-const firstPage = await authService.getAuditEvents({
+const firstPage = await authService.getAuditEventPage({
   userId,
   limit: 20,
 })
 
-const nextPage = await authService.getAuditEvents({
+const nextPage = await authService.getAuditEventPage({
   userId,
-  before: toAuditEventCursor(firstPage.at(-1)!),
+  before: firstPage.nextCursor,
   limit: 20,
 })
 ```

--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -112,24 +112,26 @@ If the operator surface needs a custom audit filter or explicitly needs raw audi
 down to the narrower audit API:
 
 ```ts
-const auditEvents = await authService.getAuditEvents({
+const auditPage = await authService.getAuditEventPage({
   userId,
   limit: 50,
 })
+
+const auditEvents = auditPage.events
 ```
 
 For continuation-friendly trusted pagination, derive the cursor from the last item you already
 returned and keep it server-owned:
 
 ```ts
-const firstPage = await authService.getAuditEvents({
+const firstPage = await authService.getAuditEventPage({
   userId,
   limit: 50,
 })
 
-const nextPage = await authService.getAuditEvents({
+const nextPage = await authService.getAuditEventPage({
   userId,
-  before: toAuditEventCursor(firstPage.at(-1)!),
+  before: firstPage.nextCursor,
   limit: 50,
 })
 ```

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -56,6 +56,7 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.getUserCredentials).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getAccountInspectionSnapshot).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getAccountSecuritySnapshot).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getAuditEventPage).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.resolveSessionContext).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')

--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -1,9 +1,19 @@
 import type { AuthServiceRuntime } from './runtime.js'
-import type { AuditEvent, AuditEventCursor, AuditEventQuery } from '../domain/types.js'
+import {
+  toAuditEventCursor,
+  type AuditEvent,
+  type AuditEventCursor,
+  type AuditEventPage,
+  type AuditEventQuery,
+} from '../domain/types.js'
 import { invalidInput } from '../errors.js'
 import { assertValidDate } from '../utils/time.js'
 
 const DefaultAuditEventLimit = 50
+
+interface NormalizedAuditEventQuery extends AuditEventQuery {
+  readonly limit: number
+}
 
 export async function getAuditEvents(
   runtime: AuthServiceRuntime,
@@ -13,7 +23,28 @@ export async function getAuditEvents(
   return runtime.repos.auditLogRepo.list(query)
 }
 
-function normalizeAuditEventQuery(input: AuditEventQuery): AuditEventQuery {
+export async function getAuditEventPage(
+  runtime: AuthServiceRuntime,
+  input: AuditEventQuery = {},
+): Promise<AuditEventPage> {
+  const query = normalizeAuditEventQuery(input)
+  const matchingEvents = await runtime.repos.auditLogRepo.list({
+    ...query,
+    limit: query.limit + 1,
+  })
+  const events = matchingEvents.slice(0, query.limit)
+  const nextCursor =
+    matchingEvents.length > query.limit && events.length > 0
+      ? toAuditEventCursor(events.at(-1)!)
+      : undefined
+
+  return {
+    events,
+    ...(nextCursor ? { nextCursor } : {}),
+  }
+}
+
+function normalizeAuditEventQuery(input: AuditEventQuery): NormalizedAuditEventQuery {
   const before = input.before ? normalizeAuditEventCursor(input.before) : undefined
   const after = input.after ? normalizeAuditEventCursor(input.after) : undefined
 

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -1,6 +1,6 @@
 import { getAccountInspectionSnapshot } from './account-inspection.js'
 import { getAccountSecuritySnapshot } from './account-security.js'
-import { getAuditEvents } from './audit-events.js'
+import { getAuditEventPage, getAuditEvents } from './audit-events.js'
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import { finishEmailMagicLinkSignIn, startEmailMagicLinkSignIn } from './magic-link.js'
@@ -31,6 +31,7 @@ import type {
   AccountInspectionSnapshot,
   AccountSecuritySnapshot,
   AuditEvent,
+  AuditEventPage,
   AuditEventQuery,
   AuthResult,
   AuthService,
@@ -198,6 +199,10 @@ export class DefaultAuthService implements AuthService {
 
   async getAuditEvents(input?: AuditEventQuery): Promise<readonly AuditEvent[]> {
     return getAuditEvents(this.runtime, input)
+  }
+
+  async getAuditEventPage(input?: AuditEventQuery): Promise<AuditEventPage> {
+    return getAuditEventPage(this.runtime, input)
   }
 
   async getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot> {

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -40,6 +40,11 @@ export interface AuditEventQuery {
   readonly limit?: number
 }
 
+export interface AuditEventPage {
+  readonly events: readonly AuditEvent[]
+  readonly nextCursor?: AuditEventCursor
+}
+
 export function toAuditEventCursor(event: Pick<AuditEvent, 'occurredAt' | 'id'>): AuditEventCursor {
   return {
     occurredAt: event.occurredAt,

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -1,6 +1,6 @@
 import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
 import type { AccountInspectionSnapshot, AccountSecuritySnapshot } from './views.js'
-import type { AuditEvent, AuditEventQuery } from './audit.js'
+import type { AuditEvent, AuditEventPage, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
   ConsumeVerificationInput,
@@ -88,6 +88,7 @@ export interface AuthService {
   getUserCredentials(userId: UserId): Promise<readonly Credential[]>
   getUserSessions(userId: UserId): Promise<readonly Session[]>
   getAuditEvents(input?: AuditEventQuery): Promise<readonly AuditEvent[]>
+  getAuditEventPage(input?: AuditEventQuery): Promise<AuditEventPage>
   getAccountSecuritySnapshot(userId: UserId): Promise<AccountSecuritySnapshot>
   getAccountInspectionSnapshot(
     input: GetAccountInspectionSnapshotInput,

--- a/test/core/audit-pagination.test.ts
+++ b/test/core/audit-pagination.test.ts
@@ -4,7 +4,7 @@ import { createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from './support.js'
 
 describe('DefaultAuthService audit pagination parity', () => {
-  it('keeps raw audit pagination and aggregate inspection windows aligned in-memory', async () => {
+  it('returns older-page metadata for the raw audit page helper in-memory', async () => {
     const { service } = createInMemoryAuthKit()
     const signedIn = await service.signIn({
       assertion: assertion({
@@ -23,55 +23,44 @@ describe('DefaultAuthService audit pagination parity', () => {
     })
     await service.revokeSession(signedIn.session.id)
 
-    const rawFirstPage = await service.getAuditEvents({
+    const rawFirstPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
       limit: 2,
     })
-    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: { limit: 2 },
-    })
 
-    expect(rawFirstPage.map((event) => event.type)).toEqual([
+    expect(rawFirstPage.events.map((event) => event.type)).toEqual([
       AuditEventType.SessionRevoked,
       AuditEventType.SignIn,
     ])
-    expect(inspectionFirstPage.auditEvents.map((event) => event.id)).toEqual(
-      rawFirstPage.map((event) => event.id),
-    )
+    expect(rawFirstPage.nextCursor).toEqual(toAuditEventCursor(rawFirstPage.events[1]!))
+    expect(
+      (await service.getAuditEventPage({ userId: signedIn.user.id })).events.map(
+        (event) => event.type,
+      ),
+    ).toEqual([AuditEventType.SessionRevoked, AuditEventType.SignIn, AuditEventType.SessionCreated])
+    expect((await service.getAuditEventPage()).events.map((event) => event.type)).toEqual([
+      AuditEventType.SessionRevoked,
+      AuditEventType.VerificationCreated,
+      AuditEventType.SignIn,
+      AuditEventType.SessionCreated,
+    ])
 
-    const rawNextPage = await service.getAuditEvents({
+    const rawNextPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
-      before: toAuditEventCursor(rawFirstPage.at(-1)!),
+      before: rawFirstPage.nextCursor!,
       limit: 2,
     })
-    const inspectionNextPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: {
-        limit: 2,
-        before: toAuditEventCursor(inspectionFirstPage.auditEvents.at(-1)!),
-      },
-    })
 
-    expect(rawNextPage.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
-    expect(inspectionNextPage.auditEvents.map((event) => event.id)).toEqual(
-      rawNextPage.map((event) => event.id),
-    )
+    expect(rawNextPage.events.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
+    expect(rawNextPage.nextCursor).toBeUndefined()
 
-    const rawEmptyPage = await service.getAuditEvents({
+    const rawEmptyPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
-      after: toAuditEventCursor(rawFirstPage[0]!),
+      after: toAuditEventCursor(rawFirstPage.events[0]!),
       limit: 2,
     })
-    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: {
-        limit: 2,
-        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
-      },
-    })
 
-    expect(rawEmptyPage).toEqual([])
-    expect(inspectionEmptyPage.auditEvents).toEqual([])
+    expect(rawEmptyPage.events).toEqual([])
+    expect(rawEmptyPage.nextCursor).toBeUndefined()
   })
 })

--- a/test/postgres/audit-pagination.test.ts
+++ b/test/postgres/audit-pagination.test.ts
@@ -3,7 +3,7 @@ import { AuditEventType, VerificationPurpose, addSeconds, toAuditEventCursor } f
 import { createPostgresTestKit, now } from './support.js'
 
 describe('Postgres audit pagination parity', () => {
-  it('keeps raw audit pagination and aggregate inspection windows aligned on Postgres', async () => {
+  it('returns older-page metadata for the raw audit page helper on Postgres', async () => {
     const { service } = await createPostgresTestKit()
     const signedIn = await service.signIn({
       assertion: {
@@ -23,55 +23,33 @@ describe('Postgres audit pagination parity', () => {
     })
     await service.revokeSession(signedIn.session.id)
 
-    const rawFirstPage = await service.getAuditEvents({
+    const rawFirstPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
       limit: 2,
     })
-    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: { limit: 2 },
-    })
 
-    expect(rawFirstPage.map((event) => event.type)).toEqual([
+    expect(rawFirstPage.events.map((event) => event.type)).toEqual([
       AuditEventType.SessionRevoked,
       AuditEventType.SignIn,
     ])
-    expect(inspectionFirstPage.auditEvents.map((event) => event.id)).toEqual(
-      rawFirstPage.map((event) => event.id),
-    )
+    expect(rawFirstPage.nextCursor).toEqual(toAuditEventCursor(rawFirstPage.events[1]!))
 
-    const rawNextPage = await service.getAuditEvents({
+    const rawNextPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
-      before: toAuditEventCursor(rawFirstPage.at(-1)!),
+      before: rawFirstPage.nextCursor!,
       limit: 2,
     })
-    const inspectionNextPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: {
-        limit: 2,
-        before: toAuditEventCursor(inspectionFirstPage.auditEvents.at(-1)!),
-      },
-    })
 
-    expect(rawNextPage.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
-    expect(inspectionNextPage.auditEvents.map((event) => event.id)).toEqual(
-      rawNextPage.map((event) => event.id),
-    )
+    expect(rawNextPage.events.map((event) => event.type)).toEqual([AuditEventType.SessionCreated])
+    expect(rawNextPage.nextCursor).toBeUndefined()
 
-    const rawEmptyPage = await service.getAuditEvents({
+    const rawEmptyPage = await service.getAuditEventPage({
       userId: signedIn.user.id,
-      after: toAuditEventCursor(rawFirstPage[0]!),
+      after: toAuditEventCursor(rawFirstPage.events[0]!),
       limit: 2,
     })
-    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
-      userId: signedIn.user.id,
-      audit: {
-        limit: 2,
-        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
-      },
-    })
 
-    expect(rawEmptyPage).toEqual([])
-    expect(inspectionEmptyPage.auditEvents).toEqual([])
+    expect(rawEmptyPage.events).toEqual([])
+    expect(rawEmptyPage.nextCursor).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #199

## Summary
- add a page-oriented audit read-side API with older-page continuation metadata
- keep the existing raw audit slice API untouched for narrow callers
- update trusted timeline docs and smoke coverage for the new public surface