### PR TITLE
docs: define v0.39 current-account re-auth backlog

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -394,9 +394,21 @@ Tracking issues: #258, #259, #260, #261.
 
 ## Next Release
 
-### v0.39 - Backlog To Be Defined
+### v0.39 - Current-Account Re-Auth Helpers
 
-- The next releasable scope has not been defined yet.
+- Add trusted current-account OTP re-auth helpers so self-service security routes can bootstrap
+  recent-auth challenges from a local `sessionToken` boundary instead of rebuilding owned-target
+  verification flows in application code.
+- Add a current-account password re-auth confirmation helper that proves the current password on
+  the trusted session boundary without mutating local credentials or widening neutral failure
+  shapes.
+- Add parity and neutrality coverage for current-account re-auth helpers across in-memory and
+  Postgres-backed service setups, including stale-session, disabled-account, and owned-target edge
+  cases.
+- Add canonical backend and account-security recipes for app-owned recent-auth persistence, OTP
+  re-auth challenge routes, and sensitive current-account actions that consume `reAuthenticatedAt`.
+
+Tracking issues: #265, #266, #267, #268.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- define the v0.39 release theme around current-account re-auth helpers
- add detailed tracking issues #265, #266, #267, and #268
- replace the v0.39 roadmap placeholder with the concrete scope and tracking set

## Testing
- npm run check