### PR TITLE
ci: route workflows to ephemeral self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,4 +3,5 @@ self-hosted-runner:
     - ci
     - release-deploy
     - uniauth-ci
+    - uniauth-codeql
     - uniauth-release-deploy

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,4 +4,5 @@ self-hosted-runner:
     - release-deploy
     - uniauth-ci
     - uniauth-codeql
+    - uniauth-dependabot
     - uniauth-release-deploy

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - ci
+    - release-deploy

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,5 @@ self-hosted-runner:
   labels:
     - ci
     - release-deploy
+    - uniauth-ci
+    - uniauth-release-deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Check package
@@ -32,11 +27,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Check package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci]
     container:
       image: node:22-alpine
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: uniauth-ci
+    runs-on: ${{ github.actor == 'dependabot[bot]' && 'uniauth-dependabot' || 'uniauth-ci' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,14 @@ permissions:
 
 jobs:
   check:
-    runs-on: [self-hosted, linux, x64, ci]
-    container:
-      image: node:22-alpine
+    runs-on: uniauth-ci
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
       - name: Install dependencies
         run: npm ci
       - name: Check package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,24 @@ permissions:
 
 jobs:
   check:
-    runs-on: ${{ github.actor == 'dependabot[bot]' && 'uniauth-dependabot' || 'uniauth-ci' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    runs-on: uniauth-ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          package-manager-cache: false
+      - name: Install dependencies
+        run: npm ci
+      - name: Check package
+        run: npm run check
+
+  dependabot-check:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: uniauth-dependabot
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
+          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Check package

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: [self-hosted, linux, x64, ci]
+    runs-on: uniauth-ci
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: uniauth-codeql
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: uniauth-ci
+    runs-on: uniauth-codeql
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,12 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          package-manager-cache: false
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: https://npm.pkg.github.com
           scope: '@alyldas'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,13 @@ permissions:
   packages: write
   pull-requests: write
 
+concurrency:
+  group: uniauth-release-deploy
+  cancel-in-progress: false
+
 jobs:
   release-please:
-    runs-on: [self-hosted, linux, x64, release-deploy]
+    runs-on: uniauth-release-deploy
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, release-deploy]
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.release.outputs.tag_name }}
-      - name: Set up Node.js
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          package-manager-cache: false
-          registry-url: https://npm.pkg.github.com
-          scope: '@alyldas'
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created == 'true' }}
         run: npm ci


### PR DESCRIPTION
Routes CI jobs to the shared ephemeral self-hosted ci label and release/deploy jobs to the serialized release-deploy label.