### PR TITLE
feat: add current-account closure export snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,18 @@ const currentInspection = await service.getCurrentAccountInspectionSnapshot({
 })
 ```
 
+Before destructive account closure, a self-service route can also stay on the trusted token
+boundary and return a safe pre-closure auth snapshot:
+
+```ts
+const closureExport = await service.getCurrentAccountClosureExportSnapshot({
+  sessionToken,
+  audit: {
+    limit: 50,
+  },
+})
+```
+
 Trusted backend tooling can start from one trusted aggregate inspection helper:
 
 ```ts

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -38,6 +38,19 @@ const current = await authService.getCurrentAccountInspectionSnapshot({
 })
 ```
 
+For pre-closure export screens, use the dedicated closure export snapshot instead of serializing raw
+entities or calling storage repositories directly:
+
+```ts
+const exportSnapshot = await authService.getCurrentAccountClosureExportSnapshot({
+  sessionToken,
+  touch: true,
+  audit: {
+    limit: 50,
+  },
+})
+```
+
 ## Recommended Read-Side Shape
 
 The minimal current-account server-side composition usually looks like this:
@@ -100,6 +113,11 @@ Do not serialize:
 - `Credential.passwordHash`
 - `Session.tokenHash`
 - `Verification.secretHash`
+
+The closure export helper returns the same safe account, session, credential, identity, and audit
+views plus `generatedAt`. It is intentionally not a legal data-portability export engine. File
+format, retention policy, profile data outside local auth, billing state, and downstream
+application records remain application-owned.
 
 ## Security Timeline
 
@@ -466,6 +484,32 @@ Keep incorrect current-password responses neutral and leave session refresh, coo
 "sign out other devices after password change" policy in the application layer.
 
 ### Close Current Account
+
+If the account-closure flow offers a "download my auth security data" step, keep that route
+read-only and on the same trusted session boundary:
+
+```ts
+const exportSnapshot = await authService.getCurrentAccountClosureExportSnapshot({
+  sessionToken: request.auth.sessionToken,
+  audit: {
+    limit: 50,
+  },
+})
+
+return {
+  generatedAt: exportSnapshot.generatedAt.toISOString(),
+  user: exportSnapshot.account.user,
+  identities: exportSnapshot.account.identities,
+  credentials: exportSnapshot.account.credentials,
+  sessions: exportSnapshot.account.sessions,
+  auditEvents: exportSnapshot.auditEvents,
+  nextAuditCursor: exportSnapshot.nextAuditCursor ?? null,
+}
+```
+
+Keep the actual download format application-owned. The helper only returns local auth safe views;
+it does not collect product profile data, billing records, provider token records, or downstream
+application tables.
 
 Use `closeCurrentAccountByToken(...)` for self-service account closure from an authenticated
 settings route. Keep the recent-auth marker application-owned, then pass it into the helper on the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,7 @@ identities, and email/phone are optional identity attributes.
 - `resolveSessionContext`
 - `getCurrentAccountSecuritySnapshot`
 - `getCurrentAccountInspectionSnapshot`
+- `getCurrentAccountClosureExportSnapshot`
 - `getCurrentAccountAuditEventPage`
 - `startCurrentAccountOtpReAuth`
 - `linkCurrentIdentityByToken`
@@ -94,7 +95,9 @@ OTP re-auth challenges can stay on that trusted token boundary as well instead o
 generic verification ownership checks in route code. Account closure follows the same shape:
 the current session token identifies the actor, core disables the current user, revokes active
 local sessions, and leaves cookie clearing, legal retention, and downstream data deletion to the
-application.
+application. Pre-closure export snapshots also stay on that boundary: core returns safe local auth
+views and a bounded audit window, while file generation, legal export policy, billing state, and
+application-profile data remain outside the package.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -291,8 +291,38 @@ For bearer and mobile client transport choices around local sessions, see
 ## Self-Service Account Closure
 
 Keep account closure on the same trusted `sessionToken` boundary as other account-security writes.
-The route should enforce recent-auth using your app-owned marker, call core once, and then clear
-browser transport state after the helper succeeds:
+If the product offers a pre-closure auth snapshot download, keep that as a read-only route before
+the destructive close route:
+
+```ts
+app.get('/auth/account/closure-export', requireSession, async (req, res, next) => {
+  try {
+    const snapshot = await authService.getCurrentAccountClosureExportSnapshot({
+      sessionToken: req.auth.sessionToken,
+      audit: {
+        limit: 50,
+      },
+    })
+
+    res.status(200).json({
+      generatedAt: snapshot.generatedAt.toISOString(),
+      account: snapshot.account,
+      currentSessionId: snapshot.currentSessionId,
+      auditEvents: snapshot.auditEvents,
+      nextAuditCursor: snapshot.nextAuditCursor ?? null,
+    })
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+The closure export helper returns only local auth safe views. The application still owns the file
+format, profile data outside local auth, billing records, legal retention, and downstream
+application-table export.
+
+The close route should enforce recent-auth using your app-owned marker, call core once, and then
+clear browser transport state after the helper succeeds:
 
 ```ts
 app.post('/auth/account/close', requireSession, async (req, res, next) => {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -468,12 +468,19 @@ Tracking issues: #294, #295, #296, #297.
 
 ## Next Release
 
-### v0.44 - Backlog To Be Defined
+### v0.44 - Current-Account Closure Export
 
-- Define the next releasable feature set after current-account account closure.
-- Keep `v0.44` scoped to product-facing additions rather than a maintenance-only batch.
+- Add a trusted `getCurrentAccountClosureExportSnapshot(...)` helper so self-service account
+  closure flows can offer a safe pre-closure auth snapshot without reading storage internals.
+- Keep the helper on the existing `sessionToken` boundary and reuse safe account, credential,
+  session, identity, and audit views without provider tokens, password hashes, session token hashes,
+  verification hashes, or raw metadata.
+- Add parity and secret-boundary coverage across in-memory and Postgres-backed service setups,
+  including stale disabled-account neutrality.
+- Add account-security and backend route recipes that keep file format, legal export policy,
+  billing state, profile data, and downstream application records application-owned.
 
-Tracking issues: none yet.
+Tracking issues: #301, #302, #303, #304.
 
 ## Versioning
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -89,6 +89,9 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.getCurrentAccountInspectionSnapshot).toBeTypeOf(
       'function',
     )
+    expect(core.DefaultAuthService.prototype.getCurrentAccountClosureExportSnapshot).toBeTypeOf(
+      'function',
+    )
     expect(core.DefaultAuthService.prototype.getCurrentAccountAuditEventPage).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.getCurrentAccountReAuthStatus).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.assertCurrentAccountReAuth).toBeTypeOf('function')
@@ -202,8 +205,12 @@ describe('package exports', () => {
     expect(contractsDeclarations).toContain('AuthServiceInfrastructure')
     expect(viewDeclarations).toContain('export interface CurrentAccountSecuritySnapshot')
     expect(viewDeclarations).toContain('export interface CurrentAccountInspectionSnapshot')
+    expect(viewDeclarations).toContain('export interface CurrentAccountClosureExportSnapshot')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountSecuritySnapshotInput')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountInspectionSnapshotInput')
+    expect(flowDeclarations).toContain(
+      'export interface GetCurrentAccountClosureExportSnapshotInput',
+    )
     expect(flowDeclarations).toContain('export interface GetCurrentAccountAuditEventPageInput')
     expect(flowDeclarations).toContain('export interface GetCurrentAccountReAuthStatusInput')
     expect(flowDeclarations).toContain('export interface CurrentAccountReAuthStatus')
@@ -242,6 +249,9 @@ describe('package exports', () => {
     )
     expect(serviceDeclarations).toContain(
       'getCurrentAccountInspectionSnapshot(input: GetCurrentAccountInspectionSnapshotInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'getCurrentAccountClosureExportSnapshot(input: GetCurrentAccountClosureExportSnapshotInput)',
     )
     expect(serviceDeclarations).toContain(
       'getCurrentAccountAuditEventPage(input: GetCurrentAccountAuditEventPageInput)',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -5,6 +5,7 @@ import { getUserIdentities, link, mergeAccounts, unlink } from './accounts.js'
 import { getUserCredentials } from './credentials.js'
 import {
   getCurrentAccountAuditEventPage,
+  getCurrentAccountClosureExportSnapshot,
   getCurrentAccountInspectionSnapshot,
 } from './current-account-inspection.js'
 import {
@@ -80,6 +81,7 @@ import type {
   AssertCurrentAccountReAuthInput,
   AuthResult,
   AuthService,
+  CurrentAccountClosureExportSnapshot,
   CurrentAccountInspectionSnapshot,
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
@@ -107,6 +109,7 @@ import type {
   CloseCurrentAccountByTokenInput,
   CloseCurrentAccountByTokenResult,
   GetCurrentAccountAuditEventPageInput,
+  GetCurrentAccountClosureExportSnapshotInput,
   GetCurrentAccountInspectionSnapshotInput,
   GetCurrentAccountReAuthStatusInput,
   GetCurrentAccountSecuritySnapshotInput,
@@ -307,6 +310,12 @@ export class DefaultAuthService implements AuthService {
     input: GetCurrentAccountInspectionSnapshotInput,
   ): Promise<CurrentAccountInspectionSnapshot> {
     return getCurrentAccountInspectionSnapshot(this.runtime, input)
+  }
+
+  async getCurrentAccountClosureExportSnapshot(
+    input: GetCurrentAccountClosureExportSnapshotInput,
+  ): Promise<CurrentAccountClosureExportSnapshot> {
+    return getCurrentAccountClosureExportSnapshot(this.runtime, input)
   }
 
   async getCurrentAccountAuditEventPage(

--- a/src/application/current-account-inspection.ts
+++ b/src/application/current-account-inspection.ts
@@ -4,8 +4,10 @@ import type { AuthServiceRuntime } from './runtime.js'
 import { resolveSessionContext } from './session-context.js'
 import type {
   AuditEventPage,
+  CurrentAccountClosureExportSnapshot,
   CurrentAccountInspectionSnapshot,
   GetCurrentAccountAuditEventPageInput,
+  GetCurrentAccountClosureExportSnapshotInput,
   GetCurrentAccountInspectionSnapshotInput,
 } from '../domain/types.js'
 import { toCurrentAccountInspectionSnapshot } from '../domain/types.js'
@@ -34,6 +36,22 @@ export async function getCurrentAccountInspectionSnapshot(
     auditEvents: auditPage.events,
     ...(auditPage.nextCursor ? { nextAuditCursor: auditPage.nextCursor } : {}),
   })
+}
+
+export async function getCurrentAccountClosureExportSnapshot(
+  runtime: AuthServiceRuntime,
+  input: GetCurrentAccountClosureExportSnapshotInput,
+): Promise<CurrentAccountClosureExportSnapshot> {
+  const generatedAt = input.now ?? runtime.clock.now()
+  const inspection = await getCurrentAccountInspectionSnapshot(runtime, {
+    ...input,
+    now: generatedAt,
+  })
+
+  return {
+    ...inspection,
+    generatedAt,
+  }
 }
 
 export async function getCurrentAccountAuditEventPage(

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -143,6 +143,14 @@ export interface GetCurrentAccountInspectionSnapshotInput {
   readonly audit?: CurrentAccountAuditWindow
 }
 
+export interface GetCurrentAccountClosureExportSnapshotInput {
+  readonly sessionToken: string
+  readonly touch?: boolean
+  readonly now?: Date
+  readonly auditLimit?: number
+  readonly audit?: CurrentAccountAuditWindow
+}
+
 export interface GetCurrentAccountAuditEventPageInput {
   readonly sessionToken: string
   readonly touch?: boolean

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -2,6 +2,7 @@ import type { AuthIdentity, Credential, Session, User, Verification } from './en
 import type {
   AccountInspectionSnapshot,
   AccountSecuritySnapshot,
+  CurrentAccountClosureExportSnapshot,
   CurrentAccountInspectionSnapshot,
   CurrentAccountSecuritySnapshot,
   VerificationResendWindow,
@@ -10,6 +11,7 @@ import type { AuditEvent, AuditEventPage, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
   AssertCurrentAccountReAuthInput,
+  GetCurrentAccountClosureExportSnapshotInput,
   GetCurrentAccountSecuritySnapshotInput,
   GetCurrentAccountReAuthStatusInput,
   GetCurrentAccountAuditEventPageInput,
@@ -126,6 +128,9 @@ export interface AuthService {
   getCurrentAccountInspectionSnapshot(
     input: GetCurrentAccountInspectionSnapshotInput,
   ): Promise<CurrentAccountInspectionSnapshot>
+  getCurrentAccountClosureExportSnapshot(
+    input: GetCurrentAccountClosureExportSnapshotInput,
+  ): Promise<CurrentAccountClosureExportSnapshot>
   getCurrentAccountAuditEventPage(
     input: GetCurrentAccountAuditEventPageInput,
   ): Promise<AuditEventPage>

--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -61,6 +61,10 @@ export interface CurrentAccountInspectionSnapshot extends CurrentAccountSecurity
   readonly nextAuditCursor?: AuditEventCursor
 }
 
+export interface CurrentAccountClosureExportSnapshot extends CurrentAccountInspectionSnapshot {
+  readonly generatedAt: Date
+}
+
 export interface AuditEventView {
   readonly id: AuditEvent['id']
   readonly type: AuditEvent['type']

--- a/test/core/current-account-inspection.test.ts
+++ b/test/core/current-account-inspection.test.ts
@@ -54,6 +54,119 @@ describe('DefaultAuthService current-account inspection helpers', () => {
     expect(inspection.nextAuditCursor).toEqual(page.nextCursor)
   })
 
+  it('builds a closure export snapshot from the current-account inspection view', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-closure-export',
+        email: 'current-account-closure-export@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'current-account-closure-export@example.com',
+      secret: '123456',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const generatedAt = addSeconds(now, 20)
+    const exportSnapshot = await service.getCurrentAccountClosureExportSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: generatedAt,
+      audit: { limit: 2 },
+    })
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: generatedAt,
+      audit: { limit: 2 },
+    })
+
+    expect(exportSnapshot).toEqual({
+      ...inspection,
+      generatedAt,
+    })
+    expect(exportSnapshot.currentSessionId).toBe(signedIn.session.id)
+    expect(exportSnapshot.auditEvents).toHaveLength(2)
+    expect(exportSnapshot.nextAuditCursor).toEqual(inspection.nextAuditCursor)
+  })
+
+  it('keeps closure export snapshots free of raw credential, session, and verification secrets', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-closure-export-secrets',
+        email: 'current-account-closure-export-secrets@example.com',
+        emailVerified: true,
+        metadata: {
+          providerAccessToken: 'raw-provider-token',
+        },
+      }),
+      now,
+    })
+    const credential = await service.setPassword({
+      userId: signedIn.user.id,
+      email: 'current-account-closure-export-secrets@example.com',
+      password: 'plain-password',
+      now: addSeconds(now, 5),
+      metadata: {
+        passwordResetToken: 'raw-password-metadata-token',
+      },
+    })
+    const verification = await service.createVerification({
+      purpose: 'sign-in',
+      target: 'current-account-closure-export-secrets@example.com',
+      secret: 'raw-verification-secret',
+      now: addSeconds(now, 10),
+      metadata: {
+        deliverySecret: 'raw-verification-metadata-secret',
+      },
+    })
+    const otherSession = await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 15),
+      metadata: {
+        deviceToken: 'raw-session-metadata-token',
+      },
+    })
+    const rawCurrentSession = await store.sessionRepo.findById(signedIn.session.id)
+
+    const snapshot = await service.getCurrentAccountClosureExportSnapshot({
+      sessionToken: signedIn.sessionToken,
+      now: addSeconds(now, 20),
+      audit: { limit: 5 },
+    })
+    const serialized = JSON.stringify(snapshot)
+
+    expect(snapshot.account.user.id).toBe(signedIn.user.id)
+    expect(snapshot.account.credentials).toEqual([
+      expect.objectContaining({
+        id: credential.id,
+        subject: 'current-account-closure-export-secrets@example.com',
+        type: 'password',
+      }),
+    ])
+    expect(snapshot.account.sessions.map((session) => session.id)).toEqual(
+      expect.arrayContaining([signedIn.session.id, otherSession.session.id]),
+    )
+    expect(serialized).not.toContain(credential.passwordHash)
+    expect(serialized).not.toContain(rawCurrentSession!.tokenHash)
+    expect(serialized).not.toContain(otherSession.sessionToken)
+    expect(serialized).not.toContain(verification.verification.secretHash)
+    expect(serialized).not.toContain('raw-provider-token')
+    expect(serialized).not.toContain('raw-password-metadata-token')
+    expect(serialized).not.toContain('raw-verification-metadata-secret')
+    expect(serialized).not.toContain('raw-session-metadata-token')
+  })
+
   it('returns the same current-account audit page as the user-scoped audit helper', async () => {
     const { service } = createInMemoryAuthKit()
     const signedIn = await service.signIn({
@@ -125,12 +238,18 @@ describe('DefaultAuthService current-account inspection helpers', () => {
       sessionToken: signedIn.sessionToken,
       audit: { limit: 1 },
     })
+    const exportSnapshot = await service.getCurrentAccountClosureExportSnapshot({
+      sessionToken: signedIn.sessionToken,
+      audit: { limit: 1 },
+    })
     const page = await service.getCurrentAccountAuditEventPage({
       sessionToken: signedIn.sessionToken,
       limit: 1,
     })
 
     expect(inspection.currentSessionId).toBe(signedIn.session.id)
+    expect(exportSnapshot.currentSessionId).toBe(signedIn.session.id)
+    expect(exportSnapshot.generatedAt).toEqual(now)
     expect(page.events).toHaveLength(1)
   })
 
@@ -244,6 +363,15 @@ describe('DefaultAuthService current-account inspection helpers', () => {
         sessionToken: signedIn.sessionToken,
         now: addSeconds(now, 20),
         limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.getCurrentAccountClosureExportSnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        audit: { limit: 1 },
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.SessionNotFound,

--- a/test/postgres/current-account-inspection.test.ts
+++ b/test/postgres/current-account-inspection.test.ts
@@ -48,6 +48,107 @@ describe('Postgres current-account inspection helpers', () => {
     expect(inspection.nextAuditCursor).toEqual(page.nextCursor)
   })
 
+  it('builds a closure export snapshot from the Postgres current-account inspection view', async () => {
+    const { service } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-closure-export',
+        email: 'pg-current-account-closure-export@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+
+    await service.createVerification({
+      purpose: 'sign-in',
+      target: 'pg-current-account-closure-export@example.com',
+      secret: '654321',
+      now: addSeconds(now, 5),
+    })
+    await service.createSession({
+      userId: signedIn.user.id,
+      now: addSeconds(now, 10),
+    })
+
+    const generatedAt = addSeconds(now, 20)
+    const exportSnapshot = await service.getCurrentAccountClosureExportSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: generatedAt,
+      audit: { limit: 2 },
+    })
+    const inspection = await service.getCurrentAccountInspectionSnapshot({
+      sessionToken: signedIn.sessionToken,
+      touch: true,
+      now: generatedAt,
+      audit: { limit: 2 },
+    })
+
+    expect(exportSnapshot).toEqual({
+      ...inspection,
+      generatedAt,
+    })
+    expect(exportSnapshot.currentSessionId).toBe(signedIn.session.id)
+    expect(exportSnapshot.auditEvents).toHaveLength(2)
+  })
+
+  it('keeps Postgres closure export snapshots free of raw secrets and metadata', async () => {
+    const { service, store } = await createPostgresTestKit()
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-closure-export-secrets',
+        email: 'pg-current-account-closure-export-secrets@example.com',
+        emailVerified: true,
+        metadata: {
+          providerAccessToken: 'pg-raw-provider-token',
+        },
+      },
+      now,
+    })
+    const credential = await service.setPassword({
+      userId: signedIn.user.id,
+      email: 'pg-current-account-closure-export-secrets@example.com',
+      password: 'plain-password',
+      now: addSeconds(now, 5),
+      metadata: {
+        passwordResetToken: 'pg-raw-password-metadata-token',
+      },
+    })
+    const verification = await service.createVerification({
+      purpose: 'sign-in',
+      target: 'pg-current-account-closure-export-secrets@example.com',
+      secret: 'pg-raw-verification-secret',
+      now: addSeconds(now, 10),
+      metadata: {
+        deliverySecret: 'pg-raw-verification-metadata-secret',
+      },
+    })
+    const rawCurrentSession = await store.sessionRepo.findById(signedIn.session.id)
+
+    const snapshot = await service.getCurrentAccountClosureExportSnapshot({
+      sessionToken: signedIn.sessionToken,
+      now: addSeconds(now, 20),
+      audit: { limit: 5 },
+    })
+    const serialized = JSON.stringify(snapshot)
+
+    expect(snapshot.account.credentials).toEqual([
+      expect.objectContaining({
+        id: credential.id,
+        subject: 'pg-current-account-closure-export-secrets@example.com',
+        type: 'password',
+      }),
+    ])
+    expect(serialized).not.toContain(credential.passwordHash)
+    expect(serialized).not.toContain(rawCurrentSession!.tokenHash)
+    expect(serialized).not.toContain(verification.verification.secretHash)
+    expect(serialized).not.toContain('pg-raw-provider-token')
+    expect(serialized).not.toContain('pg-raw-password-metadata-token')
+    expect(serialized).not.toContain('pg-raw-verification-metadata-secret')
+  })
+
   it('returns the same current-account audit page as the user-scoped audit helper on Postgres', async () => {
     const { service } = await createPostgresTestKit()
     const signedIn = await service.signIn({
@@ -155,6 +256,15 @@ describe('Postgres current-account inspection helpers', () => {
         sessionToken: signedIn.sessionToken,
         now: addSeconds(now, 20),
         limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.getCurrentAccountClosureExportSnapshot({
+        sessionToken: signedIn.sessionToken,
+        now: addSeconds(now, 20),
+        audit: { limit: 1 },
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.SessionNotFound,


### PR DESCRIPTION
## Summary
- add getCurrentAccountClosureExportSnapshot to the public current-account read-side API
- return generatedAt with existing safe account, session, identity, credential, and audit views
- cover in-memory and Postgres parity, disabled-account neutrality, and raw secret boundaries
- document pre-closure export route recipes and mark v0.44 scope in the roadmap

## Validation
- npm run check

Closes #301.
Closes #302.
Closes #303.