### PR TITLE
test: harden audit page metadata parity

### DIFF
--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -103,9 +103,9 @@ const sessions = await authService.getUserSessions(userId)
 const credentials = await authService.getUserCredentials(userId)
 ```
 
-Use the aggregate inspection helper as the default. Reach for these narrower reads only when the
-surrounding tooling truly needs independent pagination, separate caching, raw audit metadata, or a
-reduced payload.
+Use the aggregate inspection helper as the default and treat it as the canonical support pagination
+surface. Reach for these narrower reads only when the surrounding tooling truly needs independent
+pagination, separate caching, raw audit metadata, or a reduced payload.
 
 ## Audit Timeline Inspection
 
@@ -179,10 +179,10 @@ return {
 Do not expose `secretHash`, raw OTP values, magic-link secrets, or internal routing assumptions to
 operator clients.
 
-## Combined Inspection Service
+## Canonical Paginated Inspection Service
 
 For a continuation-friendly next page, stay on the same aggregate helper and reuse the metadata it
-already returns:
+already returns. This should be the default recipe for operator tooling:
 
 ```ts
 const nextInspection = await authService.getAccountInspectionSnapshot({
@@ -195,7 +195,8 @@ const nextInspection = await authService.getAccountInspectionSnapshot({
 ```
 
 One practical server-side composition pattern is to keep pagination state explicit and let the
-framework layer own authorization and HTTP response shaping:
+framework layer own authorization and HTTP response shaping, while UniAuth owns the inspection
+window semantics:
 
 ```ts
 async function inspectAccountSecurity(input: {
@@ -228,6 +229,9 @@ async function inspectAccountSecurity(input: {
 
 Keep outward serialization and operator authorization outside this helper. UniAuth only owns the
 local account-security state, audit timeline composition, and verification lifecycle.
+
+Drop down to `getAuditEventPage(...)` only when the operator surface explicitly needs raw audit
+metadata or a custom filter that should not be bundled into the aggregate inspection response.
 
 ## Action Handoff
 

--- a/test/core/audit-pagination.test.ts
+++ b/test/core/audit-pagination.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { AuditEventType, VerificationPurpose, addSeconds, toAuditEventCursor } from '../../src'
+import {
+  AuditEventType,
+  VerificationPurpose,
+  addSeconds,
+  toAuditEventCursor,
+  toAuditEventView,
+} from '../../src'
 import { createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from './support.js'
 
@@ -62,5 +68,69 @@ describe('DefaultAuthService audit pagination parity', () => {
 
     expect(rawEmptyPage.events).toEqual([])
     expect(rawEmptyPage.nextCursor).toBeUndefined()
+  })
+
+  it('keeps aggregate inspection audit windows in parity with the raw page helper in-memory', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'inspection-audit-page-reader',
+        email: 'inspection-audit-page-reader@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'inspection-audit-page-reader@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    const rawFirstPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+
+    expect(inspectionFirstPage.auditEvents).toEqual(rawFirstPage.events.map(toAuditEventView))
+    expect(inspectionFirstPage.nextAuditCursor).toEqual(rawFirstPage.nextCursor)
+
+    const rawNextPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      before: rawFirstPage.nextCursor!,
+      limit: 2,
+    })
+    const inspectionNextPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: inspectionFirstPage.nextAuditCursor,
+      },
+    })
+
+    expect(inspectionNextPage.auditEvents).toEqual(rawNextPage.events.map(toAuditEventView))
+    expect(inspectionNextPage.nextAuditCursor).toEqual(rawNextPage.nextCursor)
+
+    const rawEmptyPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      after: toAuditEventCursor(rawFirstPage.events[0]!),
+      limit: 2,
+    })
+    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
+      },
+    })
+
+    expect(inspectionEmptyPage.auditEvents).toEqual(rawEmptyPage.events.map(toAuditEventView))
+    expect(inspectionEmptyPage.nextAuditCursor).toEqual(rawEmptyPage.nextCursor)
   })
 })

--- a/test/postgres/audit-pagination.test.ts
+++ b/test/postgres/audit-pagination.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { AuditEventType, VerificationPurpose, addSeconds, toAuditEventCursor } from '../../src'
+import {
+  AuditEventType,
+  VerificationPurpose,
+  addSeconds,
+  toAuditEventCursor,
+  toAuditEventView,
+} from '../../src'
 import { createPostgresTestKit, now } from './support.js'
 
 describe('Postgres audit pagination parity', () => {
@@ -51,5 +57,70 @@ describe('Postgres audit pagination parity', () => {
 
     expect(rawEmptyPage.events).toEqual([])
     expect(rawEmptyPage.nextCursor).toBeUndefined()
+  })
+
+  it('keeps aggregate inspection audit windows in parity with the raw page helper on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-inspection-audit-page-reader',
+        email: 'pg-inspection-audit-page-reader@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'pg-inspection-audit-page-reader@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.revokeSession(signedIn.session.id)
+
+    const rawFirstPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+    const inspectionFirstPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: { limit: 2 },
+    })
+
+    expect(inspectionFirstPage.auditEvents).toEqual(rawFirstPage.events.map(toAuditEventView))
+    expect(inspectionFirstPage.nextAuditCursor).toEqual(rawFirstPage.nextCursor)
+
+    const rawNextPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      before: rawFirstPage.nextCursor!,
+      limit: 2,
+    })
+    const inspectionNextPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        before: inspectionFirstPage.nextAuditCursor,
+      },
+    })
+
+    expect(inspectionNextPage.auditEvents).toEqual(rawNextPage.events.map(toAuditEventView))
+    expect(inspectionNextPage.nextAuditCursor).toEqual(rawNextPage.nextCursor)
+
+    const rawEmptyPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      after: toAuditEventCursor(rawFirstPage.events[0]!),
+      limit: 2,
+    })
+    const inspectionEmptyPage = await service.getAccountInspectionSnapshot({
+      userId: signedIn.user.id,
+      audit: {
+        limit: 2,
+        after: toAuditEventCursor(inspectionFirstPage.auditEvents[0]!),
+      },
+    })
+
+    expect(inspectionEmptyPage.auditEvents).toEqual(rawEmptyPage.events.map(toAuditEventView))
+    expect(inspectionEmptyPage.nextAuditCursor).toEqual(rawEmptyPage.nextCursor)
   })
 })


### PR DESCRIPTION
## Summary
- add focused raw-vs-aggregate audit pagination parity coverage for in-memory and Postgres
- make support-inspection docs treat aggregate inspection pagination as the canonical operator recipe
- keep raw audit page docs positioned as the metadata-aware fallback path

Closes #201