### PR TITLE
feat: add current-account security helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ license, subscription, private contract, or other written permission.
 - Exposes safe projection helpers for account-security and verification-status read-side flows.
 - Exposes an aggregated `getAccountSecuritySnapshot(userId)` read-side API for account-security
   screens.
+- Exposes a current-account aggregate helper and token-based self-service session revoke helpers for
+  trusted account-security routes after transport resolution.
 - Exposes a trusted `getAccountInspectionSnapshot({ userId, audit? })` aggregate read-side
   API for backend support and admin inspection flows.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
@@ -315,6 +317,16 @@ helpers instead of serializing raw entities directly:
 const snapshot = await service.getAccountSecuritySnapshot(userId)
 
 const verificationStatus = toVerificationStatusView(verification)
+```
+
+When the caller is already authenticated by a trusted local `sessionToken`, prefer the aggregate
+helper instead of manually composing `resolveSessionContext(...)` and `getAccountSecuritySnapshot(...)`:
+
+```ts
+const current = await service.getCurrentAccountSecuritySnapshot({
+  sessionToken,
+  touch: true,
+})
 ```
 
 Trusted backend tooling can start from one trusted aggregate inspection helper:

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -25,12 +25,25 @@ const snapshot = await authService.getAccountSecuritySnapshot(userId)
 const verificationStatus = toVerificationStatusView(verification)
 ```
 
-## Recommended Read-Side Shape
-
-The minimal server-side composition usually looks like this:
+When the caller is already authenticated by a trusted local session token, prefer the aggregate
+helper instead of manually composing `resolveSessionContext(...)` with a second user-scoped read:
 
 ```ts
-const snapshot = await authService.getAccountSecuritySnapshot(userId)
+const current = await authService.getCurrentAccountSecuritySnapshot({
+  sessionToken,
+  touch: true,
+})
+```
+
+## Recommended Read-Side Shape
+
+The minimal current-account server-side composition usually looks like this:
+
+```ts
+const current = await authService.getCurrentAccountSecuritySnapshot({
+  sessionToken,
+  touch: true,
+})
 ```
 
 Keep the response client-safe:
@@ -38,11 +51,12 @@ Keep the response client-safe:
 ```ts
 return {
   user: {
-    id: snapshot.user.id,
-    email: snapshot.user.email ?? null,
-    displayName: snapshot.user.displayName ?? null,
+    id: current.account.user.id,
+    email: current.account.user.email ?? null,
+    displayName: current.account.user.displayName ?? null,
   },
-  identities: snapshot.identities.map((identity) => ({
+  currentSessionId: current.currentSessionId,
+  identities: current.account.identities.map((identity) => ({
     id: identity.id,
     provider: identity.provider,
     status: identity.status,
@@ -50,16 +64,17 @@ return {
     phone: identity.phone ?? null,
     trustLevel: identity.trustLevel ?? null,
   })),
-  credentials: snapshot.credentials.map((credential) => ({
+  credentials: current.account.credentials.map((credential) => ({
     id: credential.id,
     type: credential.type,
     subject: credential.subject,
     createdAt: credential.createdAt.toISOString(),
     updatedAt: credential.updatedAt.toISOString(),
   })),
-  sessions: snapshot.sessions.map((session) => ({
+  sessions: current.account.sessions.map((session) => ({
     id: session.id,
     status: session.status,
+    isCurrent: session.id === current.currentSessionId,
     createdAt: session.createdAt.toISOString(),
     expiresAt: session.expiresAt.toISOString(),
     lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
@@ -130,8 +145,8 @@ verification reads, continue in [Support and admin inspection recipe](support-in
 
 For device-list or active-session screens:
 
-1. resolve the current local session from the transport;
-2. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
+1. resolve or trust the current local session token from the transport;
+2. load the aggregate view through `authService.getCurrentAccountSecuritySnapshot(...)`;
 3. present a sanitized session list;
 4. keep revoke and logout responses application-owned.
 
@@ -140,7 +155,9 @@ For device-list or active-session screens:
 Treat sign-out of the current device as one backend write plus one transport cleanup:
 
 ```ts
-await authService.revokeSession(request.auth.session.id)
+await authService.revokeCurrentSessionByToken({
+  sessionToken: request.auth.sessionToken,
+})
 clearSessionCookie(response)
 ```
 
@@ -152,19 +169,19 @@ token deletion, mobile secure-storage deletion, redirect behavior, and neutral r
 For "sign out other devices" or "sign out all devices except this one":
 
 ```ts
