### PR TITLE
docs: sync roadmap after v0.36.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -352,20 +352,24 @@ Tracking issues: #221, #222, #223, #224.
 
 Tracking issues: #225, #226, #227, #228, #229, #230, #231.
 
-## Next Release
-
 ### v0.36 - Current-Account Security Helpers
 
-- Add `getCurrentAccountSecuritySnapshot({ sessionToken, touch?, now? })` for self-service
+- Added `getCurrentAccountSecuritySnapshot({ sessionToken, touch?, now? })` for self-service
   account-security routes that already trust a local session token.
-- Add token-based self-service session revoke helpers for current-session logout and
+- Added token-based self-service session revoke helpers for current-session logout and
   sign-out-other-devices flows without rebuilding session + user ownership checks in every backend.
-- Add parity coverage for the new current-account helper layer across in-memory and Postgres-backed
+- Added parity coverage for the current-account helper layer across in-memory and Postgres-backed
   service setups, including stale-session neutrality and current-session markers.
-- Update account-security and session-transport recipes so current-account routes use the aggregate
+- Updated account-security and session-transport recipes so current-account routes use the aggregate
   helper layer instead of manual multi-call composition.
 
 Tracking issues: #244, #245, #246, #247.
+
+## Next Release
+
+### v0.37 - Backlog To Be Defined
+
+- The next releasable scope has not been defined yet.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.36 into Released after the published release
- restore v0.37 as the next-release placeholder
- keep roadmap aligned with closed v0.36 tracking issues