### PR TITLE
feat: add current-account action helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ license, subscription, private contract, or other written permission.
   trusted account-security routes after transport resolution.
 - Exposes current-account inspection aggregate and audit-page helpers for self-service security
   routes that already trust a local session token.
+- Exposes token-based current-account write-side helpers for selected-session revoke, sign-in-method
+  unlink, and local password setup or change after transport resolution.
 - Exposes a trusted `getAccountInspectionSnapshot({ userId, audit? })` aggregate read-side
   API for backend support and admin inspection flows.
 - Supports bulk local session revocation for sign-out-all-devices style account-security flows.
@@ -359,6 +361,21 @@ If the surrounding tooling truly needs raw audit entities, custom filters, or me
 serialization, `getAuditEvents(...)` and `getAuditEventPage(...)` remain available as the narrower
 read-side primitives. Self-service current-account routes that need timeline pagination can stay on
 the trusted token boundary through `getCurrentAccountAuditEventPage(...)`.
+
+The same trusted token boundary can also own self-service account mutations:
+
+```ts
+await service.revokeOwnedSessionByToken({
+  sessionToken,
+  targetSessionId,
+})
+
+await service.unlinkCurrentIdentityByToken({
+  sessionToken,
+  identityId,
+  reAuthenticatedAt,
+})
+```
 
 Trusted resend and cooldown polling can use one read-side helper per verification:
 

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -222,30 +222,26 @@ records and returns the current session id the application can mark in its respo
 
 ### Revoke One Selected Device
 
-For per-device revoke actions, first prove ownership from the read-side snapshot and only then call
-`revokeSession(...)`:
+For per-device revoke actions, keep the mutation on the trusted current-account boundary and let the
+service enforce ownership of the selected session:
 
 ```ts
-const current = await authService.getCurrentAccountSecuritySnapshot({
+const result = await authService.revokeOwnedSessionByToken({
   sessionToken: request.auth.sessionToken,
+  targetSessionId: body.sessionId,
 })
-const target = current.account.sessions.find((session) => session.id === body.sessionId)
 
-if (!target) {
-  return response.status(404).json({ error: 'Session not found.' })
-}
-
-await authService.revokeSession(target.id)
-
-if (target.id === current.currentSessionId) {
+if (result.revokedCurrentSession) {
   clearSessionCookie(response)
 }
 
 return response.status(204).send()
 ```
 
-The application decides whether a missing or foreign session should look like `404`, `204`, or a
-generic neutral response. UniAuth only enforces local session state.
+The application can still pre-load the session list through
+`getCurrentAccountSecuritySnapshot(...)` for UI rendering, but the write-side route no longer has to
+re-prove ownership by hand. Missing, foreign, stale, or disabled-account session targets collapse
+to the neutral `SessionNotFound` path.
 
 ## Sign-In Method Action Recipes
 
@@ -255,7 +251,8 @@ For sign-in method screens:
    `authService.getAccountSecuritySnapshot(userId)`, depending on whether the route is self-service
    or trusted admin/support;
 2. present provider ids, statuses, email or phone hints, and credential types;
-3. compose mutations through `unlink(...)`, `setPassword(...)`, `changePassword(...)`, or new
+3. compose mutations through `unlinkCurrentIdentityByToken(...)`,
+   `setCurrentAccountPasswordByToken(...)`, `changeCurrentAccountPasswordByToken(...)`, or new
    provider link flows.
 
 Keep the same public security rules:
@@ -267,23 +264,12 @@ Keep the same public security rules:
 ### Unlink One Sign-In Method
 
 Resolve the current account snapshot first so the application knows which method the user selected,
-then unlink by `identityId`:
+then keep the unlink on the current-account token boundary:
 
 ```ts
-const current = await authService.getCurrentAccountInspectionSnapshot({
+await authService.unlinkCurrentIdentityByToken({
   sessionToken: request.auth.sessionToken,
-})
-const targetIdentity = current.account.identities.find(
-  (identity) => identity.id === body.identityId,
-)
-
-if (!targetIdentity) {
-  return response.status(404).json({ error: 'Sign-in method not found.' })
-}
-
-await authService.unlink({
-  userId: request.auth.userId,
-  identityId: targetIdentity.id,
+  identityId: body.identityId,
   reAuthenticatedAt: request.auth.reAuthenticatedAt,
 })
 
@@ -291,43 +277,37 @@ return response.status(204).send()
 ```
 
 If policy or invariant checks reject the unlink, keep the outward response neutral enough for your
