### PR TITLE
feat: add current-account profile update helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,12 @@ the trusted token boundary through `getCurrentAccountAuditEventPage(...)`.
 The same trusted token boundary can also own self-service account mutations:
 
 ```ts
+await service.updateCurrentAccountProfileByToken({
+  sessionToken,
+  displayName,
+  reAuthenticatedAt,
+})
+
 await service.revokeOwnedSessionByToken({
   sessionToken,
   targetSessionId,

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -263,6 +263,34 @@ to the neutral `SessionNotFound` path.
 
 ## Sign-In Method Action Recipes
 
+### Update Current Account Profile
+
+Use `updateCurrentAccountProfileByToken(...)` when an authenticated settings route needs to update
+local auth profile fields owned by the `User` record:
+
+```ts
+const user = await authService.updateCurrentAccountProfileByToken({
+  sessionToken: request.auth.sessionToken,
+  displayName: body.displayName,
+  reAuthenticatedAt: request.auth.reAuthenticatedAt,
+})
+
+return {
+  id: user.id,
+  displayName: user.displayName ?? null,
+  updatedAt: user.updatedAt.toISOString(),
+}
+```
+
+The helper trims display names and treats a blank display name as clearing the local display name.
+It does not update email, phone, identities, credentials, avatars, media storage, or product profile
+tables. Keep those flows application-owned or route them through identity linking, unlinking, and
+verification flows where ownership can be proven.
+
+Applications that consider profile changes sensitive can configure
+`AuthPolicyAction.UpdateProfile` in `requireReAuthFor` and pass the same app-owned
+`reAuthenticatedAt` marker used by password, unlink, and closure routes.
+
 For sign-in method screens:
 
 1. load the aggregate view through `authService.getCurrentAccountInspectionSnapshot(...)` or

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ identities, and email/phone are optional identity attributes.
 - `revokeOwnedSessionByToken`
 - `revokeOtherSessionsByToken`
 - `unlinkCurrentIdentityByToken`
+- `updateCurrentAccountProfileByToken`
 - `confirmCurrentAccountPasswordByToken`
 - `setCurrentAccountPasswordByToken`
 - `changeCurrentAccountPasswordByToken`
@@ -97,7 +98,9 @@ the current session token identifies the actor, core disables the current user, 
 local sessions, and leaves cookie clearing, legal retention, and downstream data deletion to the
 application. Pre-closure export snapshots also stay on that boundary: core returns safe local auth
 views and a bounded audit window, while file generation, legal export policy, billing state, and
-application-profile data remain outside the package.
+application-profile data remain outside the package. Current-account profile updates stay on the
+same boundary for local auth display-name changes while email, phone, avatars, media storage, and
+product profile records remain application-owned or identity-flow-owned.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -116,9 +116,9 @@ Express ownership notes:
   account existence hints.
 - For account-security screens and mutations, use [Account security recipes](account-security.md)
   and prefer `getCurrentAccountInspectionSnapshot({ sessionToken, audit? })` plus the token-based
-  self-service link, revoke, unlink, password-action, account-closure, and recent-auth helpers
-  instead of reading adapter internals or re-routing current-account writes through raw `userId`
-  calls.
+  self-service profile update, link, revoke, unlink, password-action, account-closure, and
+  recent-auth helpers instead of reading adapter internals or re-routing current-account writes
+  through raw `userId` calls.
 
 ## Fastify
 
@@ -287,6 +287,36 @@ Minimum expectations:
 
 For bearer and mobile client transport choices around local sessions, see
 [Session transport recipes](session-transport.md).
+
+## Self-Service Profile Update
+
+Keep local auth profile updates on the same trusted `sessionToken` boundary as other
+current-account routes:
+
+```ts
+app.patch('/auth/account/profile', requireSession, async (req, res, next) => {
+  try {
+    const user = await authService.updateCurrentAccountProfileByToken({
+      sessionToken: req.auth.sessionToken,
+      displayName: req.body.displayName,
+      reAuthenticatedAt: req.auth.reAuthenticatedAt,
+    })
+
+    res.status(200).json({
+      id: user.id,
+      displayName: user.displayName ?? null,
+      updatedAt: user.updatedAt.toISOString(),
+    })
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+Validate request body shape in the framework layer before calling the helper. Core trims display
+names and treats blank values as clearing the local auth display name. Email, phone, avatars, media
+storage, billing profile, and application-specific profile tables remain application-owned or
+identity-flow-owned.
 
 ## Self-Service Account Closure
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -482,12 +482,19 @@ Tracking issues: #301, #302, #303, #304.
 
 ## Next Release
 
-### v0.45 - Backlog To Be Defined
+### v0.45 - Current-Account Profile Update
 
-- Define the next releasable feature set after current-account closure export.
-- Keep `v0.45` scoped to product-facing additions rather than a maintenance-only batch.
+- Add a trusted `updateCurrentAccountProfileByToken(...)` helper so self-service profile routes can
+  update local auth profile fields on the same `sessionToken` boundary as the rest of the
+  current-account helper layer.
+- Keep the helper scoped to local user profile fields such as display name, while email, phone,
+  identities, credentials, avatars, media storage, and product profile tables remain application or
+  identity-flow owned.
+- Add parity and neutrality coverage across in-memory and Postgres-backed service setups, including
+  stale-session, revoked-session, expired-session, and disabled-account paths.
+- Add account-security and backend route recipes for safe current-account profile update routes.
 
-Tracking issues: none yet.
+Tracking issues: #308, #309, #310, #311.
 
 ## Versioning
 

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -34,9 +34,11 @@ describe('package exports', () => {
     expect(bridges.mapAuthJsOAuthToAssertion).toBeTypeOf('function')
     expect(bridges.mapBetterAuthOAuthToAssertion).toBeTypeOf('function')
     expect(core.AuditEventType.SignIn).toBe('auth.sign_in')
+    expect(core.AuditEventType.AccountProfileUpdated).toBe('auth.account_profile_updated')
     expect(core.AuditEventType.VerificationCancelled).toBe('auth.verification_cancelled')
     expect(core.CredentialType.Password).toBe('password')
     expect(core.AuthPolicyAction.ChangePassword).toBe('changePassword')
+    expect(core.AuthPolicyAction.UpdateProfile).toBe('updateProfile')
     expect(core.DefaultAuthService).toBeTypeOf('function')
     expect(core.EMAIL_MAGIC_LINK_PROVIDER_ID).toBe('email-magic-link')
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
@@ -103,6 +105,9 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.revokeOwnedSessionByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeOtherSessionsByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.unlinkCurrentIdentityByToken).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.updateCurrentAccountProfileByToken).toBeTypeOf(
+      'function',
+    )
     expect(core.DefaultAuthService.prototype.setCurrentAccountPasswordByToken).toBeTypeOf(
       'function',
     )
@@ -221,6 +226,7 @@ describe('package exports', () => {
     expect(flowDeclarations).toContain('export interface CancelCurrentAccountOtpReAuthInput')
     expect(flowDeclarations).toContain('export interface LinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UnlinkCurrentIdentityByTokenInput')
+    expect(flowDeclarations).toContain('export interface UpdateCurrentAccountProfileByTokenInput')
     expect(flowDeclarations).toContain('export interface RevokeOwnedSessionByTokenResult')
     expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
     expect(serviceDeclarations).toContain(
@@ -273,6 +279,9 @@ describe('package exports', () => {
     )
     expect(serviceDeclarations).toContain(
       'unlinkCurrentIdentityByToken(input: UnlinkCurrentIdentityByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'updateCurrentAccountProfileByToken(input: UpdateCurrentAccountProfileByTokenInput)',
     )
     expect(serviceDeclarations).toContain(
       'setCurrentAccountPasswordByToken(input: SetCurrentAccountPasswordByTokenInput)',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -20,6 +20,7 @@ import {
   revokeOwnedSessionByToken,
   setCurrentAccountPasswordByToken,
   unlinkCurrentIdentityByToken,
+  updateCurrentAccountProfileByToken,
 } from './current-account-actions.js'
 import {
   assertCurrentAccountReAuth,
@@ -149,6 +150,7 @@ import type {
   TouchSessionInput,
   UnlinkInput,
   UnlinkCurrentIdentityByTokenInput,
+  UpdateCurrentAccountProfileByTokenInput,
   User,
   UserId,
   Verification,
@@ -352,6 +354,12 @@ export class DefaultAuthService implements AuthService {
     input: CloseCurrentAccountByTokenInput,
   ): Promise<CloseCurrentAccountByTokenResult> {
     return closeCurrentAccountByToken(this.runtime, input)
+  }
+
+  async updateCurrentAccountProfileByToken(
+    input: UpdateCurrentAccountProfileByTokenInput,
+  ): Promise<User> {
+    return updateCurrentAccountProfileByToken(this.runtime, input)
   }
 
   async setCurrentAccountPasswordByToken(

--- a/src/application/current-account-actions.ts
+++ b/src/application/current-account-actions.ts
@@ -16,9 +16,15 @@ import type {
   RevokeOwnedSessionByTokenResult,
   SetCurrentAccountPasswordByTokenInput,
   UnlinkCurrentIdentityByTokenInput,
+  UpdateCurrentAccountProfileByTokenInput,
+  User,
 } from '../domain/types.js'
 import { AuditEventType, AuthPolicyAction, isActiveSession } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput } from '../errors.js'
+
+const CurrentAccountProfileField = {
+  DisplayName: 'displayName',
+} as const
 
 export async function revokeOwnedSessionByToken(
   runtime: AuthServiceRuntime,
@@ -135,6 +141,41 @@ export async function closeCurrentAccountByToken(
   })
 }
 
+export async function updateCurrentAccountProfileByToken(
+  runtime: AuthServiceRuntime,
+  input: UpdateCurrentAccountProfileByTokenInput,
+): Promise<User> {
+  return runtime.transaction.run(async () => {
+    const now = input.now ?? runtime.clock.now()
+    const { session, user } = await resolveSessionContext(runtime, {
+      sessionToken: input.sessionToken,
+      now,
+    })
+
+    await ensureReAuth(
+      runtime,
+      AuthPolicyAction.UpdateProfile,
+      user.id,
+      input.reAuthenticatedAt,
+      now,
+    )
+
+    const patch = normalizeCurrentAccountProfilePatch(input, now)
+    const updated = await runtime.repos.userRepo.update(user.id, patch)
+
+    await audit(runtime, AuditEventType.AccountProfileUpdated, now, {
+      userId: user.id,
+      sessionId: session.id,
+      metadata: {
+        changedFields: [CurrentAccountProfileField.DisplayName],
+        ...optionalProp('requestMetadata', input.metadata),
+      },
+    })
+
+    return updated
+  })
+}
+
 export async function setCurrentAccountPasswordByToken(
   runtime: AuthServiceRuntime,
   input: SetCurrentAccountPasswordByTokenInput,
@@ -182,4 +223,21 @@ export async function changeCurrentAccountPasswordByToken(
       ...(input.metadata ? { metadata: input.metadata } : {}),
     })
   })
+}
+
+function normalizeCurrentAccountProfilePatch(
+  input: UpdateCurrentAccountProfileByTokenInput,
+  now: Date,
+): Pick<User, 'updatedAt'> & { readonly displayName?: User['displayName'] | undefined } {
+  if (!Object.hasOwn(input, CurrentAccountProfileField.DisplayName)) {
+    throw invalidInput('Current account profile update requires at least one profile field.')
+  }
+
+  const displayName =
+    typeof input.displayName === 'string' ? input.displayName.trim() || undefined : undefined
+
+  return {
+    displayName,
+    updatedAt: now,
+  }
 }

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -6,6 +6,7 @@ export const AuditEventType = {
   IdentityUnlinked: 'auth.identity_unlinked',
   AccountsMerged: 'auth.accounts_merged',
   AccountClosed: 'auth.account_closed',
+  AccountProfileUpdated: 'auth.account_profile_updated',
   SessionCreated: 'auth.session_created',
   SessionRevoked: 'auth.session_revoked',
   VerificationCreated: 'auth.verification_created',

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -259,6 +259,14 @@ export interface CloseCurrentAccountByTokenResult {
   readonly revokedSessionIds: readonly SessionId[]
 }
 
+export interface UpdateCurrentAccountProfileByTokenInput {
+  readonly sessionToken: string
+  readonly displayName?: string
+  readonly reAuthenticatedAt?: Date
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface RevokeUserSessionsInput {
   readonly userId: UserId
   readonly exceptSessionId?: SessionId

--- a/src/domain/policy.ts
+++ b/src/domain/policy.ts
@@ -5,6 +5,7 @@ export const AuthPolicyAction = {
   MergeAccounts: 'mergeAccounts',
   SetPassword: 'setPassword',
   ChangePassword: 'changePassword',
+  UpdateProfile: 'updateProfile',
   CloseAccount: 'closeAccount',
 } as const
 

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -56,6 +56,7 @@ import type {
   TouchSessionInput,
   UnlinkInput,
   UnlinkCurrentIdentityByTokenInput,
+  UpdateCurrentAccountProfileByTokenInput,
 } from './flows.js'
 import type { SessionId, UserId, VerificationId } from './ids.js'
 import type {
@@ -146,6 +147,7 @@ export interface AuthService {
   closeCurrentAccountByToken(
     input: CloseCurrentAccountByTokenInput,
   ): Promise<CloseCurrentAccountByTokenResult>
+  updateCurrentAccountProfileByToken(input: UpdateCurrentAccountProfileByTokenInput): Promise<User>
   setCurrentAccountPasswordByToken(
     input: SetCurrentAccountPasswordByTokenInput,
   ): Promise<Credential>

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -117,6 +117,157 @@ describe('DefaultAuthService current-account action helpers', () => {
     })
   })
 
+  it('updates the current account profile by trusted session token', async () => {
+    const { service } = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.UpdateProfile],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-profile',
+        email: 'current-account-profile@example.com',
+        emailVerified: true,
+        phone: '+15550000001',
+        phoneVerified: true,
+        displayName: 'Before',
+        metadata: { externalProfileId: 'profile-1' },
+      }),
+      now,
+    })
+    const originalIdentities = await service.getUserIdentities(signedIn.user.id)
+    const originalSessions = await service.getUserSessions(signedIn.user.id)
+
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    const updatedAt = addSeconds(now, 20)
+    const updated = await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: '  Updated Name  ',
+      reAuthenticatedAt: updatedAt,
+      now: updatedAt,
+      metadata: { source: 'settings' },
+    })
+
+    expect(updated).toMatchObject({
+      id: signedIn.user.id,
+      displayName: 'Updated Name',
+      email: 'current-account-profile@example.com',
+      phone: '+15550000001',
+      updatedAt,
+    })
+    await expect(service.getUser(signedIn.user.id)).resolves.toMatchObject({
+      displayName: 'Updated Name',
+      email: 'current-account-profile@example.com',
+      phone: '+15550000001',
+    })
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(originalIdentities)
+    expect(await service.getUserSessions(signedIn.user.id)).toEqual(originalSessions)
+    await expect(service.getAuditEvents({ userId: signedIn.user.id })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.AccountProfileUpdated,
+          sessionId: signedIn.session.id,
+          metadata: {
+            changedFields: ['displayName'],
+            requestMetadata: { source: 'settings' },
+          },
+        }),
+      ]),
+    )
+  })
+
+  it('normalizes blank current-account profile display names and rejects empty updates', async () => {
+    const { service } = createInMemoryAuthKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-profile-blank',
+        email: 'current-account-profile-blank@example.com',
+        emailVerified: true,
+        displayName: 'Before',
+      }),
+    })
+
+    const cleared = await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: '   ',
+    })
+
+    expect(cleared).toMatchObject({
+      id: signedIn.user.id,
+      updatedAt: now,
+    })
+    expect(cleared.displayName).toBeUndefined()
+    const clearedFromUndefined = await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: undefined as unknown as string,
+    })
+
+    expect(clearedFromUndefined.displayName).toBeUndefined()
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+  })
+
+  it('keeps expired and revoked current-account profile update contexts neutral', async () => {
+    const { service } = createInMemoryAuthKit()
+    const revoked = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-profile-revoked',
+        email: 'current-account-profile-revoked@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const expired = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-profile-expired',
+        email: 'current-account-profile-expired@example.com',
+        emailVerified: true,
+      }),
+      sessionExpiresAt: addSeconds(now, 5),
+      now,
+    })
+
+    await service.revokeCurrentSessionByToken({
+      sessionToken: revoked.sessionToken,
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: revoked.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: expired.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+
   it('unlinks current-account identities by session token and preserves re-auth and last-identity rules', async () => {
     const { service } = createInMemoryAuthKit({
       policy: createDefaultAuthPolicy({
@@ -582,6 +733,15 @@ describe('DefaultAuthService current-account action helpers', () => {
       service.closeCurrentAccountByToken({
         sessionToken: signedIn.sessionToken,
         reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+        displayName: 'Updated',
         now: addSeconds(now, 20),
       }),
     ).rejects.toMatchObject({

--- a/test/postgres/current-account-actions.test.ts
+++ b/test/postgres/current-account-actions.test.ts
@@ -135,6 +135,150 @@ describe('Postgres current-account action helpers', () => {
     )
   })
 
+  it('updates the current Postgres account profile by trusted session token', async () => {
+    const { service } = await createPostgresTestKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.UpdateProfile],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-profile',
+        email: 'pg-current-account-profile@example.com',
+        emailVerified: true,
+        phone: '+15550000002',
+        phoneVerified: true,
+        displayName: 'Before',
+        metadata: { externalProfileId: 'pg-profile-1' },
+      },
+      now,
+    })
+    const originalIdentities = await service.getUserIdentities(signedIn.user.id)
+    const originalSessions = await service.getUserSessions(signedIn.user.id)
+
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    const updatedAt = addSeconds(now, 20)
+    const updated = await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: '  Updated Name  ',
+      reAuthenticatedAt: updatedAt,
+      now: updatedAt,
+      metadata: { source: 'settings' },
+    })
+
+    expect(updated).toMatchObject({
+      id: signedIn.user.id,
+      displayName: 'Updated Name',
+      email: 'pg-current-account-profile@example.com',
+      phone: '+15550000002',
+      updatedAt,
+    })
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(originalIdentities)
+    expect(await service.getUserSessions(signedIn.user.id)).toEqual(originalSessions)
+    await expect(service.getAuditEvents({ userId: signedIn.user.id })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.AccountProfileUpdated,
+          sessionId: signedIn.session.id,
+          metadata: {
+            changedFields: ['displayName'],
+            requestMetadata: { source: 'settings' },
+          },
+        }),
+      ]),
+    )
+  })
+
+  it('normalizes blank Postgres profile display names and rejects empty updates', async () => {
+    const { service } = await createPostgresTestKit({
+      clock: { now: () => now },
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-profile-blank',
+        email: 'pg-current-account-profile-blank@example.com',
+        emailVerified: true,
+        displayName: 'Before',
+      },
+    })
+
+    const cleared = await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: '   ',
+    })
+
+    expect(cleared).toMatchObject({
+      id: signedIn.user.id,
+      updatedAt: now,
+    })
+    expect(cleared.displayName).toBeUndefined()
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+  })
+
+  it('keeps expired and revoked Postgres current-account profile update contexts neutral', async () => {
+    const { service } = await createPostgresTestKit()
+    const revoked = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-profile-revoked',
+        email: 'pg-current-account-profile-revoked@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const expired = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-profile-expired',
+        email: 'pg-current-account-profile-expired@example.com',
+        emailVerified: true,
+      },
+      sessionExpiresAt: addSeconds(now, 5),
+      now,
+    })
+
+    await service.revokeCurrentSessionByToken({
+      sessionToken: revoked.sessionToken,
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: revoked.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: expired.sessionToken,
+        displayName: 'Updated',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+  })
+
   it('closes the current Postgres account by trusted session token and revokes sessions', async () => {
     const { service, store } = await createPostgresTestKit({
       policy: createDefaultAuthPolicy({
@@ -268,6 +412,15 @@ describe('Postgres current-account action helpers', () => {
       service.closeCurrentAccountByToken({
         sessionToken: signedIn.sessionToken,
         reAuthenticatedAt: addSeconds(now, 20),
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.SessionNotFound,
+    })
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+        displayName: 'Updated',
         now: addSeconds(now, 20),
       }),
     ).rejects.toMatchObject({


### PR DESCRIPTION
## Summary
- add updateCurrentAccountProfileByToken to the public current-account write-side API
- add profile-update audit and optional policy re-auth action
- cover in-memory and Postgres success, blank display-name normalization, stale-session neutrality, and non-profile mutation boundaries
- document profile update route ownership and mark v0.45 scope in the roadmap

## Validation
- npm run check

Closes #308.
Closes #309.
Closes #310.