### PR TITLE
docs: sync roadmap after v0.37.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -365,23 +365,27 @@ Tracking issues: #225, #226, #227, #228, #229, #230, #231.
 
 Tracking issues: #244, #245, #246, #247.
 
-## Next Release
-
 ### v0.37 - Current-Account Inspection Helpers
 
-- Add `getCurrentAccountInspectionSnapshot({ sessionToken, touch?, now?, audit? })` so self-service
+- Added `getCurrentAccountInspectionSnapshot({ sessionToken, touch?, now?, audit? })` so self-service
   security routes can load current-account snapshot state and a bounded audit window through one
   trusted local-session helper.
-- Add `getCurrentAccountAuditEventPage({ sessionToken, touch?, now?, ...filters })` so current
+- Added `getCurrentAccountAuditEventPage({ sessionToken, touch?, now?, ...filters })` so current
   account security timelines can paginate through the same neutral trusted-session boundary without
   re-resolving ownership in each route.
-- Add parity coverage for current-account aggregate inspection and page helpers across in-memory and
+- Added parity coverage for current-account aggregate inspection and page helpers across in-memory and
   Postgres-backed service setups, including stale-session neutrality and current-session markers.
-- Update account-security, session-transport, backend, and architecture docs so self-service
+- Updated account-security, session-transport, backend, and architecture docs so self-service
   security routes use the current-account inspection layer instead of mixing admin inspection with
   manual session resolution.
 
 Tracking issues: #251, #252, #253, #254.
+
+## Next Release
+
+### v0.38 - Backlog To Be Defined
+
+- The next releasable scope has not been defined yet.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.37 into Released after the published release
- restore v0.38 as the next-release placeholder
- keep roadmap aligned with the closed v0.37 tracking issues