### PR TITLE
ci: enforce source import boundaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,21 @@ project maintainer.
 - Keep public errors stable and avoid leaking account ownership state.
 - Add tests for security-sensitive behavior before changing policy or orchestration.
 
+## Source Boundaries
+
+`npm run lint` enforces source import boundaries.
+
+- `src/domain`, `src/contracts`, and `src/ports` must stay implementation-free.
+- `src/application` must not import provider adapters, bridges, persistence adapters, or testing
+  modules.
+- `src/providers` families must stay isolated from each other and from application, persistence,
+  bridge, and testing internals.
+- `src/postgres` stays below the application layer.
+- `src/utils` stays reusable and must not drift upward into application or adapter ownership.
+
+If a change needs a new dependency direction, document the reason in the same pull request instead
+of bypassing the rule silently.
+
 ## Useful Docs
 
 - [Development](docs/development.md)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,29 @@ import prettier from 'eslint-config-prettier'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
+function restrictImports(files, patterns, message) {
+  return {
+    files,
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: patterns.map((group) => ({ group: [group], message })),
+        },
+      ],
+    },
+  }
+}
+
+const providerAdapterPatterns = [
+  '**/messenger.js',
+  '**/oauth-oidc.js',
+  '**/providers/messenger.js',
+  '**/providers/messenger/**',
+  '**/providers/oauth-oidc.js',
+  '**/providers/oauth-oidc/**',
+]
+
 export default [
   {
     ignores: ['dist', 'coverage', 'node_modules', 'package-lock.json'],
@@ -22,4 +45,113 @@ export default [
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },
+  restrictImports(
+    ['src/domain/**/*.ts', 'src/contracts/**/*.ts', 'src/ports/**/*.ts'],
+    [
+      '**/application/**',
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      '**/utils/**',
+      ...providerAdapterPatterns,
+    ],
+    'Domain and contract layers must stay implementation-free and import only domain or contract code.',
+  ),
+  restrictImports(
+    ['src/application/**/*.ts'],
+    [
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      ...providerAdapterPatterns,
+    ],
+    'Application orchestration must not depend on provider adapters, bridges, persistence adapters, or testing modules.',
+  ),
+  restrictImports(
+    ['src/bridges/**/*.ts'],
+    [
+      '**/application/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      ...providerAdapterPatterns,
+    ],
+    'Bridge helpers must stay independent from application, persistence, provider adapter, and testing internals.',
+  ),
+  restrictImports(
+    ['src/providers/messenger.ts', 'src/providers/messenger/**/*.ts'],
+    [
+      '**/application/**',
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      '**/oauth-oidc.js',
+      '**/providers/oauth-oidc.js',
+      '**/providers/oauth-oidc/**',
+    ],
+    'Messenger provider adapters must not depend on application, persistence, bridge, testing, or OAuth/OIDC adapter internals.',
+  ),
+  restrictImports(
+    ['src/providers/oauth-oidc.ts', 'src/providers/oauth-oidc/**/*.ts'],
+    [
+      '**/application/**',
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      '**/messenger.js',
+      '**/providers/messenger.js',
+      '**/providers/messenger/**',
+    ],
+    'OAuth/OIDC provider adapters must not depend on application, persistence, bridge, testing, or messenger adapter internals.',
+  ),
+  restrictImports(
+    ['src/postgres/**/*.ts'],
+    [
+      '**/application/**',
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/testing.js',
+      '**/testing/**',
+      ...providerAdapterPatterns,
+    ],
+    'Postgres adapters must stay below the application layer and independent from providers, bridges, and testing internals.',
+  ),
+  restrictImports(
+    ['src/testing/**/*.ts'],
+    [
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      ...providerAdapterPatterns,
+    ],
+    'Testing helpers should compose public or application-facing boundaries, not provider, bridge, or persistence adapter internals.',
+  ),
+  restrictImports(
+    ['src/utils/**/*.ts'],
+    [
+      '**/application/**',
+      '**/bridges.js',
+      '**/bridges/**',
+      '**/postgres.js',
+      '**/postgres/**',
+      '**/testing.js',
+      '**/testing/**',
+      ...providerAdapterPatterns,
+    ],
+    'Utility modules must stay reusable and must not depend on application, adapters, or testing layers.',
+  ),
 ]


### PR DESCRIPTION
## Summary
- add lightweight ESLint import-boundary rules for domain, contracts, application, providers, bridges, postgres, testing, and utils
- keep the rule set small and contributor-readable instead of adding a second architecture framework
- document the intent in CONTRIBUTING so future direction changes are explicit

Closes #230