### PR TITLE
feat: add current-account OTP re-auth management helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ const challenge = await service.startCurrentAccountOtpReAuth({
   channel: OtpChannel.Email,
 })
 
+const resent = await service.resendCurrentAccountOtpReAuth({
+  sessionToken,
+  verificationId: challenge.verificationId,
+})
+
 const passwordConfirmation = await service.confirmCurrentAccountPasswordByToken({
   sessionToken,
   currentPassword,

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -334,8 +334,24 @@ UniAuth still does not own:
 - browser redirect or challenge-step UI;
 - whether the route offers OTP, password confirmation, or both.
 
-For resend or cancellation after a current-account OTP re-auth challenge has started, keep using
-the shared verification lifecycle helpers on the returned `verificationId`.
+For resend or cancellation after a current-account OTP re-auth challenge has started, keep that
+management on the same trusted `sessionToken` boundary too. The route can stay inside
+current-account ownership checks instead of falling back to generic verification orchestration:
+
+```ts
+const resent = await authService.resendCurrentAccountOtpReAuth({
+  sessionToken: request.auth.sessionToken,
+  verificationId: body.verificationId,
+})
+
+await authService.cancelCurrentAccountOtpReAuth({
+  sessionToken: request.auth.sessionToken,
+  verificationId: body.verificationId,
+})
+```
+
+The application still owns UI cooldown timers, retry buttons, and how the new `verificationId`
+replaces the previous one in client state after a resend.
 
 ### Link A New Sign-In Method
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,9 @@ stay on the same trusted boundary too: applications can start current-account OT
 identity or confirm the current password from `sessionToken`, then persist the resulting
 `reAuthenticatedAt` marker in app-owned session state. The same layer can now also answer or
 enforce whether recent auth is currently required for a specific sensitive current-account action
-before application-owned side effects continue.
+before application-owned side effects continue. Resend and cancellation of those current-account
+OTP re-auth challenges can stay on that trusted token boundary as well instead of dropping back to
+generic verification ownership checks in route code.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -44,8 +44,13 @@ const challenge = await service.startCurrentAccountOtpReAuth({
   channel: OtpChannel.Email,
 })
 
-const verification = await service.finishOtpChallenge({
+const resent = await service.resendCurrentAccountOtpReAuth({
+  sessionToken,
   verificationId: challenge.verificationId,
+})
+
+const verification = await service.finishOtpChallenge({
+  verificationId: resent.verificationId,
   secret: 'code from user input',
   purpose: VerificationPurpose.ReAuth,
   channel: OtpChannel.Email,
@@ -54,6 +59,16 @@ const verification = await service.finishOtpChallenge({
 
 The application still owns how `verification.consumedAt` becomes a recent-auth marker in its own
 session, cookie, or server-side request context.
+
+If the user abandons that step instead of finishing it, the route can cancel the current-account
+challenge on the same trusted boundary:
+
+```ts
+await service.cancelCurrentAccountOtpReAuth({
+  sessionToken,
+  verificationId: challenge.verificationId,
+})
+```
 
 If the UI only needs to know whether a fresh recent-auth step is currently required for a sensitive
 self-service action, prefer the dedicated status helper over hand-rolled freshness math:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -440,12 +440,17 @@ Tracking issues: #280, #281, #282, #283.
 
 ## Next Release
 
-### v0.42 - Backlog To Be Defined
+### v0.42 - Current-Account OTP Re-Auth Challenge Management
 
-- Define the next releasable feature set after current-account identity linking.
-- Keep `v0.42` scoped to product-facing additions rather than another maintenance-only batch.
+- Keep current-account recent-auth flows on the same trusted `sessionToken` boundary after the
+  challenge has started, so self-service routes do not fall back to generic verification ownership
+  orchestration for resend or cancellation.
+- Add parity and neutrality coverage for resend and cancellation across in-memory and Postgres
+  stores, including stale-session and foreign-verification paths.
+- Document canonical current-account OTP re-auth management routes alongside the existing account
+  security and local-auth recipes.
 
-Tracking issues: none yet.
+Tracking issues: #287, #288, #289, #290.
 
 ## Versioning
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -93,6 +93,8 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.getCurrentAccountReAuthStatus).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.assertCurrentAccountReAuth).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.startCurrentAccountOtpReAuth).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.resendCurrentAccountOtpReAuth).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.cancelCurrentAccountOtpReAuth).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.linkCurrentIdentityByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeCurrentSessionByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeOwnedSessionByToken).toBeTypeOf('function')
@@ -208,12 +210,20 @@ describe('package exports', () => {
     expect(flowDeclarations).toContain('export interface AssertCurrentAccountReAuthInput')
     expect(flowDeclarations).toContain('export interface CurrentAccountReAuthAssertion')
     expect(flowDeclarations).toContain('export interface StartCurrentAccountOtpReAuthInput')
+    expect(flowDeclarations).toContain('export interface ResendCurrentAccountOtpReAuthInput')
+    expect(flowDeclarations).toContain('export interface CancelCurrentAccountOtpReAuthInput')
     expect(flowDeclarations).toContain('export interface LinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UnlinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface RevokeOwnedSessionByTokenResult')
     expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
     expect(serviceDeclarations).toContain(
       'linkCurrentIdentityByToken(input: LinkCurrentIdentityByTokenInput): Promise<LinkResult>',
+    )
+    expect(serviceDeclarations).toContain(
+      'resendCurrentAccountOtpReAuth(input: ResendCurrentAccountOtpReAuthInput): Promise<StartOtpChallengeResult>',
+    )
+    expect(serviceDeclarations).toContain(
+      'cancelCurrentAccountOtpReAuth(input: CancelCurrentAccountOtpReAuthInput): Promise<Verification>',
     )
     expect(localAuthDeclarations).toContain(
       'export interface SetCurrentAccountPasswordByTokenInput',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -21,8 +21,10 @@ import {
 } from './current-account-actions.js'
 import {
   assertCurrentAccountReAuth,
+  cancelCurrentAccountOtpReAuth,
   getCurrentAccountReAuthStatus,
   confirmCurrentAccountPasswordByToken,
+  resendCurrentAccountOtpReAuth,
   startCurrentAccountOtpReAuth,
 } from './current-account-re-auth.js'
 import {
@@ -100,6 +102,7 @@ import type {
   FinishOtpChallengeInput,
   FinishOtpSignInInput,
   GetAccountInspectionSnapshotInput,
+  CancelCurrentAccountOtpReAuthInput,
   GetCurrentAccountAuditEventPageInput,
   GetCurrentAccountInspectionSnapshotInput,
   GetCurrentAccountReAuthStatusInput,
@@ -117,6 +120,7 @@ import type {
   RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
+  ResendCurrentAccountOtpReAuthInput,
   ResendOtpChallengeInput,
   ResolveSessionContextInput,
   ResolveSessionInput,
@@ -170,6 +174,18 @@ export class DefaultAuthService implements AuthService {
     input: StartCurrentAccountOtpReAuthInput,
   ): Promise<StartOtpChallengeResult> {
     return startCurrentAccountOtpReAuth(this.runtime, input)
+  }
+
+  async resendCurrentAccountOtpReAuth(
+    input: ResendCurrentAccountOtpReAuthInput,
+  ): Promise<StartOtpChallengeResult> {
+    return resendCurrentAccountOtpReAuth(this.runtime, input)
+  }
+
+  async cancelCurrentAccountOtpReAuth(
+    input: CancelCurrentAccountOtpReAuthInput,
+  ): Promise<Verification> {
+    return cancelCurrentAccountOtpReAuth(this.runtime, input)
   }
 
   async resendOtpChallenge(input: ResendOtpChallengeInput): Promise<StartOtpChallengeResult> {

--- a/src/application/current-account-re-auth.ts
+++ b/src/application/current-account-re-auth.ts
@@ -1,7 +1,12 @@
 import { listActiveIdentitiesForUser } from './accounts/shared.js'
 import { optionalProp } from './optional.js'
-import { normalizeOtpTarget } from './otp-delivery.js'
-import { startOtpChallenge } from './otp.js'
+import { normalizeOtpTarget, type SupportedOtpChannel } from './otp-delivery.js'
+import {
+  cancelOtpChallenge,
+  findOtpChallengeRecord,
+  resendOtpChallenge,
+  startOtpChallenge,
+} from './otp.js'
 import {
   getPasswordHasher,
   findUsablePasswordIdentity,
@@ -13,19 +18,28 @@ import { resolveSessionContext } from './session-context.js'
 import type {
   AssertCurrentAccountReAuthInput,
   AuthIdentity,
+  CancelCurrentAccountOtpReAuthInput,
   ConfirmCurrentAccountPasswordByTokenInput,
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
   CurrentAccountPasswordReAuthConfirmation,
   GetCurrentAccountReAuthStatusInput,
   OtpChannel as OtpChannelType,
+  ResendCurrentAccountOtpReAuthInput,
   SessionId,
-  StartCurrentAccountOtpReAuthInput,
   StartOtpChallengeResult,
+  StartCurrentAccountOtpReAuthInput,
   UserId,
+  Verification,
 } from '../domain/types.js'
 import { OtpChannel, VerificationPurpose } from '../domain/types.js'
-import { invalidCredentials, invalidInput } from '../errors.js'
+import {
+  UniAuthError,
+  UniAuthErrorCode,
+  invalidCredentials,
+  invalidInput,
+  isUniAuthError,
+} from '../errors.js'
 
 const CURRENT_ACCOUNT_RE_AUTH_TARGET_ERROR =
   'Identity cannot be used for current-account OTP re-auth.'
@@ -99,6 +113,46 @@ export async function startCurrentAccountOtpReAuth(
   })
 }
 
+export async function resendCurrentAccountOtpReAuth(
+  runtime: AuthServiceRuntime,
+  input: ResendCurrentAccountOtpReAuthInput,
+): Promise<StartOtpChallengeResult> {
+  const { actor, challenge } = await resolveCurrentAccountOwnedOtpReAuthChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+
+  return resendOtpChallenge(runtime, {
+    verificationId: challenge.verification.id,
+    ...optionalProp('secret', input.secret),
+    ...optionalProp('ttlSeconds', input.ttlSeconds),
+    now: actor.now,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  })
+}
+
+export async function cancelCurrentAccountOtpReAuth(
+  runtime: AuthServiceRuntime,
+  input: CancelCurrentAccountOtpReAuthInput,
+): Promise<Verification> {
+  const { actor, challenge } = await resolveCurrentAccountOwnedOtpReAuthChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+
+  return cancelOtpChallenge(runtime, {
+    verificationId: challenge.verification.id,
+    purpose: VerificationPurpose.ReAuth,
+    channel: challenge.channel,
+    now: actor.now,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  })
+}
+
 export async function confirmCurrentAccountPasswordByToken(
   runtime: AuthServiceRuntime,
   input: ConfirmCurrentAccountPasswordByTokenInput,
@@ -161,4 +215,74 @@ function resolveCurrentAccountOtpReAuthTarget(
   }
 
   throw invalidInput(CURRENT_ACCOUNT_RE_AUTH_TARGET_ERROR)
+}
+
+async function resolveCurrentAccountOwnedOtpReAuthChallenge(
+  runtime: AuthServiceRuntime,
+  sessionToken: string,
+  verificationId: Verification['id'],
+  now: Date | undefined,
+): Promise<{
+  readonly actor: ResolvedCurrentAccountActor
+  readonly challenge: {
+    readonly verification: Verification
+    readonly channel: SupportedOtpChannel
+  }
+}> {
+  const actor = await resolveCurrentAccountActor(runtime, sessionToken, now)
+  const challenge = await getCurrentAccountOwnedOtpReAuthChallenge(runtime, verificationId)
+  const identities = await listActiveIdentitiesForUser(runtime, actor.userId)
+  const owned = identities.some((identity) =>
+    currentAccountOwnsOtpReAuthTarget(
+      runtime,
+      identity,
+      challenge.verification.target,
+      challenge.channel,
+    ),
+  )
+
+  if (!owned) {
+    throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+  }
+
+  return { actor, challenge }
+}
+
+async function getCurrentAccountOwnedOtpReAuthChallenge(
+  runtime: AuthServiceRuntime,
+  verificationId: Verification['id'],
+): Promise<{
+  readonly verification: Verification
+  readonly channel: SupportedOtpChannel
+}> {
+  try {
+    return await findOtpChallengeRecord(runtime, {
+      verificationId,
+      purpose: VerificationPurpose.ReAuth,
+      context: 'current-account OTP re-auth',
+    })
+  } catch (error) {
+    if (
+      isUniAuthError(error) &&
+      (error.code === UniAuthErrorCode.VerificationNotFound ||
+        error.code === UniAuthErrorCode.InvalidInput)
+    ) {
+      throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+    }
+
+    throw error
+  }
+}
+
+function currentAccountOwnsOtpReAuthTarget(
+  runtime: Pick<AuthServiceRuntime, 'normalizer'>,
+  identity: AuthIdentity,
+  target: string,
+  channel: SupportedOtpChannel,
+): boolean {
+  try {
+    return resolveCurrentAccountOtpReAuthTarget(runtime, identity, channel) === target
+  } catch {
+    return false
+  }
 }

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -223,7 +223,7 @@ export async function finishOtpSignIn(
   })
 }
 
-async function findOtpChallengeRecord(
+export async function findOtpChallengeRecord(
   runtime: AuthServiceRuntime,
   input: {
     readonly verificationId: Verification['id']

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -165,6 +165,22 @@ export interface StartCurrentAccountOtpReAuthInput {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface ResendCurrentAccountOtpReAuthInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly secret?: string
+  readonly ttlSeconds?: number
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface CancelCurrentAccountOtpReAuthInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface GetCurrentAccountReAuthStatusInput {
   readonly sessionToken: string
   readonly action: AuthPolicyAction

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -28,6 +28,8 @@ import type {
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
   StartCurrentAccountOtpReAuthInput,
+  ResendCurrentAccountOtpReAuthInput,
+  CancelCurrentAccountOtpReAuthInput,
   GetVerificationResendWindowInput,
   LinkInput,
   LinkResult,
@@ -80,6 +82,10 @@ export interface AuthService {
   startCurrentAccountOtpReAuth(
     input: StartCurrentAccountOtpReAuthInput,
   ): Promise<StartOtpChallengeResult>
+  resendCurrentAccountOtpReAuth(
+    input: ResendCurrentAccountOtpReAuthInput,
+  ): Promise<StartOtpChallengeResult>
+  cancelCurrentAccountOtpReAuth(input: CancelCurrentAccountOtpReAuthInput): Promise<Verification>
   resendOtpChallenge(input: ResendOtpChallengeInput): Promise<StartOtpChallengeResult>
   finishOtpChallenge(input: FinishOtpChallengeInput): Promise<Verification>
   finishOtpSignIn(input: FinishOtpSignInInput): Promise<AuthResult>

--- a/test/core/current-account-reauth.test.ts
+++ b/test/core/current-account-reauth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   AuditEventType,
   AuthPolicyAction,
+  DefaultAuthService,
   OtpChannel,
   UniAuthErrorCode,
   VerificationPurpose,
@@ -110,7 +111,7 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       now: addSeconds(now, 5),
     })
 
-    await service.startCurrentAccountOtpReAuth({
+    const challenge = await service.startCurrentAccountOtpReAuth({
       sessionToken: alice.sessionToken,
       identityId: phoneIdentity.identity.id,
       channel: OtpChannel.Phone,
@@ -121,6 +122,24 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
     expect(smsSender.listMessages()[0]).toMatchObject({
       to: '+15550000001',
       text: 'Your sign-in code is 222222.',
+    })
+
+    const resent = await service.resendCurrentAccountOtpReAuth({
+      sessionToken: alice.sessionToken,
+      verificationId: challenge.verificationId,
+      secret: '222223',
+      now: addSeconds(now, 9),
+    })
+
+    expect(smsSender.listMessages()[1]).toMatchObject({
+      to: '+15550000001',
+      text: 'Your sign-in code is 222223.',
+    })
+
+    await service.cancelCurrentAccountOtpReAuth({
+      sessionToken: alice.sessionToken,
+      verificationId: resent.verificationId,
+      now: addSeconds(now, 10),
     })
 
     await expect(
@@ -144,6 +163,208 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
     })
+  })
+
+  it('resends and cancels current-account OTP re-auth on the trusted session boundary', async () => {
+    const { service, emailSender, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-resend-owner',
+        email: 'current-account-reauth-resend@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    const challenge = await service.startCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      identityId: signedIn.identity.id,
+      channel: OtpChannel.Email,
+      secret: '111111',
+      now: addSeconds(now, 10),
+      metadata: { source: 'current-account-reauth-start' },
+    })
+
+    const resent = await service.resendCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: challenge.verificationId,
+      secret: '222222',
+      ttlSeconds: 120,
+      now: addSeconds(now, 20),
+      metadata: { source: 'current-account-reauth-resend' },
+    })
+
+    expect(resent.verificationId).not.toBe(challenge.verificationId)
+    expect(emailSender.listMessages()[1]).toMatchObject({
+      to: 'current-account-reauth-resend@example.com',
+      text: 'Your sign-in code is 222222.',
+      metadata: {
+        verificationId: resent.verificationId,
+        purpose: VerificationPurpose.ReAuth,
+        delivery: OtpChannel.Email,
+      },
+    })
+    expect(store.listVerifications()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: challenge.verificationId,
+          expiresAt: addSeconds(now, 20),
+        }),
+        expect.objectContaining({
+          id: resent.verificationId,
+          purpose: VerificationPurpose.ReAuth,
+          target: 'current-account-reauth-resend@example.com',
+          metadata: {
+            source: 'current-account-reauth-resend',
+          },
+        }),
+      ]),
+    )
+
+    const cancelled = await service.cancelCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: resent.verificationId,
+      now: addSeconds(now, 21),
+      metadata: { source: 'current-account-reauth-cancel' },
+    })
+
+    expect(cancelled).toMatchObject({
+      id: resent.verificationId,
+      expiresAt: addSeconds(now, 21),
+    })
+    expect(store.listAuditEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.VerificationCancelled,
+          metadata: {
+            verificationId: resent.verificationId,
+            purpose: VerificationPurpose.ReAuth,
+            source: 'current-account-reauth-cancel',
+          },
+        }),
+      ]),
+    )
+
+    await expect(
+      service.finishOtpChallenge({
+        verificationId: resent.verificationId,
+        secret: '222222',
+        purpose: VerificationPurpose.ReAuth,
+        channel: OtpChannel.Email,
+        now: addSeconds(now, 22),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
+    })
+  })
+
+  it('keeps current-account OTP re-auth resend and cancellation neutral for foreign or non-re-auth challenges', async () => {
+    const { service } = createInMemoryAuthKit()
+    const alice = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-neutral-owner',
+        email: 'current-account-reauth-neutral-owner@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const bob = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-neutral-foreign',
+        email: 'current-account-reauth-neutral-foreign@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 1),
+    })
+
+    const ownedChallenge = await service.startCurrentAccountOtpReAuth({
+      sessionToken: alice.sessionToken,
+      identityId: alice.identity.id,
+      channel: OtpChannel.Email,
+      secret: '333333',
+      now: addSeconds(now, 10),
+    })
+    const signInChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'current-account-reauth-neutral-owner@example.com',
+      secret: '444444',
+      now: addSeconds(now, 11),
+    })
+
+    await expect(
+      service.resendCurrentAccountOtpReAuth({
+        sessionToken: bob.sessionToken,
+        verificationId: ownedChallenge.verificationId,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountOtpReAuth({
+        sessionToken: alice.sessionToken,
+        verificationId: signInChallenge.verificationId,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+  })
+
+  it('rethrows unexpected verification lookup failures from current-account OTP re-auth management helpers', async () => {
+    const {
+      service: setupService,
+      store,
+      emailSender,
+      smsSender,
+      rateLimiter,
+      passwordHasher,
+    } = createInMemoryAuthKit()
+    const signedIn = await setupService.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-verification-lookup-failure',
+        email: 'current-account-reauth-verification-lookup-failure@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const challenge = await setupService.startCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      identityId: signedIn.identity.id,
+      channel: OtpChannel.Email,
+      secret: '777777',
+      now: addSeconds(now, 5),
+    })
+    const lookupFailure = new Error('verification lookup failed')
+    const service = new DefaultAuthService({
+      repos: {
+        userRepo: store.userRepo,
+        identityRepo: store.identityRepo,
+        credentialRepo: store.credentialRepo,
+        verificationRepo: {
+          ...store.verificationRepo,
+          findById: async () => {
+            throw lookupFailure
+          },
+        },
+        sessionRepo: store.sessionRepo,
+        auditLogRepo: store.auditLogRepo,
+      },
+      emailSender,
+      smsSender,
+      rateLimiter,
+      passwordHasher,
+    })
+
+    await expect(
+      service.resendCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        verificationId: challenge.verificationId,
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toBe(lookupFailure)
   })
 
   it('confirms the current account password on the trusted session boundary without writing audit noise', async () => {
@@ -369,6 +590,13 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       }),
       now,
     })
