### PR TITLE
docs: sync roadmap after v0.38.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -381,9 +381,20 @@ Tracking issues: #244, #245, #246, #247.
 
 Tracking issues: #251, #252, #253, #254.
 
+### v0.38 - Current-Account Action Helpers
+
+- Added token-based current-account write-side helpers for selected-session revoke, sign-in-method
+  unlink, and local password setup or change after transport resolution.
+- Added parity and neutrality coverage for those helpers across in-memory and Postgres-backed
+  service setups, including disabled-account session-token paths.
+- Updated account-security, backend, session-transport, and README recipes so self-service routes
+  stay on the trusted `sessionToken` boundary instead of bouncing back to raw `userId` mutations.
+
+Tracking issues: #258, #259, #260, #261.
+
 ## Next Release
 
-### v0.38 - Backlog To Be Defined
+### v0.39 - Backlog To Be Defined
 
 - The next releasable scope has not been defined yet.
 


### PR DESCRIPTION
## Summary
- move v0.38 from Next Release to Released in the roadmap
- record the current-account action helper scope and tracking issues
- restore v0.39 as the next backlog placeholder after the published v0.38.0 release