### PR TITLE
feat: add current-account inspection helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ license, subscription, private contract, or other written permission.
   screens.
 - Exposes a current-account aggregate helper and token-based self-service session revoke helpers for
   trusted account-security routes after transport resolution.
+- Exposes current-account inspection aggregate and audit-page helpers for self-service security
+  routes that already trust a local session token.
 - Exposes a trusted `getAccountInspectionSnapshot({ userId, audit? })` aggregate read-side
   API for backend support and admin inspection flows.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
@@ -329,6 +331,19 @@ const current = await service.getCurrentAccountSecuritySnapshot({
 })
 ```
 
+When the current account page also needs a bounded self-service audit timeline, prefer the current
+inspection aggregate instead of mixing current-account and admin-oriented helpers:
+
+```ts
+const currentInspection = await service.getCurrentAccountInspectionSnapshot({
+  sessionToken,
+  touch: true,
+  audit: {
+    limit: 20,
+  },
+})
+```
+
 Trusted backend tooling can start from one trusted aggregate inspection helper:
 
 ```ts
@@ -342,7 +357,8 @@ const inspection = await service.getAccountInspectionSnapshot({
 
 If the surrounding tooling truly needs raw audit entities, custom filters, or metadata-aware
 serialization, `getAuditEvents(...)` and `getAuditEventPage(...)` remain available as the narrower
-read-side primitives.
+read-side primitives. Self-service current-account routes that need timeline pagination can stay on
+the trusted token boundary through `getCurrentAccountAuditEventPage(...)`.
 
 Trusted resend and cooldown polling can use one read-side helper per verification:
 

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -29,9 +29,12 @@ When the caller is already authenticated by a trusted local session token, prefe
 helper instead of manually composing `resolveSessionContext(...)` with a second user-scoped read:
 
 ```ts
-const current = await authService.getCurrentAccountSecuritySnapshot({
+const current = await authService.getCurrentAccountInspectionSnapshot({
   sessionToken,
   touch: true,
+  audit: {
+    limit: 20,
+  },
 })
 ```
 
@@ -40,9 +43,12 @@ const current = await authService.getCurrentAccountSecuritySnapshot({
 The minimal current-account server-side composition usually looks like this:
 
 ```ts
-const current = await authService.getCurrentAccountSecuritySnapshot({
+const current = await authService.getCurrentAccountInspectionSnapshot({
   sessionToken,
   touch: true,
+  audit: {
+    limit: 20,
+  },
 })
 ```
 
@@ -80,6 +86,12 @@ return {
     lastSeenAt: session.lastSeenAt?.toISOString() ?? null,
     revokedAt: session.revokedAt?.toISOString() ?? null,
   })),
+  auditEvents: current.auditEvents.map((event) => ({
+    id: event.id,
+    type: event.type,
+    occurredAt: event.occurredAt.toISOString(),
+  })),
+  nextAuditCursor: current.nextAuditCursor ?? null,
 }
 ```
 
@@ -90,6 +102,15 @@ Do not serialize:
 - `Verification.secretHash`
 
 ## Security Timeline
+
+For self-service security timelines backed by a trusted local session token:
+
+```ts
+const page = await authService.getCurrentAccountAuditEventPage({
+  sessionToken,
+  limit: 20,
+})
+```
 
 For trusted backend security timelines or support inspection:
 
@@ -105,8 +126,24 @@ const events = page.events
 The service returns local `AuditEvent` records newest-first. Keep outward serialization
 application-owned and expose only the fields your support or admin surface actually needs.
 
-For continuation-based trusted pagination, keep the cursor application-owned and derive it from the
-last event you already returned:
+For continuation-based current-account pagination, keep the cursor application-owned and derive it
+from the last event you already returned:
+
+```ts
+const firstPage = await authService.getCurrentAccountAuditEventPage({
+  sessionToken,
+  limit: 20,
+})
+
+const nextPage = await authService.getCurrentAccountAuditEventPage({
+  sessionToken,
+  before: firstPage.nextCursor,
+  limit: 20,
+})
+```
+
+Trusted backend or support inspection can use the same pagination semantics through the user-scoped
+helper:
 
 ```ts
 const firstPage = await authService.getAuditEventPage({
@@ -214,7 +251,7 @@ generic neutral response. UniAuth only enforces local session state.
 
 For sign-in method screens:
 
-1. load the aggregate view through `authService.getCurrentAccountSecuritySnapshot(...)` or
+1. load the aggregate view through `authService.getCurrentAccountInspectionSnapshot(...)` or
    `authService.getAccountSecuritySnapshot(userId)`, depending on whether the route is self-service
    or trusted admin/support;
 2. present provider ids, statuses, email or phone hints, and credential types;
@@ -233,7 +270,7 @@ Resolve the current account snapshot first so the application knows which method
 then unlink by `identityId`:
 
 ```ts
-const current = await authService.getCurrentAccountSecuritySnapshot({
+const current = await authService.getCurrentAccountInspectionSnapshot({
   sessionToken: request.auth.sessionToken,
 })
 const targetIdentity = current.account.identities.find(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,8 @@ identities, and email/phone are optional identity attributes.
 - `resolveSession`
 - `resolveSessionContext`
 - `getCurrentAccountSecuritySnapshot`
+- `getCurrentAccountInspectionSnapshot`
+- `getCurrentAccountAuditEventPage`
 - `revokeCurrentSessionByToken`
 - `revokeOtherSessionsByToken`
 - `touchSession`
@@ -70,6 +72,9 @@ Current-account security routes can also stay on trusted token-based helpers wit
 that flow on every backend. Core can now resolve a trusted local `sessionToken`, load the current
 account-security aggregate, or revoke the current/other local sessions through one narrow helper
 layer while cookie clearing, header parsing, and outward payload shaping remain application-owned.
+That same trusted boundary now also covers current-account inspection snapshots and current-account
+audit page reads, so self-service security routes do not have to mix admin inspection helpers with
+manual session ownership resolution.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -115,8 +115,8 @@ Express ownership notes:
 - Keep route-neutral errors neutral at the HTTP layer too; do not translate invalid credentials into
   account existence hints.
 - For account-security screens and mutations, use [Account security recipes](account-security.md)
-  and prefer `getCurrentAccountSecuritySnapshot({ sessionToken })` plus the token-based self-service
-  revoke helpers instead of reading adapter internals.
+  and prefer `getCurrentAccountInspectionSnapshot({ sessionToken, audit? })` plus the token-based
+  self-service revoke helpers instead of reading adapter internals.
 
 ## Fastify
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -367,9 +367,21 @@ Tracking issues: #244, #245, #246, #247.
 
 ## Next Release
 
-### v0.37 - Backlog To Be Defined
+### v0.37 - Current-Account Inspection Helpers
 
-- The next releasable scope has not been defined yet.
+- Add `getCurrentAccountInspectionSnapshot({ sessionToken, touch?, now?, audit? })` so self-service
+  security routes can load current-account snapshot state and a bounded audit window through one
+  trusted local-session helper.
+- Add `getCurrentAccountAuditEventPage({ sessionToken, touch?, now?, ...filters })` so current
+  account security timelines can paginate through the same neutral trusted-session boundary without
+  re-resolving ownership in each route.
+- Add parity coverage for current-account aggregate inspection and page helpers across in-memory and
+  Postgres-backed service setups, including stale-session neutrality and current-session markers.
+- Update account-security, session-transport, backend, and architecture docs so self-service
+  security routes use the current-account inspection layer instead of mixing admin inspection with
+  manual session resolution.
+
+Tracking issues: #251, #252, #253, #254.
 
 ## Versioning
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -18,7 +18,8 @@ Use this document for:
 
 Use [Backend integration recipes](backend-recipes.md) for framework bootstrap and route/controller
 composition. Use [Account security recipes](account-security.md) for device lists, sign-in methods,
-verification inspection, and current-account flows after you already trust the caller.
+verification inspection, audit timelines, and current-account flows after you already trust the
+caller.
 
 ## Browser Cookies
 

--- a/docs/support-inspection.md
+++ b/docs/support-inspection.md
@@ -8,7 +8,8 @@ fields a support surface is allowed to expose. Keep this recipe server-only and 
 
 Use [Account security recipes](account-security.md) for end-user account settings, revoke flows,
 unlink, and password-management actions. Use this document when a trusted backend operator needs a
-read-only inspection surface.
+read-only inspection surface. Self-service current-account routes should stay on the token-based
+current-account inspection helpers instead of reusing the admin/support aggregate directly.
 
 ## Trusted Boundary
 

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -32,7 +32,7 @@ import {
   sealSessionCookieValue,
   unsealSessionCookieValue,
 } from '../shared/session-cookie.js'
-import { serializeCurrentAccountSecuritySnapshot } from '../shared/views.js'
+import { serializeCurrentAccountInspectionSnapshot } from '../shared/views.js'
 
 interface ExpressAuthExample {
   readonly app: Express
@@ -182,11 +182,12 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
           return
         }
 
-        const snapshot = await authService.getCurrentAccountSecuritySnapshot({
+        const inspection = await authService.getCurrentAccountInspectionSnapshot({
           sessionToken: auth.sessionToken,
+          audit: { limit: 10 },
         })
 
-        response.status(200).json(serializeCurrentAccountSecuritySnapshot(snapshot))
+        response.status(200).json(serializeCurrentAccountInspectionSnapshot(inspection))
       } catch (error) {
         next(error)
       }

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -29,7 +29,7 @@ import {
   sealSessionCookieValue,
   unsealSessionCookieValue,
 } from '../shared/session-cookie.js'
-import { serializeCurrentAccountSecuritySnapshot } from '../shared/views.js'
+import { serializeCurrentAccountInspectionSnapshot } from '../shared/views.js'
 
 interface FastifyAuthExample {
   readonly app: FastifyInstance
@@ -179,11 +179,12 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
         return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
       }
 
-      const snapshot = await authService.getCurrentAccountSecuritySnapshot({
+      const inspection = await authService.getCurrentAccountInspectionSnapshot({
         sessionToken: auth.sessionToken,
+        audit: { limit: 10 },
       })
 
-      return reply.status(200).send(serializeCurrentAccountSecuritySnapshot(snapshot))
+      return reply.status(200).send(serializeCurrentAccountInspectionSnapshot(inspection))
     },
   )
 

--- a/examples/shared/views.ts
+++ b/examples/shared/views.ts
@@ -1,4 +1,5 @@
 import type {
+  CurrentAccountInspectionSnapshot,
   AccountSecuritySnapshot,
   CurrentAccountSecuritySnapshot,
   VerificationResendWindow,
@@ -51,6 +52,28 @@ export function serializeCurrentAccountSecuritySnapshot(snapshot: CurrentAccount
   return {
     ...serializeAccountSecuritySnapshot(snapshot.account),
     currentSessionId: snapshot.currentSessionId,
+  }
+}
+
+export function serializeCurrentAccountInspectionSnapshot(
+  snapshot: CurrentAccountInspectionSnapshot,
+) {
+  return {
+    ...serializeCurrentAccountSecuritySnapshot(snapshot),
+    auditEvents: snapshot.auditEvents.map((event) => ({
+      id: event.id,
+      type: event.type,
+      occurredAt: event.occurredAt.toISOString(),
+      userId: event.userId ?? null,
+      identityId: event.identityId ?? null,
+      sessionId: event.sessionId ?? null,
+    })),
+    nextAuditCursor: snapshot.nextAuditCursor
+      ? {
+          id: snapshot.nextAuditCursor.id,
+          occurredAt: snapshot.nextAuditCursor.occurredAt.toISOString(),
+        }
+      : null,
   }
 }
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -86,6 +86,10 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.getCurrentAccountSecuritySnapshot).toBeTypeOf(
       'function',
     )
+    expect(core.DefaultAuthService.prototype.getCurrentAccountInspectionSnapshot).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.getCurrentAccountAuditEventPage).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeCurrentSessionByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeOtherSessionsByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
@@ -94,6 +98,7 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.touchSession).toBeTypeOf('function')
     expect(core.toAccountInspectionSnapshot).toBeTypeOf('function')
     expect(core.toAccountSecuritySnapshot).toBeTypeOf('function')
+    expect(core.toCurrentAccountInspectionSnapshot).toBeTypeOf('function')
     expect(core.toAuditEventView).toBeTypeOf('function')
     expect(core.toAuditEventCursor).toBeTypeOf('function')
     expect(core.toAccountSecurityCredentialView).toBeTypeOf('function')
@@ -175,10 +180,19 @@ describe('package exports', () => {
 
     expect(contractsDeclarations).toContain('AuthServiceInfrastructure')
     expect(viewDeclarations).toContain('export interface CurrentAccountSecuritySnapshot')
+    expect(viewDeclarations).toContain('export interface CurrentAccountInspectionSnapshot')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountSecuritySnapshotInput')
+    expect(flowDeclarations).toContain('export interface GetCurrentAccountInspectionSnapshotInput')
+    expect(flowDeclarations).toContain('export interface GetCurrentAccountAuditEventPageInput')
     expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
     expect(serviceDeclarations).toContain(
       'getCurrentAccountSecuritySnapshot(input: GetCurrentAccountSecuritySnapshotInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'getCurrentAccountInspectionSnapshot(input: GetCurrentAccountInspectionSnapshotInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'getCurrentAccountAuditEventPage(input: GetCurrentAccountAuditEventPageInput)',
     )
     expect(serviceDeclarations).toContain(
       'revokeOtherSessionsByToken(input: RevokeOtherSessionsByTokenInput)',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -4,6 +4,10 @@ import { getAuditEventPage, getAuditEvents } from './audit-events.js'
 import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import {
+  getCurrentAccountAuditEventPage,
+  getCurrentAccountInspectionSnapshot,
+} from './current-account-inspection.js'
+import {
   getCurrentAccountSecuritySnapshot,
   revokeCurrentSessionByToken,
   revokeOtherSessionsByToken,
@@ -59,6 +63,7 @@ import type {
   AuditEventQuery,
   AuthResult,
   AuthService,
+  CurrentAccountInspectionSnapshot,
   CurrentAccountSecuritySnapshot,
   CancelEmailMagicLinkSignInInput,
   CancelEmailPasswordRecoveryInput,
@@ -76,6 +81,8 @@ import type {
   FinishOtpChallengeInput,
   FinishOtpSignInInput,
   GetAccountInspectionSnapshotInput,
+  GetCurrentAccountAuditEventPageInput,
+  GetCurrentAccountInspectionSnapshotInput,
   GetCurrentAccountSecuritySnapshotInput,
   GetVerificationResendWindowInput,
   LinkInput,
@@ -231,6 +238,18 @@ export class DefaultAuthService implements AuthService {
     input: GetCurrentAccountSecuritySnapshotInput,
   ): Promise<CurrentAccountSecuritySnapshot> {
     return getCurrentAccountSecuritySnapshot(this.runtime, input)
+  }
+
+  async getCurrentAccountInspectionSnapshot(
+    input: GetCurrentAccountInspectionSnapshotInput,
+  ): Promise<CurrentAccountInspectionSnapshot> {
+    return getCurrentAccountInspectionSnapshot(this.runtime, input)
+  }
+
+  async getCurrentAccountAuditEventPage(
+    input: GetCurrentAccountAuditEventPageInput,
+  ): Promise<AuditEventPage> {
+    return getCurrentAccountAuditEventPage(this.runtime, input)
   }
 
   async revokeCurrentSessionByToken(input: RevokeCurrentSessionByTokenInput): Promise<void> {

--- a/src/application/current-account-inspection.ts
+++ b/src/application/current-account-inspection.ts
@@ -1,0 +1,54 @@
+import { getAccountSecuritySnapshotForUser } from './account-security.js'
+import { getAuditEventPage } from './audit-events.js'
+import type { AuthServiceRuntime } from './runtime.js'
+import { resolveSessionContext } from './session-context.js'
+import type {
+  AuditEventPage,
+  CurrentAccountInspectionSnapshot,
+  GetCurrentAccountAuditEventPageInput,
+  GetCurrentAccountInspectionSnapshotInput,
+} from '../domain/types.js'
+import { toCurrentAccountInspectionSnapshot } from '../domain/types.js'
+
+export async function getCurrentAccountInspectionSnapshot(
+  runtime: AuthServiceRuntime,
+  input: GetCurrentAccountInspectionSnapshotInput,
+): Promise<CurrentAccountInspectionSnapshot> {
+  const { session, user } = await resolveSessionContext(runtime, input)
+  const account = await getAccountSecuritySnapshotForUser(runtime, user)
+  const auditWindow = input.audit
+  const auditLimit = auditWindow?.limit ?? input.auditLimit
+  const auditPage = await getAuditEventPage(runtime, {
+    userId: user.id,
+    ...(auditWindow?.type ? { type: auditWindow.type } : {}),
+    ...(auditWindow?.identityId ? { identityId: auditWindow.identityId } : {}),
+    ...(auditWindow?.sessionId ? { sessionId: auditWindow.sessionId } : {}),
+    ...(auditWindow?.before ? { before: auditWindow.before } : {}),
+    ...(auditWindow?.after ? { after: auditWindow.after } : {}),
+    ...(auditLimit !== undefined ? { limit: auditLimit } : {}),
+  })
+
+  return toCurrentAccountInspectionSnapshot({
+    account,
+    currentSessionId: session.id,
+    auditEvents: auditPage.events,
+    ...(auditPage.nextCursor ? { nextAuditCursor: auditPage.nextCursor } : {}),
+  })
+}
+
+export async function getCurrentAccountAuditEventPage(
+  runtime: AuthServiceRuntime,
+  input: GetCurrentAccountAuditEventPageInput,
+): Promise<AuditEventPage> {
+  const { user } = await resolveSessionContext(runtime, input)
+
+  return getAuditEventPage(runtime, {
+    userId: user.id,
+    ...(input.type ? { type: input.type } : {}),
+    ...(input.identityId ? { identityId: input.identityId } : {}),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.before ? { before: input.before } : {}),
+    ...(input.after ? { after: input.after } : {}),
+    ...(input.limit !== undefined ? { limit: input.limit } : {}),
+  })
+}

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -107,6 +107,35 @@ export interface GetCurrentAccountSecuritySnapshotInput {
   readonly now?: Date
 }
 
+export interface CurrentAccountAuditWindow {
+  readonly identityId?: AuditEventQuery['identityId']
+  readonly sessionId?: AuditEventQuery['sessionId']
+  readonly type?: AuditEventQuery['type']
+  readonly before?: AuditEventQuery['before']
+  readonly after?: AuditEventQuery['after']
+  readonly limit?: AuditEventQuery['limit']
+}
+
+export interface GetCurrentAccountInspectionSnapshotInput {
+  readonly sessionToken: string
+  readonly touch?: boolean
+  readonly now?: Date
+  readonly auditLimit?: number
+  readonly audit?: CurrentAccountAuditWindow
+}
+
+export interface GetCurrentAccountAuditEventPageInput {
+  readonly sessionToken: string
+  readonly touch?: boolean
+  readonly now?: Date
+  readonly identityId?: AuditEventQuery['identityId']
+  readonly sessionId?: AuditEventQuery['sessionId']
+  readonly type?: AuditEventQuery['type']
+  readonly before?: AuditEventQuery['before']
+  readonly after?: AuditEventQuery['after']
+  readonly limit?: AuditEventQuery['limit']
+}
+
 export interface RevokeCurrentSessionByTokenInput {
   readonly sessionToken: string
   readonly now?: Date

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -2,6 +2,7 @@ import type { AuthIdentity, Credential, Session, User, Verification } from './en
 import type {
   AccountInspectionSnapshot,
   AccountSecuritySnapshot,
+  CurrentAccountInspectionSnapshot,
   CurrentAccountSecuritySnapshot,
   VerificationResendWindow,
 } from './views.js'
@@ -9,6 +10,8 @@ import type { AuditEvent, AuditEventPage, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
   GetCurrentAccountSecuritySnapshotInput,
+  GetCurrentAccountAuditEventPageInput,
+  GetCurrentAccountInspectionSnapshotInput,
   ConsumeVerificationInput,
   CancelOtpChallengeInput,
   CancelVerificationInput,
@@ -90,6 +93,12 @@ export interface AuthService {
   getCurrentAccountSecuritySnapshot(
     input: GetCurrentAccountSecuritySnapshotInput,
   ): Promise<CurrentAccountSecuritySnapshot>
+  getCurrentAccountInspectionSnapshot(
+    input: GetCurrentAccountInspectionSnapshotInput,
+  ): Promise<CurrentAccountInspectionSnapshot>
+  getCurrentAccountAuditEventPage(
+    input: GetCurrentAccountAuditEventPageInput,
+  ): Promise<AuditEventPage>
   revokeCurrentSessionByToken(input: RevokeCurrentSessionByTokenInput): Promise<void>
   revokeOtherSessionsByToken(
     input: RevokeOtherSessionsByTokenInput,

--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -56,6 +56,11 @@ export interface CurrentAccountSecuritySnapshot {
   readonly currentSessionId: Session['id']
 }
 
+export interface CurrentAccountInspectionSnapshot extends CurrentAccountSecuritySnapshot {
+  readonly auditEvents: readonly AuditEventView[]
+  readonly nextAuditCursor?: AuditEventCursor
+}
+
 export interface AuditEventView {
   readonly id: AuditEvent['id']
   readonly type: AuditEvent['type']
@@ -172,6 +177,20 @@ export function toAccountInspectionSnapshot(input: {
 }): AccountInspectionSnapshot {
   return {
     account: input.account,
+    auditEvents: input.auditEvents.map((event) => toAuditEventView(event)),
+    ...(input.nextAuditCursor ? { nextAuditCursor: input.nextAuditCursor } : {}),
+  }
+}
+
+export function toCurrentAccountInspectionSnapshot(input: {
+  readonly account: AccountSecuritySnapshot
+  readonly currentSessionId: Session['id']
+  readonly auditEvents: readonly AuditEvent[]
+  readonly nextAuditCursor?: AuditEventCursor
+}): CurrentAccountInspectionSnapshot {
+  return {
+    account: input.account,
+    currentSessionId: input.currentSessionId,
     auditEvents: input.auditEvents.map((event) => toAuditEventView(event)),
     ...(input.nextAuditCursor ? { nextAuditCursor: input.nextAuditCursor } : {}),
   }

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,5 +1,6 @@
 import './core/read-side-and-sessions.test.js'
 import './core/current-account-security.test.js'
+import './core/current-account-inspection.test.js'
 import './core/audit-pagination.test.js'
 import './core/otp-and-verifications.test.js'
 import './core/policies-and-merge.test.js'

--- a/test/core/current-account-inspection.test.ts
+++ b/test/core/current-account-inspection.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AuditEventType,
+  UniAuthErrorCode,
+  addSeconds,
+  toAuditEventCursor,
+  toAuditEventView,
+} from '../../src'
+import { createInMemoryAuthKit } from '../../src/testing'
+import { assertion, now } from './support.js'
+
+describe('DefaultAuthService current-account inspection helpers', () => {
+  it('keeps the current-account inspection aggregate in parity with the user-scoped reads', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-inspection',
+        email: 'current-account-inspection@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'current-account-inspection@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const touchedAt = addSeconds(now, 20)
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: touchedAt,
+      audit: { limit: 2 },
+    })
+    const current = await service.getCurrentAccountSecuritySnapshot({
+      sessionToken: signedIn.sessionToken,
+      now: touchedAt,
+    })
+    const page = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+
+    expect(inspection.account).toEqual(current.account)
+    expect(inspection.currentSessionId).toBe(current.currentSessionId)
+    expect(inspection.auditEvents).toEqual(page.events.map(toAuditEventView))
+    expect(inspection.nextAuditCursor).toEqual(page.nextCursor)
+  })
+
+  it('returns the same current-account audit page as the user-scoped audit helper', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-audit-page',
+        email: 'current-account-audit-page@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'current-account-audit-page@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const pageNow = addSeconds(now, 20)
+
+    const page = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      limit: 2,
+    })
+    const rawPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+
+    expect(page).toEqual(rawPage)
+    expect(page.events.map((event) => event.type)).toEqual([
+      AuditEventType.SessionCreated,
+      AuditEventType.SignIn,
+    ])
+
+    const nextPage = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      before: page.nextCursor,
+      limit: 2,
+    })
+    const rawNextPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      before: rawPage.nextCursor!,
+      limit: 2,
+    })
+
+    expect(nextPage).toEqual(rawNextPage)
+    expect(nextPage.nextCursor).toEqual(rawNextPage.nextCursor)
+  })
+
+  it('uses the runtime clock for current-account inspection helpers when now is omitted', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-inspection-no-now',
+        email: 'current-account-inspection-no-now@example.com',
+        emailVerified: true,
+      }),
+    })
+
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      audit: { limit: 1 },
+    })
+    const page = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      limit: 1,
+    })
+
+    expect(inspection.currentSessionId).toBe(signedIn.session.id)
+    expect(page.events).toHaveLength(1)
+  })
+
+  it('uses the default audit window when current-account inspection input omits audit overrides', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-default-audit-window',
+        email: 'current-account-default-audit-window@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      now,
+    })
+    const rawPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+    })
+    const currentPage = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now,
+    })
+
+    expect(inspection.auditEvents).toEqual(rawPage.events.map(toAuditEventView))
+    expect(inspection.nextAuditCursor).toEqual(rawPage.nextCursor)
+    expect(currentPage).toEqual(rawPage)
+  })
+
+  it('threads explicit current-account audit filters through both aggregate and page helpers', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-filtered-audit',
+        email: 'current-account-filtered-audit@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const rawAll = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 10,
+    })
+    const after = toAuditEventCursor(rawAll.events[0]!)
+    const before = toAuditEventCursor(rawAll.events.at(-1)!)
+    const pageNow = addSeconds(now, 20)
+
+    const currentPage = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      type: AuditEventType.SessionCreated,
+      identityId: signedIn.identity.id,
+      sessionId: secondSession.session.id,
+      after,
+      before,
+      limit: 2,
+    })
+    const rawPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      type: AuditEventType.SessionCreated,
+      identityId: signedIn.identity.id,
+      sessionId: secondSession.session.id,
+      after,
+      before,
+      limit: 2,
+    })
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      audit: {
+        type: AuditEventType.SessionCreated,
+        identityId: signedIn.identity.id,
+        sessionId: secondSession.session.id,
+        after,
+        before,
+        limit: 2,
+      },
+    })
+
+    expect(currentPage).toEqual(rawPage)
+    expect(inspection.auditEvents).toEqual(rawPage.events.map(toAuditEventView))
+    expect(inspection.nextAuditCursor).toEqual(rawPage.nextCursor)
+  })
+
+  it('keeps stale disabled-user current-account inspection helpers neutral', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({ assertion: assertion(), now })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.getCurrentAccountInspectionSnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        audit: { limit: 1 },
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.getCurrentAccountAuditEventPage({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,4 +1,5 @@
 import './postgres/security-and-read-side.test.js'
 import './postgres/current-account-security.test.js'
+import './postgres/current-account-inspection.test.js'
 import './postgres/audit-pagination.test.js'
 import './postgres/persistence-and-merge.test.js'

--- a/test/postgres/current-account-inspection.test.ts
+++ b/test/postgres/current-account-inspection.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import { UniAuthErrorCode, addSeconds, toAuditEventView } from '../../src'
+import { createPostgresTestKit, now } from './support.js'
+
+describe('Postgres current-account inspection helpers', () => {
+  it('keeps the current-account inspection aggregate in parity with the user-scoped reads', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-inspection',
+        email: 'pg-current-account-inspection@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'pg-current-account-inspection@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const touchedAt = addSeconds(now, 20)
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: touchedAt,
+      audit: { limit: 2 },
+    })
+    const current = await service.getCurrentAccountSecuritySnapshot({
+      sessionToken: signedIn.sessionToken,
+      now: touchedAt,
+    })
+    const page = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+
+    expect(inspection.account).toEqual(current.account)
+    expect(inspection.currentSessionId).toBe(current.currentSessionId)
+    expect(inspection.auditEvents).toEqual(page.events.map(toAuditEventView))
+    expect(inspection.nextAuditCursor).toEqual(page.nextCursor)
+  })
+
+  it('returns the same current-account audit page as the user-scoped audit helper on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-audit-page',
+        email: 'pg-current-account-audit-page@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'pg-current-account-audit-page@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+    const pageNow = addSeconds(now, 20)
+
+    const page = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      limit: 2,
+    })
+    const rawPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      limit: 2,
+    })
+
+    expect(page).toEqual(rawPage)
+
+    const nextPage = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      now: pageNow,
+      before: page.nextCursor,
+      limit: 2,
+    })
+    const rawNextPage = await service.getAuditEventPage({
+      userId: signedIn.user.id,
+      before: rawPage.nextCursor!,
+      limit: 2,
+    })
+
+    expect(nextPage).toEqual(rawNextPage)
+  })
+
+  it('uses the runtime clock for current-account inspection helpers on Postgres when now is omitted', async () => {
+    const { service } = await createPostgresTestKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-inspection-no-now',
+        email: 'pg-current-account-inspection-no-now@example.com',
+        emailVerified: true,
+      },
+    })
+
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      audit: { limit: 1 },
+    })
+    const page = await service.getCurrentAccountAuditEventPage({
+      sessionToken: signedIn.sessionToken,
+      limit: 1,
+    })
+
+    expect(inspection.currentSessionId).toBe(signedIn.session.id)
+    expect(page.events).toHaveLength(1)
+  })
+
+  it('keeps stale disabled-user Postgres current-account inspection helpers neutral', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-disabled-current-account-inspection',
+        email: 'pg-disabled-current-account-inspection@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.getCurrentAccountInspectionSnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        audit: { limit: 1 },
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.getCurrentAccountAuditEventPage({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add current-account inspection and audit page helpers on top of the trusted session-token boundary
- harden parity coverage across in-memory and Postgres setups
- update self-service account-security docs, examples, and roadmap for the v0.37 scope

## Closes
- closes #251
- closes #252
- closes #253
- closes #254