-surface. Core already protects the last remaining active sign-in method.
+surface. Core still protects the last remaining active sign-in method and now also keeps foreign or
+stale identity targets on the same trusted current-account boundary.
 
 ### Add Or Replace A Local Password
 
-Use `setPassword(...)` when the account does not yet have a local password or when the application
-allows a provider-first account to add one from a trusted account-security screen:
+Use `setCurrentAccountPasswordByToken(...)` when the account does not yet have a local password or
+when the application allows a provider-first account to add one from a trusted account-security
+screen:
 
 ```ts
-const current = await authService.getCurrentAccountSecuritySnapshot({
+await authService.setCurrentAccountPasswordByToken({
   sessionToken: request.auth.sessionToken,
-})
-const passwordEmail = current.account.user.email
-
-if (!passwordEmail) {
-  return response.status(400).json({ error: 'Password setup requires a trusted email address.' })
-}
-
-await authService.setPassword({
-  userId: request.auth.userId,
-  email: passwordEmail,
   password: body.newPassword,
   reAuthenticatedAt: request.auth.reAuthenticatedAt,
 })
 ```
 
 The application still owns password policy UX, strength hints, recent-auth requirements, and
-whether the route should even be offered when a password credential already exists. Feed
-`setPassword(...)` with a trusted account-owned email, not with an arbitrary unverified request
-field.
+whether the route should even be offered when a password credential already exists.
+`setCurrentAccountPasswordByToken(...)` only works when the current account already has a trusted
+email address. If not, core rejects the route with `invalid_input` instead of letting the
+application invent a local password identity subject.
 
 ### Change Password
 
