### PR TITLE
feat: add inspection audit page metadata

### DIFF
--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -88,6 +88,7 @@ return {
     identityId: event.identityId ?? null,
     sessionId: event.sessionId ?? null,
   })),
+  nextAuditCursor: inspection.nextAuditCursor ?? null,
 }
 ```
 
@@ -180,15 +181,15 @@ operator clients.
 
 ## Combined Inspection Service
 
-For a continuation-friendly next page, stay on the same aggregate helper and derive the cursor from
-the last already returned audit item:
+For a continuation-friendly next page, stay on the same aggregate helper and reuse the metadata it
+already returns:
 
 ```ts
 const nextInspection = await authService.getAccountInspectionSnapshot({
   userId,
   audit: {
     limit: 50,
-    before: toAuditEventCursor(inspection.auditEvents.at(-1)!),
+    before: inspection.nextAuditCursor,
   },
 })
 ```
@@ -200,7 +201,9 @@ framework layer own authorization and HTTP response shaping:
 async function inspectAccountSecurity(input: {
   readonly userId: string
   readonly verificationId?: string
-  readonly before?: ReturnType<typeof toAuditEventCursor>
+  readonly before?: NonNullable<
+    Awaited<ReturnType<typeof authService.getAccountInspectionSnapshot>>['nextAuditCursor']
+  >
   readonly limit?: number
 }) {
   const inspection = await authService.getAccountInspectionSnapshot({
@@ -217,10 +220,7 @@ async function inspectAccountSecurity(input: {
 
   return {
     inspection,
-    nextAuditCursor:
-      inspection.auditEvents.length > 0
-        ? toAuditEventCursor(inspection.auditEvents.at(-1)!)
-        : undefined,
+    nextAuditCursor: inspection.nextAuditCursor,
     verificationStatus,
   }
 }

--- a/src/application/account-inspection.ts
+++ b/src/application/account-inspection.ts
@@ -1,6 +1,6 @@
 import type { AuthServiceRuntime } from './runtime.js'
 import { getAccountSecuritySnapshot } from './account-security.js'
-import { getAuditEvents } from './audit-events.js'
+import { getAuditEventPage } from './audit-events.js'
 import {
   toAccountInspectionSnapshot,
   type AccountInspectionSnapshot,
@@ -14,7 +14,7 @@ export async function getAccountInspectionSnapshot(
   const account = await getAccountSecuritySnapshot(runtime, input.userId)
   const auditWindow = input.audit
   const auditLimit = auditWindow?.limit ?? input.auditLimit
-  const auditEvents = await getAuditEvents(runtime, {
+  const auditPage = await getAuditEventPage(runtime, {
     userId: account.user.id,
     ...(auditWindow?.before ? { before: auditWindow.before } : {}),
     ...(auditWindow?.after ? { after: auditWindow.after } : {}),
@@ -23,6 +23,7 @@ export async function getAccountInspectionSnapshot(
 
   return toAccountInspectionSnapshot({
     account,
-    auditEvents,
+    auditEvents: auditPage.events,
+    ...(auditPage.nextCursor ? { nextAuditCursor: auditPage.nextCursor } : {}),
   })
 }

--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -1,4 +1,4 @@
-import type { AuditEvent } from './audit.js'
+import type { AuditEvent, AuditEventCursor } from './audit.js'
 import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
 import type { ProviderTrustLevel } from './kinds.js'
 
@@ -62,6 +62,7 @@ export interface AuditEventView {
 export interface AccountInspectionSnapshot {
   readonly account: AccountSecuritySnapshot
   readonly auditEvents: readonly AuditEventView[]
+  readonly nextAuditCursor?: AuditEventCursor
 }
 
 export interface VerificationStatusView {
@@ -151,10 +152,12 @@ export function toAuditEventView(event: AuditEvent): AuditEventView {
 export function toAccountInspectionSnapshot(input: {
   readonly account: AccountSecuritySnapshot
   readonly auditEvents: readonly AuditEvent[]
+  readonly nextAuditCursor?: AuditEventCursor
 }): AccountInspectionSnapshot {
   return {
     account: input.account,
     auditEvents: input.auditEvents.map((event) => toAuditEventView(event)),
+    ...(input.nextAuditCursor ? { nextAuditCursor: input.nextAuditCursor } : {}),
   }
 }
 

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -382,10 +382,13 @@ describe('DefaultAuthService read side and sessions', () => {
       AuditEventType.SessionRevoked,
       AuditEventType.SignIn,
     ])
+    expect(firstWindow.nextAuditCursor).toEqual(toAuditEventCursor(firstWindow.auditEvents.at(-1)!))
     expect(continuationWindow.auditEvents.map((event) => event.type)).toEqual([
       AuditEventType.SessionCreated,
     ])
+    expect(continuationWindow.nextAuditCursor).toBeUndefined()
     expect(emptyWindow.auditEvents).toEqual([])
+    expect(emptyWindow.nextAuditCursor).toBeUndefined()
   })
 
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {

--- a/test/postgres/security-and-read-side.test.ts
+++ b/test/postgres/security-and-read-side.test.ts
@@ -500,10 +500,13 @@ describe('Postgres reference persistence security and read side', () => {
       AuditEventType.SessionRevoked,
       AuditEventType.SignIn,
     ])
+    expect(firstWindow.nextAuditCursor).toEqual(toAuditEventCursor(firstWindow.auditEvents.at(-1)!))
     expect(continuationWindow.auditEvents.map((event) => event.type)).toEqual([
       AuditEventType.SessionCreated,
     ])
+    expect(continuationWindow.nextAuditCursor).toBeUndefined()
     expect(emptyWindow.auditEvents).toEqual([])
+    expect(emptyWindow.nextAuditCursor).toBeUndefined()
   })
 
   it('bulk-revokes active user sessions on Postgres while keeping the excluded session', async () => {

--- a/test/views.test.ts
+++ b/test/views.test.ts
@@ -238,6 +238,10 @@ describe('safe projection helpers', () => {
           metadata: { internal: true },
         },
       ],
+      nextAuditCursor: {
+        occurredAt: now,
+        id: asAuditEventId('audit-9'),
+      },
     })
 
     expect(
@@ -277,6 +281,10 @@ describe('safe projection helpers', () => {
           userId: user('user-9').id,
         },
       ],
+      nextAuditCursor: {
+        occurredAt: now,
+        id: asAuditEventId('audit-9'),
+      },
     })
     expect(inspectionSnapshot.auditEvents[0]).not.toHaveProperty('metadata')
   })


### PR DESCRIPTION
## Summary
- extend account inspection snapshots with aggregate audit page metadata
- reuse getAuditEventPage internally so trusted inspection flows keep stable continuation cursors
- update read-side tests and support inspection docs for the new nextAuditCursor contract

Closes #200