### PR TITLE
feat: add provider family subpath exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,12 @@ const resendWindow = await service.getVerificationResendWindow({
 ```
 
 Messenger Mini App providers are SDK-free `AuthProvider` adapters for signed Telegram and MAX
-launch data. See [Messenger providers](docs/messenger-providers.md).
+launch data. Prefer the explicit `@alyldas/uniauth/providers/messenger` subpath. See
+[Messenger providers](docs/messenger-providers.md).
 
 OAuth/OIDC providers use an SDK-free client contract for authorization-code finish flows. See
-[OAuth / OIDC providers](docs/oauth-oidc.md).
+[OAuth / OIDC providers](docs/oauth-oidc.md). Prefer
+`@alyldas/uniauth/providers/oauth-oidc` for provider-specific helpers.
 If provider tokens need to survive beyond profile fetch, keep them in app-owned storage and use the
 public helper described in [Provider token persistence](docs/provider-token-persistence.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,9 +178,10 @@ signals instead of leaking provider SDK payloads into core policy hooks.
 
 ## Provider Adapter Layout
 
-Reference provider adapters use root package exports only. Provider-specific source modules may live
-under `src/providers`, but those paths are internal implementation details and must not be added to
-`package.json` subpath exports without a package-level reason.
+Reference provider adapters now prefer explicit package subpaths such as
+`@alyldas/uniauth/providers/messenger` and `@alyldas/uniauth/providers/oauth-oidc`. Root exports
+remain for pre-1.0 compatibility, but new provider families should not automatically widen the root
+surface when a package-level subpath is enough.
 
 Each provider family should keep the same rough split when it reduces real complexity:
 

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -135,8 +135,8 @@ If both are present and disagree, the helper rejects the input.
 - If you need token persistence, keep it in application-owned storage keyed by your own session or
   callback state.
 - If you want one stable record shape for that storage, use `createOAuthOidcTokenRecord(...)` from
-  the root package and bind it to your framework-owned callback state, local user id, or local
-  session id. See [Provider token persistence](provider-token-persistence.md).
+  `@alyldas/uniauth/providers/oauth-oidc` and bind it to your framework-owned callback state, local
+  user id, or local session id. See [Provider token persistence](provider-token-persistence.md).
 - UniAuth policy invariants still apply after mapping. A framework callback does not bypass
   `AuthPolicy`, last-identity rules, or exact provider identity matching.
 - These helpers are intentionally thin. If your integration needs framework-native session

--- a/docs/messenger-providers.md
+++ b/docs/messenger-providers.md
@@ -18,8 +18,11 @@ import {
   createMaxWebAppProvider,
   createTelegramMiniAppProvider,
   validateSignedWebAppInitData,
-} from '@alyldas/uniauth'
+} from '@alyldas/uniauth/providers/messenger'
 ```
+
+The root package keeps these exports for compatibility, but messenger-specific consumers should
+prefer the explicit `@alyldas/uniauth/providers/messenger` subpath.
 
 The shared validator follows the signed WebApp launch-data algorithm used by Telegram and MAX:
 
@@ -120,7 +123,10 @@ Messenger providers stay app-owned at bootstrap and transport layers:
 ### Telegram Mini App Route
 
 ```ts
-import { TELEGRAM_MINI_APP_PROVIDER_ID, createTelegramMiniAppProvider } from '@alyldas/uniauth'
+import {
+  TELEGRAM_MINI_APP_PROVIDER_ID,
+  createTelegramMiniAppProvider,
+} from '@alyldas/uniauth/providers/messenger'
 import { authService, providerRegistry } from './auth-bootstrap.js'
 
 providerRegistry.register(
@@ -161,7 +167,10 @@ export async function postTelegramMiniAppSignIn(request: Request) {
 ### MAX WebApp Route
 
 ```ts
-import { MAX_WEBAPP_PROVIDER_ID, createMaxWebAppProvider } from '@alyldas/uniauth'
+import {
+  MAX_WEBAPP_PROVIDER_ID,
+  createMaxWebAppProvider,
+} from '@alyldas/uniauth/providers/messenger'
 import { authService, providerRegistry } from './auth-bootstrap.js'
 
 providerRegistry.register(

--- a/docs/oauth-oidc.md
+++ b/docs/oauth-oidc.md
@@ -14,8 +14,11 @@ import {
   mapOAuthOidcProfileToAssertion,
   type OAuthOidcClient,
   type OAuthOidcProfile,
-} from '@alyldas/uniauth'
+} from '@alyldas/uniauth/providers/oauth-oidc'
 ```
+
+The root package keeps these exports for compatibility, but provider-specific consumers should
+prefer the explicit `@alyldas/uniauth/providers/oauth-oidc` subpath.
 
 ## Runtime Boundary
 

--- a/docs/provider-token-persistence.md
+++ b/docs/provider-token-persistence.md
@@ -10,7 +10,7 @@ import {
   OAuthOidcTokenBindingKind,
   createOAuthOidcTokenRecord,
   type OAuthOidcTokenRecord,
-} from '@alyldas/uniauth'
+} from '@alyldas/uniauth/providers/oauth-oidc'
 ```
 
 `createOAuthOidcTokenRecord(...)` is a narrow helper for normalizing app-owned OAuth/OIDC token

--- a/examples/oauth-oidc/index.ts
+++ b/examples/oauth-oidc/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
+import { DefaultAuthService } from '@alyldas/uniauth'
 import {
-  DefaultAuthService,
   OAuthOidcTokenBindingKind,
   createOAuthOidcTokenRecord,
   createOAuthOidcProvider,
@@ -10,7 +10,7 @@ import {
   type OAuthOidcProfile,
   type OAuthOidcTokenBinding,
   type OAuthOidcTokenRecord,
-} from '@alyldas/uniauth'
+} from '@alyldas/uniauth/providers/oauth-oidc'
 import {
   InMemoryAuthStore,
   InMemoryProviderRegistry,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -4,6 +4,8 @@
     "noEmit": true,
     "paths": {
       "@alyldas/uniauth": ["../src/index.ts"],
+      "@alyldas/uniauth/providers/messenger": ["../src/providers/messenger.ts"],
+      "@alyldas/uniauth/providers/oauth-oidc": ["../src/providers/oauth-oidc.ts"],
       "@alyldas/uniauth/testing": ["../src/testing/index.ts"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,14 @@
       "types": "./dist/contracts.d.ts",
       "import": "./dist/contracts/index.js"
     },
+    "./providers/messenger": {
+      "types": "./dist/providers/messenger.d.ts",
+      "import": "./dist/providers/messenger.js"
+    },
+    "./providers/oauth-oidc": {
+      "types": "./dist/providers/oauth-oidc.d.ts",
+      "import": "./dist/providers/oauth-oidc.js"
+    },
     "./postgres": {
       "types": "./dist/postgres.d.ts",
       "import": "./dist/postgres/index.js"

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -25,6 +25,8 @@ describe('package exports', () => {
     const bridges = await import('../dist/bridges')
     const contracts = await import('../dist/contracts')
     const core = await import('../dist')
+    const messengerProviders = await import('../dist/providers/messenger')
+    const oauthOidcProviders = await import('../dist/providers/oauth-oidc')
     const postgres = await import('../dist/postgres')
     const testing = await import('../dist/testing')
 
@@ -100,6 +102,12 @@ describe('package exports', () => {
     expect(core.mapOAuthOidcProfileToAssertion).toBeTypeOf('function')
     expect(core.OAuthOidcTokenBindingKind.CallbackState).toBe('callback-state')
     expect(core.validateSignedWebAppInitData).toBeTypeOf('function')
+    expect(messengerProviders.MAX_WEBAPP_PROVIDER_ID).toBe('max-webapp')
+    expect(messengerProviders.createTelegramMiniAppProvider).toBeTypeOf('function')
+    expect(messengerProviders.validateSignedWebAppInitData).toBeTypeOf('function')
+    expect(oauthOidcProviders.createOAuthOidcProvider).toBeTypeOf('function')
+    expect(oauthOidcProviders.createOAuthOidcTokenRecord).toBeTypeOf('function')
+    expect(oauthOidcProviders.mapOAuthOidcProfileToAssertion).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toBeTypeOf('object')
     expect(core.getUniAuthAttributionNotice).toBeTypeOf('function')
     expect(core.UNIAUTH_ATTRIBUTION).toMatchObject({
@@ -118,6 +126,16 @@ describe('package exports', () => {
     expect(testing.InMemoryRateLimiter).toBeTypeOf('function')
     expect(testing.InMemorySmsSender).toBeTypeOf('function')
     expect(testing.StaticAuthProvider).toBeTypeOf('function')
+  })
+
+  it('loads provider family package subpaths through self-reference exports', async () => {
+    const messengerProviders = await import(`${packageMetadata.name}/providers/messenger`)
+    const oauthOidcProviders = await import(`${packageMetadata.name}/providers/oauth-oidc`)
+
+    expect(messengerProviders.MAX_WEBAPP_PROVIDER_ID).toBe('max-webapp')
+    expect(messengerProviders.createMaxWebAppProvider).toBeTypeOf('function')
+    expect(oauthOidcProviders.createOAuthOidcProvider).toBeTypeOf('function')
+    expect(oauthOidcProviders.createOAuthOidcTokenRecord).toBeTypeOf('function')
   })
 
   it('keeps testing package declarations aligned with the stable public surface', async () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,8 @@
     "src/index.ts",
     "src/bridges.ts",
     "src/contracts.ts",
+    "src/providers/messenger.ts",
+    "src/providers/oauth-oidc.ts",
     "src/postgres.ts",
     "src/testing/index.ts"
   ],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     'bridges/index': 'src/bridges.ts',
     'contracts/index': 'src/contracts.ts',
     index: 'src/index.ts',
+    'providers/messenger': 'src/providers/messenger.ts',
+    'providers/oauth-oidc': 'src/providers/oauth-oidc.ts',
     'postgres/index': 'src/postgres.ts',
     'testing/index': 'src/testing/index.ts',
   },


### PR DESCRIPTION
## Summary
- add public provider family subpath exports for messenger and OAuth/OIDC adapters
- prefer the new subpaths in docs, smoke coverage, and the runnable OAuth/OIDC example
- keep root exports compatible for pre-1.0 consumers while moving provider-specific imports to explicit entry points

Closes #229