-Use `changePassword(...)` when the current user already knows the existing password:
+Use `changeCurrentAccountPasswordByToken(...)` when the current user already knows the existing
+password:
 
 ```ts
-await authService.changePassword({
-  userId: request.auth.userId,
+await authService.changeCurrentAccountPasswordByToken({
+  sessionToken: request.auth.sessionToken,
   currentPassword: body.currentPassword,
   newPassword: body.newPassword,
   reAuthenticatedAt: request.auth.reAuthenticatedAt,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,11 @@ identities, and email/phone are optional identity attributes.
 - `getCurrentAccountInspectionSnapshot`
 - `getCurrentAccountAuditEventPage`
 - `revokeCurrentSessionByToken`
+- `revokeOwnedSessionByToken`
 - `revokeOtherSessionsByToken`
+- `unlinkCurrentIdentityByToken`
+- `setCurrentAccountPasswordByToken`
+- `changeCurrentAccountPasswordByToken`
 - `touchSession`
 - `getUser`
 - `getUserCredentials`
@@ -74,7 +78,9 @@ account-security aggregate, or revoke the current/other local sessions through o
 layer while cookie clearing, header parsing, and outward payload shaping remain application-owned.
 That same trusted boundary now also covers current-account inspection snapshots and current-account
 audit page reads, so self-service security routes do not have to mix admin inspection helpers with
-manual session ownership resolution.
+manual session ownership resolution. Selected-device revoke, sign-in-method unlink, and local
+password setup or change can now stay on that same token-based boundary instead of bouncing back to
+raw `userId` mutation calls after middleware resolution.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -116,7 +116,8 @@ Express ownership notes:
   account existence hints.
 - For account-security screens and mutations, use [Account security recipes](account-security.md)
   and prefer `getCurrentAccountInspectionSnapshot({ sessionToken, audit? })` plus the token-based
-  self-service revoke helpers instead of reading adapter internals.
+  self-service revoke, unlink, and password-action helpers instead of reading adapter internals or
+  re-routing current-account writes through raw `userId` calls.
 
 ## Fastify
 
@@ -165,8 +166,8 @@ Fastify ownership notes:
   rather than introducing a Fastify-specific auth dispatcher.
 - For a fuller copyable token/session recipe, see [Session transport recipes](session-transport.md).
 - For sign-in-method, device-management, revoke, and password-change routes, use
-  [Account security recipes](account-security.md) and the current-account aggregate helper instead
-  of rebuilding session + user + snapshot composition by hand.
+  [Account security recipes](account-security.md) and the current-account aggregate plus token-based
+  action helpers instead of rebuilding session + user + snapshot composition by hand.
 
 ## Nest
 

--- a/docs/session-transport.md
+++ b/docs/session-transport.md
@@ -341,10 +341,11 @@ clearSessionCookie(response)
 
 For sign-out-all-devices or device-management screens, applications can first call
 `authService.getCurrentAccountSecuritySnapshot({ sessionToken })` and then revoke the active subset
-through `authService.revokeOtherSessionsByToken({ sessionToken })` or, for trusted admin flows,
-through `authService.revokeUserSessions({ userId, exceptSessionId })`. UniAuth still does not clear
-cookies or bearer stores for those clients; the application must remove the transport artifact on
-each device as it becomes aware of the revoked local session.
+through `authService.revokeOtherSessionsByToken({ sessionToken })`,
+`authService.revokeOwnedSessionByToken({ sessionToken, targetSessionId })`, or, for trusted admin
+flows, through `authService.revokeUserSessions({ userId, exceptSessionId })`. UniAuth still does
+not clear cookies or bearer stores for those clients; the application must remove the transport
+artifact on each device as it becomes aware of the revoked local session.
 
 For the account-security write-side recipes, safe outward projection, and sign-in-method management
 flows, continue in [Account security recipes](account-security.md).

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -91,7 +91,15 @@ describe('package exports', () => {
     )
     expect(core.DefaultAuthService.prototype.getCurrentAccountAuditEventPage).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeCurrentSessionByToken).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.revokeOwnedSessionByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeOtherSessionsByToken).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.unlinkCurrentIdentityByToken).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.setCurrentAccountPasswordByToken).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.changeCurrentAccountPasswordByToken).toBeTypeOf(
+      'function',
+    )
     expect(core.DefaultAuthService.prototype.getVerification).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeUserSessions).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getUserSessions).toBeTypeOf('function')
@@ -161,6 +169,10 @@ describe('package exports', () => {
       new URL('../dist/domain/service.d.ts', import.meta.url),
       'utf8',
     )
+    const localAuthDeclarations = await readFile(
+      new URL('../dist/domain/local-auth.d.ts', import.meta.url),
+      'utf8',
+    )
     const viewDeclarations = await readFile(
       new URL('../dist/domain/views.d.ts', import.meta.url),
       'utf8',
@@ -184,7 +196,15 @@ describe('package exports', () => {
     expect(flowDeclarations).toContain('export interface GetCurrentAccountSecuritySnapshotInput')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountInspectionSnapshotInput')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountAuditEventPageInput')
+    expect(flowDeclarations).toContain('export interface UnlinkCurrentIdentityByTokenInput')
+    expect(flowDeclarations).toContain('export interface RevokeOwnedSessionByTokenResult')
     expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
+    expect(localAuthDeclarations).toContain(
+      'export interface SetCurrentAccountPasswordByTokenInput',
+    )
+    expect(localAuthDeclarations).toContain(
+      'export interface ChangeCurrentAccountPasswordByTokenInput',
+    )
     expect(serviceDeclarations).toContain(
       'getCurrentAccountSecuritySnapshot(input: GetCurrentAccountSecuritySnapshotInput)',
     )
@@ -195,7 +215,19 @@ describe('package exports', () => {
       'getCurrentAccountAuditEventPage(input: GetCurrentAccountAuditEventPageInput)',
     )
     expect(serviceDeclarations).toContain(
+      'revokeOwnedSessionByToken(input: RevokeOwnedSessionByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
       'revokeOtherSessionsByToken(input: RevokeOtherSessionsByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'unlinkCurrentIdentityByToken(input: UnlinkCurrentIdentityByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'setCurrentAccountPasswordByToken(input: SetCurrentAccountPasswordByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'changeCurrentAccountPasswordByToken(input: ChangeCurrentAccountPasswordByTokenInput)',
     )
     expect(contractsDeclarations).toContain('UserUpdatePatch')
     expect(repositoryPortDeclarations).toContain('export interface UserUpdatePatch')

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -13,6 +13,12 @@ import {
   revokeOtherSessionsByToken,
 } from './current-account-security.js'
 import {
+  changeCurrentAccountPasswordByToken,
+  revokeOwnedSessionByToken,
+  setCurrentAccountPasswordByToken,
+  unlinkCurrentIdentityByToken,
+} from './current-account-actions.js'
+import {
   cancelEmailMagicLinkSignIn,
   finishEmailMagicLinkSignIn,
   resendEmailMagicLinkSignIn,
@@ -70,6 +76,7 @@ import type {
   CancelOtpChallengeInput,
   CancelVerificationInput,
   ChangePasswordInput,
+  ChangeCurrentAccountPasswordByTokenInput,
   Credential,
   ConsumeVerificationInput,
   CreateSessionInput,
@@ -90,6 +97,8 @@ import type {
   MergeAccountsInput,
   MergeResult,
   RevokeCurrentSessionByTokenInput,
+  RevokeOwnedSessionByTokenInput,
+  RevokeOwnedSessionByTokenResult,
   RevokeOtherSessionsByTokenInput,
   RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
@@ -101,6 +110,7 @@ import type {
   Session,
   SessionId,
   SetPasswordInput,
+  SetCurrentAccountPasswordByTokenInput,
   SignInInput,
   SignInWithPasswordInput,
   StartEmailMagicLinkSignInInput,
@@ -113,6 +123,7 @@ import type {
   StartOtpChallengeResult,
   TouchSessionInput,
   UnlinkInput,
+  UnlinkCurrentIdentityByTokenInput,
   User,
   UserId,
   Verification,
@@ -256,10 +267,32 @@ export class DefaultAuthService implements AuthService {
     return revokeCurrentSessionByToken(this.runtime, input)
   }
 
+  async revokeOwnedSessionByToken(
+    input: RevokeOwnedSessionByTokenInput,
+  ): Promise<RevokeOwnedSessionByTokenResult> {
+    return revokeOwnedSessionByToken(this.runtime, input)
+  }
+
   async revokeOtherSessionsByToken(
     input: RevokeOtherSessionsByTokenInput,
   ): Promise<RevokeOtherSessionsByTokenResult> {
     return revokeOtherSessionsByToken(this.runtime, input)
+  }
+
+  async unlinkCurrentIdentityByToken(input: UnlinkCurrentIdentityByTokenInput): Promise<void> {
+    return unlinkCurrentIdentityByToken(this.runtime, input)
+  }
+
+  async setCurrentAccountPasswordByToken(
+    input: SetCurrentAccountPasswordByTokenInput,
+  ): Promise<Credential> {
+    return setCurrentAccountPasswordByToken(this.runtime, input)
+  }
+
+  async changeCurrentAccountPasswordByToken(
+    input: ChangeCurrentAccountPasswordByTokenInput,
+  ): Promise<Credential> {
+    return changeCurrentAccountPasswordByToken(this.runtime, input)
   }
 
   async touchSession(input: TouchSessionInput): Promise<Session> {

--- a/src/application/current-account-actions.ts
+++ b/src/application/current-account-actions.ts
@@ -1,0 +1,112 @@
+import { unlink } from './accounts.js'
+import { optionalProp } from './optional.js'
+import { changePassword, setPassword } from './passwords.js'
+import type { AuthServiceRuntime } from './runtime.js'
+import { resolveSessionContext } from './session-context.js'
+import { revokeStoredSession } from './sessions.js'
+import type {
+  ChangeCurrentAccountPasswordByTokenInput,
+  Credential,
+  RevokeOwnedSessionByTokenInput,
+  RevokeOwnedSessionByTokenResult,
+  SetCurrentAccountPasswordByTokenInput,
+  UnlinkCurrentIdentityByTokenInput,
+} from '../domain/types.js'
+import { isActiveSession } from '../domain/types.js'
+import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
+
+export async function revokeOwnedSessionByToken(
+  runtime: AuthServiceRuntime,
+  input: RevokeOwnedSessionByTokenInput,
+): Promise<RevokeOwnedSessionByTokenResult> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { session, user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+    const target = await runtime.repos.sessionRepo.findById(input.targetSessionId)
+
+    if (!target || target.userId !== user.id || !isActiveSession(target, now)) {
+      throw new UniAuthError(UniAuthErrorCode.SessionNotFound, 'Session was not found.')
+    }
+
+    await revokeStoredSession(runtime, target.id, now)
+
+    return {
+      currentSessionId: session.id,
+      revokedSessionId: target.id,
+      revokedCurrentSession: target.id === session.id,
+    }
+  })
+}
+
+export async function unlinkCurrentIdentityByToken(
+  runtime: AuthServiceRuntime,
+  input: UnlinkCurrentIdentityByTokenInput,
+): Promise<void> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+
+    await unlink(runtime, {
+      userId: user.id,
+      identityId: input.identityId,
+      ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
+      now,
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })
+  })
+}
+
+export async function setCurrentAccountPasswordByToken(
+  runtime: AuthServiceRuntime,
+  input: SetCurrentAccountPasswordByTokenInput,
+): Promise<Credential> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+    const email = user.email?.trim()
+
+    if (!email) {
+      throw invalidInput('Password setup requires a trusted email address.')
+    }
+
+    return setPassword(runtime, {
+      userId: user.id,
+      email,
+      password: input.password,
+      ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
+      now,
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })
+  })
+}
+
+export async function changeCurrentAccountPasswordByToken(
+  runtime: AuthServiceRuntime,
+  input: ChangeCurrentAccountPasswordByTokenInput,
+): Promise<Credential> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+
+    return changePassword(runtime, {
+      userId: user.id,
+      currentPassword: input.currentPassword,
+      newPassword: input.newPassword,
+      ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
+      now,
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+    })
+  })
+}

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -52,6 +52,14 @@ export interface UnlinkInput {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface UnlinkCurrentIdentityByTokenInput {
+  readonly sessionToken: string
+  readonly identityId: IdentityId
+  readonly reAuthenticatedAt?: Date
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface MergeAccountsInput {
   readonly sourceUserId: UserId
   readonly targetUserId: UserId
@@ -139,6 +147,18 @@ export interface GetCurrentAccountAuditEventPageInput {
 export interface RevokeCurrentSessionByTokenInput {
   readonly sessionToken: string
   readonly now?: Date
+}
+
+export interface RevokeOwnedSessionByTokenInput {
+  readonly sessionToken: string
+  readonly targetSessionId: SessionId
+  readonly now?: Date
+}
+
+export interface RevokeOwnedSessionByTokenResult {
+  readonly currentSessionId: SessionId
+  readonly revokedSessionId: SessionId
+  readonly revokedCurrentSession: boolean
 }
 
 export interface RevokeOtherSessionsByTokenInput {

--- a/src/domain/local-auth.ts
+++ b/src/domain/local-auth.ts
@@ -63,8 +63,25 @@ export interface SetPasswordInput {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface SetCurrentAccountPasswordByTokenInput {
+  readonly sessionToken: string
+  readonly password: string
+  readonly reAuthenticatedAt?: Date
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface ChangePasswordInput {
   readonly userId: UserId
+  readonly currentPassword: string
+  readonly newPassword: string
+  readonly reAuthenticatedAt?: Date
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ChangeCurrentAccountPasswordByTokenInput {
+  readonly sessionToken: string
   readonly currentPassword: string
   readonly newPassword: string
   readonly reAuthenticatedAt?: Date

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -28,6 +28,8 @@ import type {
   MergeAccountsInput,
   MergeResult,
   RevokeCurrentSessionByTokenInput,
+  RevokeOwnedSessionByTokenInput,
+  RevokeOwnedSessionByTokenResult,
   RevokeOtherSessionsByTokenInput,
   RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
@@ -41,16 +43,19 @@ import type {
   StartOtpChallengeResult,
   TouchSessionInput,
   UnlinkInput,
+  UnlinkCurrentIdentityByTokenInput,
 } from './flows.js'
 import type { SessionId, UserId, VerificationId } from './ids.js'
 import type {
   ChangePasswordInput,
+  ChangeCurrentAccountPasswordByTokenInput,
   CancelEmailMagicLinkSignInInput,
   CancelEmailPasswordRecoveryInput,
   FinishEmailMagicLinkSignInInput,
   FinishEmailPasswordRecoveryInput,
   ResendEmailMagicLinkSignInInput,
   ResendEmailPasswordRecoveryInput,
+  SetCurrentAccountPasswordByTokenInput,
   SetPasswordInput,
   SignInWithPasswordInput,
   StartEmailMagicLinkSignInInput,
@@ -100,9 +105,19 @@ export interface AuthService {
     input: GetCurrentAccountAuditEventPageInput,
   ): Promise<AuditEventPage>
   revokeCurrentSessionByToken(input: RevokeCurrentSessionByTokenInput): Promise<void>
+  revokeOwnedSessionByToken(
+    input: RevokeOwnedSessionByTokenInput,
+  ): Promise<RevokeOwnedSessionByTokenResult>
   revokeOtherSessionsByToken(
     input: RevokeOtherSessionsByTokenInput,
   ): Promise<RevokeOtherSessionsByTokenResult>
+  unlinkCurrentIdentityByToken(input: UnlinkCurrentIdentityByTokenInput): Promise<void>
+  setCurrentAccountPasswordByToken(
+    input: SetCurrentAccountPasswordByTokenInput,
+  ): Promise<Credential>
+  changeCurrentAccountPasswordByToken(
+    input: ChangeCurrentAccountPasswordByTokenInput,
+  ): Promise<Credential>
   touchSession(input: TouchSessionInput): Promise<Session>
   getUser(userId: UserId): Promise<User>
   getUserIdentities(userId: UserId): Promise<readonly AuthIdentity[]>

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -1,6 +1,7 @@
 import './core/read-side-and-sessions.test.js'
 import './core/current-account-security.test.js'
 import './core/current-account-inspection.test.js'
+import './core/current-account-actions.test.js'
 import './core/audit-pagination.test.js'
 import './core/otp-and-verifications.test.js'
 import './core/policies-and-merge.test.js'

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AuthPolicyAction,
+  PASSWORD_PROVIDER_ID,
+  UniAuthErrorCode,
+  addSeconds,
+  createDefaultAuthPolicy,
+} from '../../src'
+import { createInMemoryAuthKit } from '../../src/testing'
+import { assertion, now } from './support.js'
+
+describe('DefaultAuthService current-account action helpers', () => {
+  it('revokes one owned session by trusted session token while preserving the current session', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-owned-session',
+        email: 'current-account-owned-session@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const result = await service.revokeOwnedSessionByToken({
+      sessionToken: signedIn.sessionToken,
+      targetSessionId: secondSession.session.id,
+      now: addSeconds(now, 20),
+    })
+
+    expect(result).toEqual({
+      currentSessionId: signedIn.session.id,
+      revokedSessionId: secondSession.session.id,
+      revokedCurrentSession: false,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: secondSession.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).resolves.toMatchObject({
+      id: signedIn.session.id,
+    })
+  })
+
+  it('can revoke the current session through the selected-session helper without an explicit now override', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-revoke-current-session',
+        email: 'current-account-revoke-current-session@example.com',
+        emailVerified: true,
+      }),
+    })
+
+    const result = await service.revokeOwnedSessionByToken({
+      sessionToken: signedIn.sessionToken,
+      targetSessionId: signedIn.session.id,
+    })
+
+    expect(result).toEqual({
+      currentSessionId: signedIn.session.id,
+      revokedSessionId: signedIn.session.id,
+      revokedCurrentSession: true,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+
+  it('keeps selected-session revocation neutral for foreign sessions', async () => {
+    const { service } = createInMemoryAuthKit()
+    const alice = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-revoke-foreign-owner',
+        email: 'current-account-revoke-foreign-owner@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const bob = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-revoke-foreign-target',
+        email: 'current-account-revoke-foreign-target@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.revokeOwnedSessionByToken({
+        sessionToken: alice.sessionToken,
+        targetSessionId: bob.session.id,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+
+  it('unlinks current-account identities by session token and preserves re-auth and last-identity rules', async () => {
+    const { service } = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.Unlink],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'current-account-unlink-email',
+        email: 'current-account-unlink@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const linked = await service.link({
+      userId: signedIn.user.id,
+      assertion: assertion({
+        provider: 'github',
+        providerUserId: 'current-account-unlink-github',
+        email: 'current-account-unlink@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.unlinkCurrentIdentityByToken({
+        sessionToken: signedIn.sessionToken,
+        identityId: linked.identity.id,
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    await service.unlinkCurrentIdentityByToken({
+      sessionToken: signedIn.sessionToken,
+      identityId: linked.identity.id,
+      reAuthenticatedAt: addSeconds(now, 10),
+      now: addSeconds(now, 10),
+    })
+
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: signedIn.identity.id,
+          status: 'active',
+        }),
+        expect.objectContaining({
+          id: linked.identity.id,
+          status: 'disabled',
+        }),
+      ]),
+    )
+
+    await expect(
+      service.unlinkCurrentIdentityByToken({
+        sessionToken: signedIn.sessionToken,
+        identityId: signedIn.identity.id,
+        reAuthenticatedAt: addSeconds(now, 11),
+        now: addSeconds(now, 11),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.LastIdentity,
+    })
+  })
+
+  it('sets and changes a current-account password by trusted session token', async () => {
+    const { service } = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.SetPassword, AuthPolicyAction.ChangePassword],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'current-account-password',
+        email: 'current-account-password@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.setCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        password: 'first-password',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    const created = await service.setCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      password: 'first-password',
+      reAuthenticatedAt: addSeconds(now, 10),
+      now: addSeconds(now, 10),
+    })
+
+    expect(created.type).toBe(PASSWORD_PROVIDER_ID)
+    await expect(
+      service.signInWithPassword({
+        email: 'current-account-password@example.com',
+        password: 'first-password',
+        now: addSeconds(now, 11),
+      }),
+    ).resolves.toMatchObject({
+      user: { id: signedIn.user.id },
+    })
+
+    await expect(
+      service.changeCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        currentPassword: 'first-password',
+        newPassword: 'second-password',
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    await expect(
+      service.changeCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        currentPassword: 'wrong-password',
+        newPassword: 'second-password',
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidCredentials,
+    })
+
+    const changed = await service.changeCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      currentPassword: 'first-password',
+      newPassword: 'second-password',
+      reAuthenticatedAt: addSeconds(now, 21),
+      now: addSeconds(now, 21),
+    })
+
+    expect(changed.subject).toBe('current-account-password@example.com')
+    await expect(
+      service.signInWithPassword({
+        email: 'current-account-password@example.com',
+        password: 'first-password',
+        now: addSeconds(now, 22),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidCredentials,
+    })
+    await expect(
+      service.signInWithPassword({
+        email: 'current-account-password@example.com',
+        password: 'second-password',
+        now: addSeconds(now, 22),
+      }),
+    ).resolves.toMatchObject({
+      user: { id: signedIn.user.id },
+    })
+  })
+
+  it('rejects token-based password setup when the current account has no trusted email', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'telegram',
+        providerUserId: 'current-account-password-no-email',
+        displayName: 'No Email',
+      },
+      now,
+    })
+
+    await expect(
+      service.setCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        password: 'password',
+        reAuthenticatedAt: now,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+  })
+
+  it('uses the runtime clock and forwards metadata for current-account action helpers when now is omitted', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [
+          AuthPolicyAction.Unlink,
+          AuthPolicyAction.SetPassword,
+          AuthPolicyAction.ChangePassword,
+        ],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        provider: 'email',
+        providerUserId: 'current-account-actions-no-now',
+        email: 'current-account-actions-no-now@example.com',
+        emailVerified: true,
+      }),
+    })
+    const linked = await service.link({
+      userId: signedIn.user.id,
+      assertion: assertion({
+        provider: 'github',
+        providerUserId: 'current-account-actions-no-now-github',
+        email: 'current-account-actions-no-now@example.com',
+        emailVerified: true,
+      }),
+    })
+
+    const created = await service.setCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      password: 'first-password',
+      reAuthenticatedAt: now,
+      metadata: { source: 'current-account-set' },
+    })
+    const changed = await service.changeCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      currentPassword: 'first-password',
+      newPassword: 'second-password',
+      reAuthenticatedAt: now,
+      metadata: { source: 'current-account-change' },
+    })
+
+    await service.unlinkCurrentIdentityByToken({
+      sessionToken: signedIn.sessionToken,
+      identityId: linked.identity.id,
+      reAuthenticatedAt: now,
+      metadata: { source: 'current-account-unlink' },
+    })
+
+    expect(created.metadata).toEqual({ source: 'current-account-set' })
+    expect(changed.metadata).toEqual({ source: 'current-account-change' })
+    await expect(
+      service.signInWithPassword({
+        email: 'current-account-actions-no-now@example.com',
+        password: 'second-password',
+        now: addSeconds(now, 1),
+      }),
+    ).resolves.toMatchObject({
+      user: { id: signedIn.user.id },
+    })
+  })
+
+  it('keeps stale disabled-user current-account action helpers neutral', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-actions-disabled',
+        email: 'current-account-actions-disabled@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 5),
+    })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.revokeOwnedSessionByToken({
+        sessionToken: signedIn.sessionToken,
+        targetSessionId: secondSession.session.id,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.unlinkCurrentIdentityByToken({
+        sessionToken: signedIn.sessionToken,
+        identityId: signedIn.identity.id,
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.setCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        password: 'password',
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.changeCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        currentPassword: 'password',
+        newPassword: 'new-password',
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})

--- a/test/postgres.test.ts
+++ b/test/postgres.test.ts
@@ -1,5 +1,6 @@
 import './postgres/security-and-read-side.test.js'
 import './postgres/current-account-security.test.js'
 import './postgres/current-account-inspection.test.js'
+import './postgres/current-account-actions.test.js'
 import './postgres/audit-pagination.test.js'
 import './postgres/persistence-and-merge.test.js'

--- a/test/postgres/current-account-actions.test.ts
+++ b/test/postgres/current-account-actions.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import { AuthPolicyAction, UniAuthErrorCode, addSeconds, createDefaultAuthPolicy } from '../../src'
+import { createPostgresTestKit, now } from './support.js'
+
+describe('Postgres current-account action helpers', () => {
+  it('revokes one owned Postgres session by trusted session token while preserving the current session', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-owned-session',
+        email: 'pg-current-account-owned-session@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const result = await service.revokeOwnedSessionByToken({
+      sessionToken: signedIn.sessionToken,
+      targetSessionId: secondSession.session.id,
+      now: addSeconds(now, 20),
+    })
+
+    expect(result).toEqual({
+      currentSessionId: signedIn.session.id,
+      revokedSessionId: secondSession.session.id,
+      revokedCurrentSession: false,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: secondSession.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.resolveSession({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 21),
+      }),
+    ).resolves.toMatchObject({
+      id: signedIn.session.id,
+    })
+  })
+
+  it('unlinks and changes current-account credentials through the Postgres token-based helpers', async () => {
+    const { service } = await createPostgresTestKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [
+          AuthPolicyAction.Unlink,
+          AuthPolicyAction.SetPassword,
+          AuthPolicyAction.ChangePassword,
+        ],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-actions',
+        email: 'pg-current-account-actions@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const linked = await service.link({
+      userId: signedIn.user.id,
+      assertion: {
+        provider: 'github',
+        providerUserId: 'pg-current-account-actions-github',
+        email: 'pg-current-account-actions@example.com',
+        emailVerified: true,
+      },
+      now: addSeconds(now, 5),
+    })
+
+    await service.setCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      password: 'first-password',
+      reAuthenticatedAt: addSeconds(now, 10),
+      now: addSeconds(now, 10),
+    })
+    await service.changeCurrentAccountPasswordByToken({
+      sessionToken: signedIn.sessionToken,
+      currentPassword: 'first-password',
+      newPassword: 'second-password',
+      reAuthenticatedAt: addSeconds(now, 11),
+      now: addSeconds(now, 11),
+    })
+    await service.unlinkCurrentIdentityByToken({
+      sessionToken: signedIn.sessionToken,
+      identityId: linked.identity.id,
+      reAuthenticatedAt: addSeconds(now, 12),
+      now: addSeconds(now, 12),
+    })
+
+    await expect(
+      service.signInWithPassword({
+        email: 'pg-current-account-actions@example.com',
+        password: 'first-password',
+        now: addSeconds(now, 13),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidCredentials,
+    })
+    await expect(
+      service.signInWithPassword({
+        email: 'pg-current-account-actions@example.com',
+        password: 'second-password',
+        now: addSeconds(now, 13),
+      }),
+    ).resolves.toMatchObject({
+      user: { id: signedIn.user.id },
+    })
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: signedIn.identity.id,
+        }),
+        expect.objectContaining({
+          provider: 'password',
+        }),
+      ]),
+    )
+  })
+
+  it('keeps stale disabled-user Postgres current-account action helpers neutral', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-actions-disabled',
+        email: 'pg-current-account-actions-disabled@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const secondSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 5),
+    })
+
+    await store.userRepo.update(signedIn.user.id, {
+      disabledAt: addSeconds(now, 10),
+    })
+
+    await expect(
+      service.revokeOwnedSessionByToken({
+        sessionToken: signedIn.sessionToken,
+        targetSessionId: secondSession.session.id,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.unlinkCurrentIdentityByToken({
+        sessionToken: signedIn.sessionToken,
+        identityId: signedIn.identity.id,
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.setCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        password: 'password',
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.changeCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        currentPassword: 'password',
+        newPassword: 'new-password',
+        reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add token-based current-account helpers for selected-session revoke, identity unlink, and password setup/change
- cover in-memory and Postgres parity plus neutral disabled-account behavior
- update self-service account-security and session transport recipes to stay on the trusted sessionToken boundary

Closes #258
Closes #259
Closes #260
Closes #261