+    const challenge = await service.startCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      identityId: signedIn.identity.id,
+      channel: OtpChannel.Email,
+      secret: '555555',
+      now: addSeconds(now, 5),
+    })
 
     await store.userRepo.update(signedIn.user.id, {
       disabledAt: addSeconds(now, 10),
@@ -379,6 +607,26 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
         sessionToken: signedIn.sessionToken,
         identityId: signedIn.identity.id,
         channel: OtpChannel.Email,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+
+    await expect(
+      service.resendCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        verificationId: challenge.verificationId,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        verificationId: challenge.verificationId,
         now: addSeconds(now, 20),
       }),
     ).rejects.toMatchObject({
@@ -443,6 +691,22 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       to: 'current-account-reauth-no-now@example.com',
       text: 'Your sign-in code is 333333.',
     })
+
+    const resent = await service.resendCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: challenge.verificationId,
+      secret: '444444',
+    })
+    const resentVerification = await service.getVerification(resent.verificationId)
+
+    expect(resentVerification.createdAt).toEqual(runtimeNow)
+
+    const cancelled = await service.cancelCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: resent.verificationId,
+    })
+
+    expect(cancelled.expiresAt).toEqual(runtimeNow)
 
     await service.setCurrentAccountPasswordByToken({
       sessionToken: signedIn.sessionToken,

--- a/test/postgres/current-account-reauth.test.ts
+++ b/test/postgres/current-account-reauth.test.ts
@@ -75,6 +75,154 @@ describe('Postgres current-account re-auth helpers', () => {
     )
   })
 
+  it('keeps current-account OTP re-auth resend and cancellation aligned with trusted verification ownership on Postgres', async () => {
+    const { service, emailSender, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-reauth-resend-owner',
+        email: 'pg-current-account-reauth-resend@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    const challenge = await service.startCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      identityId: signedIn.identity.id,
+      channel: OtpChannel.Email,
+      secret: '111111',
+      now: addSeconds(now, 10),
+      metadata: { source: 'pg-current-account-reauth-start' },
+    })
+
+    const resent = await service.resendCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: challenge.verificationId,
+      secret: '222222',
+      ttlSeconds: 120,
+      now: addSeconds(now, 20),
+      metadata: { source: 'pg-current-account-reauth-resend' },
+    })
+
+    expect(resent.verificationId).not.toBe(challenge.verificationId)
+    expect(emailSender.listMessages()[1]).toMatchObject({
+      to: 'pg-current-account-reauth-resend@example.com',
+      text: 'Your sign-in code is 222222.',
+      metadata: {
+        verificationId: resent.verificationId,
+        purpose: VerificationPurpose.ReAuth,
+        delivery: OtpChannel.Email,
+      },
+    })
+
+    expect(await service.getVerification(challenge.verificationId)).toMatchObject({
+      id: challenge.verificationId,
+      expiresAt: addSeconds(now, 20),
+    })
+    expect(await service.getVerification(resent.verificationId)).toMatchObject({
+      id: resent.verificationId,
+      purpose: VerificationPurpose.ReAuth,
+      target: 'pg-current-account-reauth-resend@example.com',
+      metadata: {
+        source: 'pg-current-account-reauth-resend',
+      },
+    })
+
+    const cancelled = await service.cancelCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
+      verificationId: resent.verificationId,
+      now: addSeconds(now, 21),
+      metadata: { source: 'pg-current-account-reauth-cancel' },
+    })
+
+    expect(cancelled).toMatchObject({
+      id: resent.verificationId,
+      expiresAt: addSeconds(now, 21),
+    })
+    expect(await store.auditLogRepo.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.VerificationCancelled,
+          metadata: {
+            verificationId: resent.verificationId,
+            purpose: VerificationPurpose.ReAuth,
+            source: 'pg-current-account-reauth-cancel',
+          },
+        }),
+      ]),
+    )
+
+    await expect(
+      service.finishOtpChallenge({
+        verificationId: resent.verificationId,
+        secret: '222222',
+        purpose: VerificationPurpose.ReAuth,
+        channel: OtpChannel.Email,
+        now: addSeconds(now, 22),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
+    })
+  })
+
+  it('keeps current-account OTP re-auth resend and cancellation neutral on Postgres', async () => {
+    const { service } = await createPostgresTestKit()
+    const alice = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-reauth-neutral-owner',
+        email: 'pg-current-account-reauth-neutral-owner@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const bob = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-reauth-neutral-foreign',
+        email: 'pg-current-account-reauth-neutral-foreign@example.com',
+        emailVerified: true,
+      },
+      now: addSeconds(now, 1),
+    })
+
+    const ownedChallenge = await service.startCurrentAccountOtpReAuth({
+      sessionToken: alice.sessionToken,
+      identityId: alice.identity.id,
+      channel: OtpChannel.Email,
+      secret: '333333',
+      now: addSeconds(now, 10),
+    })
+    const signInChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'pg-current-account-reauth-neutral-owner@example.com',
+      secret: '444444',
+      now: addSeconds(now, 11),
+    })
+
+    await expect(
+      service.resendCurrentAccountOtpReAuth({
+        sessionToken: bob.sessionToken,
+        verificationId: ownedChallenge.verificationId,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountOtpReAuth({
+        sessionToken: alice.sessionToken,
+        verificationId: signInChallenge.verificationId,
+        now: addSeconds(now, 21),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+  })
+
   it('keeps current-account password confirmation aligned with change-password flows on Postgres', async () => {
     const { service, store } = await createPostgresTestKit({
       policy: createDefaultAuthPolicy({
@@ -251,6 +399,34 @@ describe('Postgres current-account re-auth helpers', () => {
         sessionToken: signedIn.sessionToken,
         identityId: signedIn.identity.id,
         channel: OtpChannel.Email,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+
+    const challenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.ReAuth,
+      channel: OtpChannel.Email,
+      target: 'pg-current-account-reauth-disabled@example.com',
+      secret: '555555',
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.resendCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        verificationId: challenge.verificationId,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        verificationId: challenge.verificationId,
         now: addSeconds(now, 20),
       }),
     ).rejects.toMatchObject({


### PR DESCRIPTION
## Summary
- add trusted current-account OTP re-auth resend and cancellation helpers
- harden in-memory and Postgres parity plus neutral edge coverage
- document current-account OTP re-auth management routes and sync the v0.42 roadmap

Closes #287
Closes #288
Closes #289
Closes #290