### PR TITLE
docs: sync roadmap after v0.45.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -480,21 +480,28 @@ Tracking issues: #294, #295, #296, #297.
 
 Tracking issues: #301, #302, #303, #304.
 
-## Next Release
-
 ### v0.45 - Current-Account Profile Update
 
-- Add a trusted `updateCurrentAccountProfileByToken(...)` helper so self-service profile routes can
+- Added a trusted `updateCurrentAccountProfileByToken(...)` helper so self-service profile routes can
   update local auth profile fields on the same `sessionToken` boundary as the rest of the
   current-account helper layer.
-- Keep the helper scoped to local user profile fields such as display name, while email, phone,
+- Kept the helper scoped to local user profile fields such as display name, while email, phone,
   identities, credentials, avatars, media storage, and product profile tables remain application or
   identity-flow owned.
-- Add parity and neutrality coverage across in-memory and Postgres-backed service setups, including
+- Added parity and neutrality coverage across in-memory and Postgres-backed service setups, including
   stale-session, revoked-session, expired-session, and disabled-account paths.
-- Add account-security and backend route recipes for safe current-account profile update routes.
+- Added account-security and backend route recipes for safe current-account profile update routes.
 
 Tracking issues: #308, #309, #310, #311.
+
+## Next Release
+
+### v0.46 - Backlog To Be Defined
+
+- Define the next releasable feature set after current-account profile update helpers.
+- Keep `v0.46` scoped to product-facing additions rather than a maintenance-only batch.
+
+Tracking issues: none yet.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- move v0.45 into released roadmap history
- add the v0.46 planning placeholder

## Verification
- npm run check

Closes #311