### PR TITLE
docs: sync roadmap after v0.43.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -450,23 +450,30 @@ Tracking issues: #280, #281, #282, #283.
 
 Tracking issues: #287, #288, #289, #290.
 
-## Next Release
-
 ### v0.43 - Current-Account Account Closure
 
-- Add a trusted `closeCurrentAccountByToken(...)` helper so self-service account closure routes can
+- Added a trusted `closeCurrentAccountByToken(...)` helper so self-service account closure routes can
   stay on the same `sessionToken` boundary as current-account inspection, session revoke, identity
   linking, password actions, and recent-auth helpers.
-- Disable the current user and revoke active local sessions inside the existing transaction
+- Disabled the current user and revoked active local sessions inside the existing transaction
   boundary while leaving cookies, legal retention, billing cancellation, and downstream data
   deletion application-owned.
-- Add focused in-memory and Postgres parity coverage for successful closure, recent-auth
+- Added focused in-memory and Postgres parity coverage for successful closure, recent-auth
   enforcement, revoked or expired sessions, disabled current-account neutrality, session revocation,
   and closure audit metadata.
-- Add canonical account-security, backend, architecture, and README route recipes for trusted
+- Added canonical account-security, backend, architecture, and README route recipes for trusted
   current-account account closure.
 
 Tracking issues: #294, #295, #296, #297.
+
+## Next Release
+
+### v0.44 - Backlog To Be Defined
+
+- Define the next releasable feature set after current-account account closure.
+- Keep `v0.44` scoped to product-facing additions rather than a maintenance-only batch.
+
+Tracking issues: none yet.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.43 account closure from Next Release into the completed roadmap section
- add a v0.44 backlog placeholder

## Validation
- npm run check

Closes #297