-const result = await authService.revokeUserSessions({
-  userId: request.auth.userId,
-  exceptSessionId: request.auth.session.id,
+const result = await authService.revokeOtherSessionsByToken({
+  sessionToken: request.auth.sessionToken,
 })
 
 return {
+  currentSessionId: result.currentSessionId,
   revokedSessionCount: result.revokedSessionIds.length,
 }
 ```
 
 This is the narrowest server-side flow when the caller is already authenticated and the target user
 is the current account. It keeps the current transport alive while revoking the other local session
-records.
+records and returns the current session id the application can mark in its response.
 
 ### Revoke One Selected Device
 
@@ -172,8 +189,10 @@ For per-device revoke actions, first prove ownership from the read-side snapshot
 `revokeSession(...)`:
 
 ```ts
-const snapshot = await authService.getAccountSecuritySnapshot(request.auth.userId)
-const target = snapshot.sessions.find((session) => session.id === body.sessionId)
+const current = await authService.getCurrentAccountSecuritySnapshot({
+  sessionToken: request.auth.sessionToken,
+})
+const target = current.account.sessions.find((session) => session.id === body.sessionId)
 
 if (!target) {
   return response.status(404).json({ error: 'Session not found.' })
@@ -181,7 +200,7 @@ if (!target) {
 
 await authService.revokeSession(target.id)
 
-if (target.id === request.auth.session.id) {
+if (target.id === current.currentSessionId) {
   clearSessionCookie(response)
 }
 
@@ -195,7 +214,9 @@ generic neutral response. UniAuth only enforces local session state.
 
 For sign-in method screens:
 
-1. load the aggregate view through `authService.getAccountSecuritySnapshot(userId)`;
+1. load the aggregate view through `authService.getCurrentAccountSecuritySnapshot(...)` or
+   `authService.getAccountSecuritySnapshot(userId)`, depending on whether the route is self-service
+   or trusted admin/support;
 2. present provider ids, statuses, email or phone hints, and credential types;
 3. compose mutations through `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new
    provider link flows.
@@ -212,8 +233,12 @@ Resolve the current account snapshot first so the application knows which method
 then unlink by `identityId`:
 
 ```ts
-const snapshot = await authService.getAccountSecuritySnapshot(request.auth.userId)
-const targetIdentity = snapshot.identities.find((identity) => identity.id === body.identityId)
+const current = await authService.getCurrentAccountSecuritySnapshot({
+  sessionToken: request.auth.sessionToken,
+})
+const targetIdentity = current.account.identities.find(
+  (identity) => identity.id === body.identityId,
+)
 
 if (!targetIdentity) {
   return response.status(404).json({ error: 'Sign-in method not found.' })
@@ -237,7 +262,10 @@ Use `setPassword(...)` when the account does not yet have a local password or wh
 allows a provider-first account to add one from a trusted account-security screen:
 
 ```ts
-const passwordEmail = snapshot.user.email
+const current = await authService.getCurrentAccountSecuritySnapshot({
+  sessionToken: request.auth.sessionToken,
+})
+const passwordEmail = current.account.user.email
 
 if (!passwordEmail) {
   return response.status(400).json({ error: 'Password setup requires a trusted email address.' })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,9 @@ identities, and email/phone are optional identity attributes.
 - `revokeUserSessions`
 - `resolveSession`
 - `resolveSessionContext`
+- `getCurrentAccountSecuritySnapshot`
+- `revokeCurrentSessionByToken`
+- `revokeOtherSessionsByToken`
 - `touchSession`
 - `getUser`
 - `getUserCredentials`
@@ -62,6 +65,11 @@ the public service layer without reaching into adapter internals.
 Session resolution remains transport-agnostic. Core can now collapse `sessionToken -> session + user`
 into one trusted read-side helper, while cookie parsing, bearer extraction, and request decoration
 stay application-owned.
+
+Current-account security routes can also stay on trusted token-based helpers without reassembling
+that flow on every backend. Core can now resolve a trusted local `sessionToken`, load the current
+account-security aggregate, or revoke the current/other local sessions through one narrow helper
+layer while cookie clearing, header parsing, and outward payload shaping remain application-owned.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -115,7 +115,8 @@ Express ownership notes:
 - Keep route-neutral errors neutral at the HTTP layer too; do not translate invalid credentials into
   account existence hints.
 - For account-security screens and mutations, use [Account security recipes](account-security.md)
-  and the built-in safe projection helpers instead of reading adapter internals.
+  and prefer `getCurrentAccountSecuritySnapshot({ sessionToken })` plus the token-based self-service
+  revoke helpers instead of reading adapter internals.
 
 ## Fastify
 
@@ -164,7 +165,8 @@ Fastify ownership notes:
   rather than introducing a Fastify-specific auth dispatcher.
 - For a fuller copyable token/session recipe, see [Session transport recipes](session-transport.md).
 - For sign-in-method, device-management, revoke, and password-change routes, use
-  [Account security recipes](account-security.md).
+  [Account security recipes](account-security.md) and the current-account aggregate helper instead
+  of rebuilding session + user + snapshot composition by hand.
 
 ## Nest
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -354,9 +354,18 @@ Tracking issues: #225, #226, #227, #228, #229, #230, #231.
 
 ## Next Release
 
-### v0.36 - Backlog To Be Defined
+### v0.36 - Current-Account Security Helpers
 
-- The next releasable scope has not been defined yet.
+- Add `getCurrentAccountSecuritySnapshot({ sessionToken, touch?, now? })` for self-service
+  account-security routes that already trust a local session token.
+- Add token-based self-service session revoke helpers for current-session logout and
+  sign-out-other-devices flows without rebuilding session + user ownership checks in every backend.
+- Add parity coverage for the new current-account helper layer across in-memory and Postgres-backed
+  service setups, including stale-session neutrality and current-session markers.
+- Update account-security and session-transport recipes so current-account routes use the aggregate
+  helper layer instead of manual multi-call composition.
+
+Tracking issues: #244, #245, #246, #247.
 
 ## Versioning
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -18,7 +18,7 @@ Use this document for:
 
 Use [Backend integration recipes](backend-recipes.md) for framework bootstrap and route/controller
 composition. Use [Account security recipes](account-security.md) for device lists, sign-in methods,
-and verification inspection after you already trust the caller and know the target `userId`.
+verification inspection, and current-account flows after you already trust the caller.
 
 ## Browser Cookies
 
@@ -58,13 +58,13 @@ resolve the token through UniAuth instead of treating `Session.id` as the client
 ```ts
 const sessionToken = unsealSessionToken(request.cookies.session)
 
-const { session, user } = await authService.resolveSessionContext({
+const auth = await authService.resolveSessionContext({
   sessionToken,
 })
 
 return {
-  user,
-  session,
+  user: auth.user,
+  session: auth.session,
 }
 ```
 
@@ -97,6 +97,7 @@ import {
 } from '@alyldas/uniauth'
 
 interface ExpressRequestAuth {
+  readonly sessionToken: string
   readonly session: Session
   readonly user: User
   readonly userId: Session['userId']
@@ -128,6 +129,7 @@ export function createExpressSessionMiddleware(authService: AuthService) {
       })
 
       request.auth = {
+        sessionToken,
         session,
         user,
         userId: session.userId,
@@ -194,6 +196,7 @@ import {
 } from '@alyldas/uniauth'
 
 interface FastifyRequestAuth {
+  readonly sessionToken: string
   readonly session: Session
   readonly user: User
   readonly userId: Session['userId']
@@ -220,6 +223,7 @@ export function createFastifySessionPreHandler(authService: AuthService) {
         sessionToken,
       })
       request.auth = {
+        sessionToken,
         session,
         user,
         userId: session.userId,
@@ -253,9 +257,9 @@ Fastify users often keep `touch: false` in the preHandler and call `touchSession
 protected-route hook or in the route handler itself, so lightweight public requests can resolve auth
 context without forcing an activity write every time.
 
-If one authenticated request also needs device lists or sign-in methods, resolve the transport here
-and then hand off to `authService.getAccountSecuritySnapshot(userId)` as described in
-[Account security recipes](account-security.md).
+If one authenticated request also needs the current account-security page, resolve the transport
+here and then hand off to `authService.getCurrentAccountSecuritySnapshot({ sessionToken, touch })`
+as described in [Account security recipes](account-security.md).
 
 What stays application-owned:
 
@@ -325,11 +329,21 @@ Treat logout as two coordinated steps:
    - delete the bearer token from client state;
    - delete the mobile-stored session token.
 
+For self-service logout after transport resolution, prefer the token-based helper:
+
+```ts
+await authService.revokeCurrentSessionByToken({
+  sessionToken,
+})
+clearSessionCookie(response)
+```
+
 For sign-out-all-devices or device-management screens, applications can first call
-`authService.getUserSessions(userId)` and then revoke the active subset through
-`authService.revokeUserSessions({ userId, exceptSessionId })`. UniAuth still does not clear cookies
-or bearer stores for those clients; the application must remove the transport artifact on each
-device as it becomes aware of the revoked local session.
+`authService.getCurrentAccountSecuritySnapshot({ sessionToken })` and then revoke the active subset
+through `authService.revokeOtherSessionsByToken({ sessionToken })` or, for trusted admin flows,
+through `authService.revokeUserSessions({ userId, exceptSessionId })`. UniAuth still does not clear
+cookies or bearer stores for those clients; the application must remove the transport artifact on
+each device as it becomes aware of the revoked local session.
 
 For the account-security write-side recipes, safe outward projection, and sign-in-method management
 flows, continue in [Account security recipes](account-security.md).

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -32,7 +32,7 @@ import {
   sealSessionCookieValue,
   unsealSessionCookieValue,
 } from '../shared/session-cookie.js'
-import { serializeAccountSecuritySnapshot } from '../shared/views.js'
+import { serializeCurrentAccountSecuritySnapshot } from '../shared/views.js'
 
 interface ExpressAuthExample {
   readonly app: Express
@@ -47,6 +47,7 @@ interface DemoAccount {
 }
 
 interface ExpressRequestAuth {
+  readonly sessionToken: string
   readonly session: Session
   readonly user: User
   readonly userId: Session['userId']
@@ -181,9 +182,11 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
           return
         }
 
-        const snapshot = await authService.getAccountSecuritySnapshot(auth.user.id)
+        const snapshot = await authService.getCurrentAccountSecuritySnapshot({
+          sessionToken: auth.sessionToken,
+        })
 
-        response.status(200).json(serializeAccountSecuritySnapshot(snapshot))
+        response.status(200).json(serializeCurrentAccountSecuritySnapshot(snapshot))
       } catch (error) {
         next(error)
       }
@@ -320,6 +323,7 @@ function createExpressSessionMiddleware(
       })
 
       request.auth = {
+        sessionToken,
         session,
         user,
         userId: session.userId,

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -29,7 +29,7 @@ import {
   sealSessionCookieValue,
   unsealSessionCookieValue,
 } from '../shared/session-cookie.js'
-import { serializeAccountSecuritySnapshot } from '../shared/views.js'
+import { serializeCurrentAccountSecuritySnapshot } from '../shared/views.js'
 
 interface FastifyAuthExample {
   readonly app: FastifyInstance
@@ -38,6 +38,7 @@ interface FastifyAuthExample {
 }
 
 interface FastifyRequestAuth {
+  readonly sessionToken: string
   readonly session: Session
   readonly user: User
   readonly userId: Session['userId']
@@ -178,9 +179,11 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
         return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
       }
 
-      const snapshot = await authService.getAccountSecuritySnapshot(auth.user.id)
+      const snapshot = await authService.getCurrentAccountSecuritySnapshot({
+        sessionToken: auth.sessionToken,
+      })
 
-      return reply.status(200).send(serializeAccountSecuritySnapshot(snapshot))
+      return reply.status(200).send(serializeCurrentAccountSecuritySnapshot(snapshot))
     },
   )
 
@@ -262,6 +265,7 @@ function createFastifySessionPreHandler(
       })
 
       request.auth = {
+        sessionToken,
         session,
         user,
         userId: session.userId,

--- a/examples/shared/views.ts
+++ b/examples/shared/views.ts
@@ -1,5 +1,6 @@
 import type {
   AccountSecuritySnapshot,
+  CurrentAccountSecuritySnapshot,
   VerificationResendWindow,
   VerificationStatusView,
 } from '@alyldas/uniauth'
@@ -43,6 +44,13 @@ export function serializeAccountSecuritySnapshot(snapshot: AccountSecuritySnapsh
       lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
       revokedAt: session.revokedAt?.toISOString() ?? null,
     })),
+  }
+}
+
+export function serializeCurrentAccountSecuritySnapshot(snapshot: CurrentAccountSecuritySnapshot) {
+  return {
+    ...serializeAccountSecuritySnapshot(snapshot.account),
+    currentSessionId: snapshot.currentSessionId,
   }
 }
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -83,6 +83,11 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.resendEmailMagicLinkSignIn).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.resendEmailPasswordRecovery).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.resolveSessionContext).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.getCurrentAccountSecuritySnapshot).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.revokeCurrentSessionByToken).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.revokeOtherSessionsByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
@@ -143,6 +148,18 @@ describe('package exports', () => {
       new URL('../dist/contracts.d.ts', import.meta.url),
       'utf8',
     )
+    const flowDeclarations = await readFile(
+      new URL('../dist/domain/flows.d.ts', import.meta.url),
+      'utf8',
+    )
+    const serviceDeclarations = await readFile(
+      new URL('../dist/domain/service.d.ts', import.meta.url),
+      'utf8',
+    )
+    const viewDeclarations = await readFile(
+      new URL('../dist/domain/views.d.ts', import.meta.url),
+      'utf8',
+    )
     const repositoryPortDeclarations = await readFile(
       new URL('../dist/ports/repositories.d.ts', import.meta.url),
       'utf8',
@@ -157,6 +174,15 @@ describe('package exports', () => {
     )
 
     expect(contractsDeclarations).toContain('AuthServiceInfrastructure')
+    expect(viewDeclarations).toContain('export interface CurrentAccountSecuritySnapshot')
+    expect(flowDeclarations).toContain('export interface GetCurrentAccountSecuritySnapshotInput')
+    expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
+    expect(serviceDeclarations).toContain(
+      'getCurrentAccountSecuritySnapshot(input: GetCurrentAccountSecuritySnapshotInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'revokeOtherSessionsByToken(input: RevokeOtherSessionsByTokenInput)',
+    )
     expect(contractsDeclarations).toContain('UserUpdatePatch')
     expect(repositoryPortDeclarations).toContain('export interface UserUpdatePatch')
     expect(repositoryPortDeclarations).toContain('export interface IdentityUpdatePatch')

--- a/src/application/account-security.ts
+++ b/src/application/account-security.ts
@@ -3,6 +3,7 @@ import { getActiveUser } from './support.js'
 import {
   toAccountSecuritySnapshot,
   type AccountSecuritySnapshot,
+  type User,
   type UserId,
 } from '../domain/types.js'
 
@@ -11,6 +12,13 @@ export async function getAccountSecuritySnapshot(
   userId: UserId,
 ): Promise<AccountSecuritySnapshot> {
   const user = await getActiveUser(runtime, userId)
+  return getAccountSecuritySnapshotForUser(runtime, user)
+}
+
+export async function getAccountSecuritySnapshotForUser(
+  runtime: AuthServiceRuntime,
+  user: User,
+): Promise<AccountSecuritySnapshot> {
   const [identities, credentials, sessions] = await Promise.all([
     runtime.repos.identityRepo.listByUserId(user.id),
     runtime.repos.credentialRepo.listByUserId(user.id),

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -4,6 +4,11 @@ import { getAuditEventPage, getAuditEvents } from './audit-events.js'
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import {
+  getCurrentAccountSecuritySnapshot,
+  revokeCurrentSessionByToken,
+  revokeOtherSessionsByToken,
+} from './current-account-security.js'
+import {
   cancelEmailMagicLinkSignIn,
   finishEmailMagicLinkSignIn,
   resendEmailMagicLinkSignIn,
@@ -54,6 +59,7 @@ import type {
   AuditEventQuery,
   AuthResult,
   AuthService,
+  CurrentAccountSecuritySnapshot,
   CancelEmailMagicLinkSignInInput,
   CancelEmailPasswordRecoveryInput,
   CancelOtpChallengeInput,
@@ -70,11 +76,15 @@ import type {
   FinishOtpChallengeInput,
   FinishOtpSignInInput,
   GetAccountInspectionSnapshotInput,
+  GetCurrentAccountSecuritySnapshotInput,
   GetVerificationResendWindowInput,
   LinkInput,
   LinkResult,
   MergeAccountsInput,
   MergeResult,
+  RevokeCurrentSessionByTokenInput,
+  RevokeOtherSessionsByTokenInput,
+  RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
   ResendOtpChallengeInput,
@@ -215,6 +225,22 @@ export class DefaultAuthService implements AuthService {
 
   async resolveSessionContext(input: ResolveSessionContextInput): Promise<ResolvedSessionContext> {
     return resolveSessionContext(this.runtime, input)
+  }
+
+  async getCurrentAccountSecuritySnapshot(
+    input: GetCurrentAccountSecuritySnapshotInput,
+  ): Promise<CurrentAccountSecuritySnapshot> {
+    return getCurrentAccountSecuritySnapshot(this.runtime, input)
+  }
+
+  async revokeCurrentSessionByToken(input: RevokeCurrentSessionByTokenInput): Promise<void> {
+    return revokeCurrentSessionByToken(this.runtime, input)
+  }
+
+  async revokeOtherSessionsByToken(
+    input: RevokeOtherSessionsByTokenInput,
+  ): Promise<RevokeOtherSessionsByTokenResult> {
+    return revokeOtherSessionsByToken(this.runtime, input)
   }
 
   async touchSession(input: TouchSessionInput): Promise<Session> {

--- a/src/application/current-account-security.ts
+++ b/src/application/current-account-security.ts
@@ -1,0 +1,62 @@
+import { getAccountSecuritySnapshotForUser } from './account-security.js'
+import type { AuthServiceRuntime } from './runtime.js'
+import { resolveSessionContext } from './session-context.js'
+import { revokeStoredSession, revokeUserSessions } from './sessions.js'
+import {
+  type CurrentAccountSecuritySnapshot,
+  type GetCurrentAccountSecuritySnapshotInput,
+  type RevokeCurrentSessionByTokenInput,
+  type RevokeOtherSessionsByTokenInput,
+  type RevokeOtherSessionsByTokenResult,
+} from '../domain/types.js'
+
+export async function getCurrentAccountSecuritySnapshot(
+  runtime: AuthServiceRuntime,
+  input: GetCurrentAccountSecuritySnapshotInput,
+): Promise<CurrentAccountSecuritySnapshot> {
+  const { session, user } = await resolveSessionContext(runtime, input)
+  const account = await getAccountSecuritySnapshotForUser(runtime, user)
+
+  return {
+    account,
+    currentSessionId: session.id,
+  }
+}
+
+export async function revokeCurrentSessionByToken(
+  runtime: AuthServiceRuntime,
+  input: RevokeCurrentSessionByTokenInput,
+): Promise<void> {
+  await runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { session } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+
+    await revokeStoredSession(runtime, session.id, now)
+  })
+}
+
+export async function revokeOtherSessionsByToken(
+  runtime: AuthServiceRuntime,
+  input: RevokeOtherSessionsByTokenInput,
+): Promise<RevokeOtherSessionsByTokenResult> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { session, user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+    const revoked = await revokeUserSessions(runtime, {
+      userId: user.id,
+      exceptSessionId: session.id,
+      now,
+    })
+
+    return {
+      ...revoked,
+      currentSessionId: session.id,
+    }
+  })
+}

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -39,8 +39,7 @@ export async function revokeSession(
 ): Promise<void> {
   await runtime.transaction.run(async () => {
     const now = runtime.clock.now()
-    const session = await requireStoredSession(runtime, sessionId)
-    await revokeSessionRecord(runtime, session, now)
+    await revokeStoredSession(runtime, sessionId, now)
   })
 }
 
@@ -200,6 +199,15 @@ async function requireStoredSession(
   }
 
   return session
+}
+
+export async function revokeStoredSession(
+  runtime: AuthServiceRuntime,
+  sessionId: SessionId,
+  now: Date,
+): Promise<void> {
+  const session = await requireStoredSession(runtime, sessionId)
+  await revokeSessionRecord(runtime, session, now)
 }
 
 async function revokeSessionRecord(

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -101,6 +101,26 @@ export interface ResolvedSessionContext {
   readonly user: User
 }
 
+export interface GetCurrentAccountSecuritySnapshotInput {
+  readonly sessionToken: string
+  readonly touch?: boolean
+  readonly now?: Date
+}
+
+export interface RevokeCurrentSessionByTokenInput {
+  readonly sessionToken: string
+  readonly now?: Date
+}
+
+export interface RevokeOtherSessionsByTokenInput {
+  readonly sessionToken: string
+  readonly now?: Date
+}
+
+export interface RevokeOtherSessionsByTokenResult extends RevokeUserSessionsResult {
+  readonly currentSessionId: SessionId
+}
+
 export interface RevokeUserSessionsInput {
   readonly userId: UserId
   readonly exceptSessionId?: SessionId

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -2,11 +2,13 @@ import type { AuthIdentity, Credential, Session, User, Verification } from './en
 import type {
   AccountInspectionSnapshot,
   AccountSecuritySnapshot,
+  CurrentAccountSecuritySnapshot,
   VerificationResendWindow,
 } from './views.js'
 import type { AuditEvent, AuditEventPage, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
+  GetCurrentAccountSecuritySnapshotInput,
   ConsumeVerificationInput,
   CancelOtpChallengeInput,
   CancelVerificationInput,
@@ -22,6 +24,9 @@ import type {
   LinkResult,
   MergeAccountsInput,
   MergeResult,
+  RevokeCurrentSessionByTokenInput,
+  RevokeOtherSessionsByTokenInput,
+  RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
   ResendOtpChallengeInput,
@@ -82,6 +87,13 @@ export interface AuthService {
   revokeUserSessions(input: RevokeUserSessionsInput): Promise<RevokeUserSessionsResult>
   resolveSession(input: ResolveSessionInput): Promise<Session>
   resolveSessionContext(input: ResolveSessionContextInput): Promise<ResolvedSessionContext>
+  getCurrentAccountSecuritySnapshot(
+    input: GetCurrentAccountSecuritySnapshotInput,
+  ): Promise<CurrentAccountSecuritySnapshot>
+  revokeCurrentSessionByToken(input: RevokeCurrentSessionByTokenInput): Promise<void>
+  revokeOtherSessionsByToken(
+    input: RevokeOtherSessionsByTokenInput,
+  ): Promise<RevokeOtherSessionsByTokenResult>
   touchSession(input: TouchSessionInput): Promise<Session>
   getUser(userId: UserId): Promise<User>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>

--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -51,6 +51,11 @@ export interface AccountSecuritySnapshot {
   readonly sessions: readonly AccountSecuritySessionView[]
 }
 
+export interface CurrentAccountSecuritySnapshot {
+  readonly account: AccountSecuritySnapshot
+  readonly currentSessionId: Session['id']
+}
+
 export interface AuditEventView {
   readonly id: AuditEvent['id']
   readonly type: AuditEvent['type']

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,4 +1,5 @@
 import './core/read-side-and-sessions.test.js'
+import './core/current-account-security.test.js'
 import './core/audit-pagination.test.js'
 import './core/otp-and-verifications.test.js'
 import './core/policies-and-merge.test.js'

--- a/test/core/current-account-security.test.ts
+++ b/test/core/current-account-security.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+import { AuditEventType, UniAuthErrorCode, addSeconds } from '../../src'
+import { createInMemoryAuthKit } from '../../src/testing'
+import { assertion, now } from './support.js'
+
+describe('DefaultAuthService current-account security helpers', () => {
+  it('loads the current account-security snapshot from a trusted session token', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const touchedAt = addSeconds(now, 30)
+
+    const snapshot = await service.getCurrentAccountSecuritySnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: touchedAt,
+    })
+
+    expect(snapshot.currentSessionId).toBe(signedIn.session.id)
+    expect(snapshot.account).toEqual({
+      ...(await service.getAccountSecuritySnapshot(signedIn.user.id)),
+    })
+    expect(snapshot.account.sessions).toEqual([
+      {
+        id: signedIn.session.id,
+        status: signedIn.session.status,
+        createdAt: signedIn.session.createdAt,
+        expiresAt: signedIn.session.expiresAt,
+        lastSeenAt: touchedAt,
+      },
+      {
+        id: secondSession.session.id,
+        status: secondSession.session.status,
+        createdAt: secondSession.session.createdAt,
+        expiresAt: secondSession.session.expiresAt,
+      },
+    ])
+  })
+
+  it('revokes the current session by trusted session token', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+
+    await service.revokeCurrentSessionByToken({
+      sessionToken: signedIn.sessionToken,
+      now: addSeconds(now, 20),
+    })
+
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    expect(
+      (await service.getAuditEvents({ userId: signedIn.user.id })).map((event) => event.type),
+    ).toContain(AuditEventType.SessionRevoked)
+  })
+
+  it('revokes the current session by trusted session token without an explicit now override', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({ assertion: assertion() })
+
+    await service.revokeCurrentSessionByToken({
+      sessionToken: signedIn.sessionToken,
+    })
+
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+
+  it('revokes other sessions by trusted session token while preserving the current session', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const result = await service.revokeOtherSessionsByToken({
+      sessionToken: signedIn.sessionToken,
+      now: addSeconds(now, 20),
+    })
+
+    expect(result).toEqual({
+      userId: signedIn.user.id,
+      currentSessionId: signedIn.session.id,
+      revokedSessionIds: [secondSession.session.id],
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: secondSession.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).resolves.toMatchObject({
+      id: signedIn.session.id,
+    })
+  })
+
+  it('keeps stale disabled-user current-account helpers neutral', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.getCurrentAccountSecuritySnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.revokeOtherSessionsByToken({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,3 +1,4 @@
 import './postgres/security-and-read-side.test.js'
+import './postgres/current-account-security.test.js'
 import './postgres/audit-pagination.test.js'
 import './postgres/persistence-and-merge.test.js'

--- a/test/postgres/current-account-security.test.ts
+++ b/test/postgres/current-account-security.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { UniAuthErrorCode, addSeconds } from '../../src'
+import { createPostgresTestKit, now } from './support.js'
+
+describe('Postgres current-account security helpers', () => {
+  it('matches the current-account aggregate helper with the read-side snapshot', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-security',
+        email: 'pg-current-account-security@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const touchedAt = addSeconds(now, 30)
+
+    const snapshot = await service.getCurrentAccountSecuritySnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: touchedAt,
+    })
+    const account = await service.getAccountSecuritySnapshot(signedIn.user.id)
+
+    expect(snapshot.currentSessionId).toBe(signedIn.session.id)
+    expect(snapshot.account).toEqual(account)
+    expect(snapshot.account.sessions).toEqual([
+      {
+        id: signedIn.session.id,
+        status: signedIn.session.status,
+        createdAt: signedIn.session.createdAt,
+        expiresAt: signedIn.session.expiresAt,
+        lastSeenAt: touchedAt,
+      },
+      {
+        id: secondSession.session.id,
+        status: secondSession.session.status,
+        createdAt: secondSession.session.createdAt,
+        expiresAt: secondSession.session.expiresAt,
+      },
+    ])
+  })
+
+  it('revokes other Postgres sessions by trusted session token while preserving the current one', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-revoke-other-sessions',
+        email: 'pg-revoke-other-sessions@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const result = await service.revokeOtherSessionsByToken({
+      sessionToken: signedIn.sessionToken,
+      now: addSeconds(now, 20),
+    })
+
+    expect(result).toEqual({
+      userId: signedIn.user.id,
+      currentSessionId: signedIn.session.id,
+      revokedSessionIds: [secondSession.session.id],
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: secondSession.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).resolves.toMatchObject({
+      id: signedIn.session.id,
+    })
+  })
+
+  it('revokes other Postgres sessions by trusted session token without an explicit now override', async () => {
+    const { service } = await createPostgresTestKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-revoke-other-sessions-no-now',
+        email: 'pg-revoke-other-sessions-no-now@example.com',
+        emailVerified: true,
+      },
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+    })
+
+    const result = await service.revokeOtherSessionsByToken({
+      sessionToken: signedIn.sessionToken,
+    })
+
+    expect(result.revokedSessionIds).toEqual([secondSession.session.id])
+    expect(result.currentSessionId).toBe(signedIn.session.id)
+  })
+
+  it('keeps stale disabled-user Postgres current-account helpers neutral', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-disabled-current-account',
+        email: 'pg-disabled-current-account@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.getCurrentAccountSecuritySnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.revokeCurrentSessionByToken({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})

--- a/test/postgres/support.ts
+++ b/test/postgres/support.ts
@@ -5,6 +5,7 @@ import {
   createAuthService,
   createDefaultAuthPolicy,
   createSequentialIdGenerator,
+  type Clock,
   type AuthPolicy,
 } from '../../src'
 import {
@@ -22,6 +23,7 @@ import { now } from '../helpers.js'
 
 interface PostgresTestKitOptions {
   readonly policy?: AuthPolicy
+  readonly clock?: Clock
   readonly verificationResendCooldownSeconds?: number
 }
 
@@ -90,6 +92,7 @@ export async function createPostgresTestKit(
         allowMergeAccounts: true,
         requireReAuthFor: [],
       }),
+    ...(options.clock ? { clock: options.clock } : {}),
   })
 
   return {


### PR DESCRIPTION
## Summary
- add current-account security aggregate and token-based self-service revoke helpers
- harden in-memory/Postgres parity and stale-session neutrality coverage
- update account-security, session-transport, backend, and example recipes to the new canonical helper path

## Details
- add `getCurrentAccountSecuritySnapshot({ sessionToken, touch?, now? })`
- add `revokeCurrentSessionByToken(...)` and `revokeOtherSessionsByToken(...)`
- reuse existing `resolveSessionContext(...)`, revoke semantics, and safe read-side projections
- keep cookie clearing, bearer deletion, and HTTP payload shaping application-owned

Closes #244
Closes #245
Closes #246
Closes #247
