### PR TITLE
feat: add current-account verified contact changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ license, subscription, private contract, or other written permission.
 - Exposes current-account inspection aggregate and audit-page helpers for self-service security
   routes that already trust a local session token.
 - Exposes token-based current-account write-side helpers for sign-in-method link/unlink,
-  selected-session revoke, account closure, and local password setup or change after transport
-  resolution.
+  selected-session revoke, verified contact changes, account closure, and local password setup or
+  change after transport resolution.
 - Exposes current-account OTP and password re-auth helpers for self-service recent-auth bootstrapping
   on the trusted local session-token boundary.
 - Exposes a trusted `getAccountInspectionSnapshot({ userId, audit? })` aggregate read-side
@@ -386,6 +386,19 @@ await service.updateCurrentAccountProfileByToken({
   reAuthenticatedAt,
 })
 
+const contactChange = await service.startCurrentAccountContactChange({
+  sessionToken,
+  channel: OtpChannel.Email,
+  target: newEmail,
+  reAuthenticatedAt,
+})
+
+await service.finishCurrentAccountContactChange({
+  sessionToken,
+  verificationId: contactChange.verificationId,
+  secret: code,
+})
+
 await service.revokeOwnedSessionByToken({
   sessionToken,
   targetSessionId,
@@ -684,6 +697,7 @@ contact `alyldas@ya.ru`.
 - [Basic Node example](examples/basic-node/index.ts)
 - [Express auth module example](examples/express-auth/index.ts)
 - [Fastify auth module example](examples/fastify-auth/index.ts)
+- [Current-account contact change example](examples/current-account-contact-change/index.ts)
 - [Link and unlink example](examples/link-unlink/index.ts)
 - [OTP backend wiring example](examples/otp-backend/index.ts)
 - [OAuth / OIDC wiring example](examples/oauth-oidc/index.ts)

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -291,6 +291,52 @@ Applications that consider profile changes sensitive can configure
 `AuthPolicyAction.UpdateProfile` in `requireReAuthFor` and pass the same app-owned
 `reAuthenticatedAt` marker used by password, unlink, and closure routes.
 
+### Update Current Account Contact
+
+Use `startCurrentAccountContactChange(...)` and `finishCurrentAccountContactChange(...)` when an
+authenticated settings route needs to update the local `User.email` or `User.phone` field after OTP
+proof on the new target:
+
+```ts
+const started = await authService.startCurrentAccountContactChange({
+  sessionToken: request.auth.sessionToken,
+  channel: body.channel,
+  target: body.target,
+  reAuthenticatedAt: request.auth.reAuthenticatedAt,
+})
+
+return {
+  verificationId: started.verificationId,
+  expiresAt: started.expiresAt.toISOString(),
+  delivery: started.delivery,
+}
+```
+
+```ts
+const user = await authService.finishCurrentAccountContactChange({
+  sessionToken: request.auth.sessionToken,
+  verificationId: body.verificationId,
+  secret: body.code,
+})
+
+return {
+  id: user.id,
+  email: user.email ?? null,
+  phone: user.phone ?? null,
+  updatedAt: user.updatedAt.toISOString(),
+}
+```
+
+`resendCurrentAccountContactChange(...)` and `cancelCurrentAccountContactChange(...)` keep the
+challenge on the same trusted `sessionToken` boundary. The helpers normalize email and phone
+targets, reject unchanged targets, and update only the local `User` contact field after successful
+verification. They do not rewrite sign-in identities, password credential subjects, OAuth provider
+profiles, notification preferences, or product profile tables.
+
+Applications that consider contact changes sensitive can configure `AuthPolicyAction.UpdateContact`
+in `requireReAuthFor` and pass the same app-owned `reAuthenticatedAt` marker used by password,
+unlink, profile, and closure routes.
+
 For sign-in method screens:
 
 1. load the aggregate view through `authService.getCurrentAccountInspectionSnapshot(...)` or
@@ -299,6 +345,7 @@ For sign-in method screens:
 2. present provider ids, statuses, email or phone hints, and credential types;
 3. compose mutations through `linkCurrentIdentityByToken(...)`, `unlinkCurrentIdentityByToken(...)`,
    `setCurrentAccountPasswordByToken(...)`, `changeCurrentAccountPasswordByToken(...)`,
+   `startCurrentAccountContactChange(...)`, `finishCurrentAccountContactChange(...)`,
    `closeCurrentAccountByToken(...)`, or new provider link flows.
 
 Keep the same public security rules:
@@ -627,6 +674,7 @@ Do not send `secretHash` to browsers, mobile clients, or untrusted callers.
 
 - [Express auth module example](../examples/express-auth/index.ts)
 - [Fastify auth module example](../examples/fastify-auth/index.ts)
+- [Current-account contact change example](../examples/current-account-contact-change/index.ts)
 - [OTP backend wiring example](../examples/otp-backend/index.ts)
 - [Session transport recipes](session-transport.md)
 - [Backend integration recipes](backend-recipes.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,10 @@ identities, and email/phone are optional identity attributes.
 - `revokeOtherSessionsByToken`
 - `unlinkCurrentIdentityByToken`
 - `updateCurrentAccountProfileByToken`
+- `startCurrentAccountContactChange`
+- `resendCurrentAccountContactChange`
+- `cancelCurrentAccountContactChange`
+- `finishCurrentAccountContactChange`
 - `confirmCurrentAccountPasswordByToken`
 - `setCurrentAccountPasswordByToken`
 - `changeCurrentAccountPasswordByToken`
@@ -99,8 +103,11 @@ local sessions, and leaves cookie clearing, legal retention, and downstream data
 application. Pre-closure export snapshots also stay on that boundary: core returns safe local auth
 views and a bounded audit window, while file generation, legal export policy, billing state, and
 application-profile data remain outside the package. Current-account profile updates stay on the
-same boundary for local auth display-name changes while email, phone, avatars, media storage, and
-product profile records remain application-owned or identity-flow-owned.
+same boundary for local auth display-name changes. Verified email or phone changes can also stay on
+that boundary through a dedicated contact-change OTP lifecycle that updates only the local `User`
+contact field after proof of the new target. Sign-in identities, password credential subjects,
+OAuth provider profiles, avatars, media storage, notification preferences, and product profile
+records remain application-owned or identity-flow-owned.
 
 OTP challenges use `EmailSender` for email delivery and `SmsSender` for phone delivery. Core
 creates and hashes the verification secret, tracks the verification lifecycle, and maps successful

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -265,6 +265,7 @@ The repository keeps small transport-facing examples alongside these framework n
 
 - [Express auth module example](../examples/express-auth/index.ts)
 - [Fastify auth module example](../examples/fastify-auth/index.ts)
+- [Current-account contact change example](../examples/current-account-contact-change/index.ts)
 - [OTP backend wiring example](../examples/otp-backend/index.ts)
 - [OAuth / OIDC wiring example](../examples/oauth-oidc/index.ts)
 - [Provider token persistence](provider-token-persistence.md)
@@ -317,6 +318,59 @@ Validate request body shape in the framework layer before calling the helper. Co
 names and treats blank values as clearing the local auth display name. Email, phone, avatars, media
 storage, billing profile, and application-specific profile tables remain application-owned or
 identity-flow-owned.
+
+## Self-Service Contact Change
+
+Keep verified email and phone changes on the same trusted `sessionToken` boundary. Core owns the
+OTP challenge lifecycle and the local `User` contact field update; the application still owns body
+validation, UI labels, cookie rotation, notification preferences, and any product profile tables:
+
+```ts
+app.post('/auth/account/contact-change/start', requireSession, async (req, res, next) => {
+  try {
+    const started = await authService.startCurrentAccountContactChange({
+      sessionToken: req.auth.sessionToken,
+      channel: req.body.channel,
+      target: req.body.target,
+      reAuthenticatedAt: req.auth.reAuthenticatedAt,
+    })
+
+    res.status(202).json({
+      verificationId: started.verificationId,
+      expiresAt: started.expiresAt.toISOString(),
+      delivery: started.delivery,
+    })
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+```ts
+app.post('/auth/account/contact-change/finish', requireSession, async (req, res, next) => {
+  try {
+    const user = await authService.finishCurrentAccountContactChange({
+      sessionToken: req.auth.sessionToken,
+      verificationId: req.body.verificationId,
+      secret: req.body.code,
+    })
+
+    res.status(200).json({
+      id: user.id,
+      email: user.email ?? null,
+      phone: user.phone ?? null,
+      updatedAt: user.updatedAt.toISOString(),
+    })
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+Use `resendCurrentAccountContactChange(...)` and `cancelCurrentAccountContactChange(...)` for
+trusted resend and cancellation routes. The helpers update only `User.email` or `User.phone` after
+proof of the new target; sign-in identities, password credential subjects, OAuth profiles, avatars,
+and downstream application records remain owned by their existing flows.
 
 ## Self-Service Account Closure
 

--- a/docs/normalization.md
+++ b/docs/normalization.md
@@ -188,6 +188,7 @@ That behavior should apply consistently to:
 
 - email OTP start;
 - phone OTP start;
+- current-account contact-change start;
 - email magic-link start;
 - password sign-in;
 - password recovery start;
@@ -208,6 +209,7 @@ normalized value is persisted or used as a key:
 - `AuthIdentity.email`;
 - `AuthIdentity.phone`;
 - `AuthIdentity.providerUserId` for local email-derived identities;
+- `User.email` and `User.phone` for verified current-account contact changes;
 - `Credential.subject` for password credentials;
 - pending `Verification.target` values;
 - application-owned rate-limit keys or analytics dimensions;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -496,10 +496,19 @@ Tracking issues: #308, #309, #310, #311.
 
 ## Next Release
 
-### v0.46 - Backlog To Be Defined
+### v0.46 - Current-Account Verified Contact Change
 
-- Define the next releasable feature set after current-account profile update helpers.
-- Keep `v0.46` scoped to product-facing additions rather than a maintenance-only batch.
+- Added trusted current-account verified contact change helpers for local `User.email` and
+  `User.phone` updates after OTP proof of the new target.
+- Kept start, resend, cancel, and finish routes on the existing `sessionToken` boundary with
+  optional recent-auth policy enforcement through `AuthPolicyAction.UpdateContact`.
+- Left sign-in identities, password credential subjects, provider profiles, notification
+  preferences, and product profile tables outside the contact-change helper boundary.
+- Added focused in-memory and Postgres parity coverage for re-auth enforcement, resend replacement,
+  cancellation, foreign-verification neutrality, safe field updates, and contact-change audit
+  metadata.
+- Added account-security and backend route recipes plus runnable examples for self-service verified
+  contact changes.
 
 Tracking issues: none yet.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,6 +25,8 @@ risks, see [Threat model](threat-model.md).
 - Password sign-in uses neutral invalid-credential errors for missing users, wrong passwords, and
   inconsistent credential state.
 - Password recovery uses hashed verification secrets and consume-once finish semantics.
+- Current-account contact changes update local email or phone only after OTP proof of the new
+  target.
 - OTP delivery failures do not expose account state; the app-owned sender adapter decides retry,
   dead-letter, and cleanup behavior.
 - Queue-backed delivery may wrap sender ports, but delivery attempts and exhausted-delivery state
@@ -46,6 +48,9 @@ risks, see [Threat model](threat-model.md).
 - Merge users: denied by default; extension point: `AuthPolicy.canMergeUsers`. The merge context now
   includes source and target active identities so policy can inspect provider trust and metadata.
 - Re-auth: required for merge by default; extension point: `AuthPolicy.requiresReAuth`.
+- Current-account contact change: allowed by default after trusted session resolution and OTP proof;
+  optional recent-auth enforcement uses `AuthPolicy.requiresReAuth` with
+  `AuthPolicyAction.UpdateContact`.
 
 ## Threats Covered in v0.1
 
@@ -104,6 +109,16 @@ risks, see [Threat model](threat-model.md).
   arbitrary error details by hand.
 - OTP, magic-link, and password-recovery abuse-control docs now use one canonical server-owned
   recipe for resend and 429 shaping.
+
+## Threats Covered in v0.46
+
+- Current-account email and phone updates prove the new target through the shared OTP verification
+  lifecycle before mutating local user contact fields.
+- Contact-change verifications are scoped to the current user and cannot be finished from another
+  trusted session.
+- Contact-change helpers update only `User.email` or `User.phone`; sign-in identities and password
+  credential subjects are not silently rewritten.
+- Recent-auth requirements for contact changes can be enforced through the existing policy hook.
 
 ## Threats Covered in v0.11
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -45,6 +45,8 @@ UniAuth response:
 
 - exact `(provider, providerUserId)` match wins before any email or phone hint;
 - default policy does not auto-link by email or phone;
+- current-account contact changes prove the new target through an owned session and OTP challenge
+  without treating that target as a provider-linking shortcut;
 - merge is explicit and denied by default;
 - trust context can tighten auto-link, explicit link, and merge decisions.
 

--- a/examples/current-account-contact-change/index.ts
+++ b/examples/current-account-contact-change/index.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from 'node:url'
+import { AuthPolicyAction, OtpChannel, addSeconds, createDefaultAuthPolicy } from '@alyldas/uniauth'
+import { createInMemoryAuthKit } from '@alyldas/uniauth/testing'
+
+const now = new Date('2026-01-01T00:00:00.000Z')
+
+export async function runCurrentAccountContactChangeExample(): Promise<void> {
+  const { service, emailSender, smsSender } = createInMemoryAuthKit({
+    policy: createDefaultAuthPolicy({
+      requireReAuthFor: [AuthPolicyAction.UpdateContact],
+    }),
+    verificationResendCooldownSeconds: 0,
+  })
+  const signedIn = await service.signIn({
+    assertion: {
+      provider: 'email',
+      providerUserId: 'alice@example.com',
+      email: 'alice@example.com',
+      emailVerified: true,
+      displayName: 'Alice Example',
+    },
+    now,
+  })
+
+  const emailChange = await service.startCurrentAccountContactChange({
+    sessionToken: signedIn.sessionToken,
+    channel: OtpChannel.Email,
+    target: 'alice.new@example.com',
+    secret: '123456',
+    reAuthenticatedAt: now,
+    now: addSeconds(now, 10),
+    metadata: { route: 'account-contact-email-start' },
+  })
+  const emailDelivery = emailSender.listMessages().at(-1)
+
+  if (!emailDelivery) {
+    throw new Error('Expected the application-owned email sender to capture one message.')
+  }
+
+  const updated = await service.finishCurrentAccountContactChange({
+    sessionToken: signedIn.sessionToken,
+    verificationId: emailChange.verificationId,
+    secret: '123456',
+    now: addSeconds(now, 20),
+    metadata: { route: 'account-contact-email-finish' },
+  })
+  const phoneChange = await service.startCurrentAccountContactChange({
+    sessionToken: signedIn.sessionToken,
+    channel: OtpChannel.Phone,
+    target: '+1 (555) 000-0100',
+    secret: '654321',
+    reAuthenticatedAt: addSeconds(now, 20),
+    now: addSeconds(now, 30),
+    metadata: { route: 'account-contact-phone-start' },
+  })
+  const resentPhoneChange = await service.resendCurrentAccountContactChange({
+    sessionToken: signedIn.sessionToken,
+    verificationId: phoneChange.verificationId,
+    secret: '777777',
+    now: addSeconds(now, 40),
+    metadata: { route: 'account-contact-phone-resend' },
+  })
+  const cancelledPhoneChange = await service.cancelCurrentAccountContactChange({
+    sessionToken: signedIn.sessionToken,
+    verificationId: resentPhoneChange.verificationId,
+    now: addSeconds(now, 50),
+    metadata: { route: 'account-contact-phone-cancel' },
+  })
+
+  console.log({
+    userId: updated.id,
+    email: updated.email ?? null,
+    phone: updated.phone ?? null,
+    emailDelivery: {
+      to: emailDelivery.to,
+      subject: emailDelivery.subject,
+    },
+    phoneDeliveryCount: smsSender.listMessages().length,
+    cancelledPhoneChange: {
+      verificationId: cancelledPhoneChange.id,
+      status: cancelledPhoneChange.status,
+      expiresAt: cancelledPhoneChange.expiresAt.toISOString(),
+    },
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await runCurrentAccountContactChangeExample()
+}

--- a/examples/express-auth/index.ts
+++ b/examples/express-auth/index.ts
@@ -194,6 +194,77 @@ export async function createExpressAuthExample(): Promise<ExpressAuthExample> {
     },
   )
 
+  app.post(
+    '/account/contact/email/start',
+    sessionMiddleware,
+    requireExpressSession,
+    async (request, response, next) => {
+      try {
+        const auth = request.auth
+
+        if (!auth) {
+          response.status(401).json({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+          return
+        }
+
+        const email = readRequiredString(request.body?.email, 'email')
+        const challenge = await authService.startCurrentAccountContactChange({
+          sessionToken: auth.sessionToken,
+          channel: OtpChannel.Email,
+          target: email,
+          metadata: { transport: 'express', route: 'contact-email-start' },
+        })
+
+        response.status(202).json({
+          verificationId: challenge.verificationId,
+          delivery: challenge.delivery,
+          expiresAt: challenge.expiresAt.toISOString(),
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
+  app.post(
+    '/account/contact/email/finish',
+    sessionMiddleware,
+    requireExpressSession,
+    async (request, response, next) => {
+      try {
+        const auth = request.auth
+
+        if (!auth) {
+          response.status(401).json({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+          return
+        }
+
+        const verificationId = parseVerificationId(
+          readRequiredString(request.body?.verificationId, 'verificationId'),
+        )
+        const code = readRequiredString(request.body?.code, 'code')
+        const user = await authService.finishCurrentAccountContactChange({
+          sessionToken: auth.sessionToken,
+          verificationId,
+          secret: code,
+          metadata: { transport: 'express', route: 'contact-email-finish' },
+        })
+
+        response.status(200).json({
+          user: {
+            id: user.id,
+            email: user.email ?? null,
+            phone: user.phone ?? null,
+            displayName: user.displayName ?? null,
+          },
+          updatedAt: user.updatedAt.toISOString(),
+        })
+      } catch (error) {
+        next(error)
+      }
+    },
+  )
+
   app.use((error: unknown, _request: Request, response: Response, next: NextFunction): void => {
     if (response.headersSent) {
       next(error)
@@ -246,6 +317,8 @@ export async function runExpressAuthExample(): Promise<void> {
             'POST /auth/otp/finish',
             'GET /me',
             'GET /account/security',
+            'POST /account/contact/email/start',
+            'POST /account/contact/email/finish',
           ],
           note: 'OTP codes are printed by the application-owned email sender.',
         },

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -188,6 +188,92 @@ export async function createFastifyAuthExample(): Promise<FastifyAuthExample> {
     },
   )
 
+  app.post<{
+    Body: {
+      email: string
+    }
+  }>(
+    '/account/contact/email/start',
+    {
+      preHandler: [sessionPreHandler, requireFastifySession],
+      schema: {
+        body: {
+          type: 'object',
+          required: ['email'],
+          properties: {
+            email: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const auth = request.auth
+
+      if (!auth) {
+        return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+      }
+
+      const challenge = await authService.startCurrentAccountContactChange({
+        sessionToken: auth.sessionToken,
+        channel: OtpChannel.Email,
+        target: request.body.email,
+        metadata: { transport: 'fastify', route: 'contact-email-start' },
+      })
+
+      return reply.status(202).send({
+        verificationId: challenge.verificationId,
+        delivery: challenge.delivery,
+        expiresAt: challenge.expiresAt.toISOString(),
+      })
+    },
+  )
+
+  app.post<{
+    Body: {
+      verificationId: string
+      code: string
+    }
+  }>(
+    '/account/contact/email/finish',
+    {
+      preHandler: [sessionPreHandler, requireFastifySession],
+      schema: {
+        body: {
+          type: 'object',
+          required: ['verificationId', 'code'],
+          properties: {
+            verificationId: { type: 'string', minLength: 1 },
+            code: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const auth = request.auth
+
+      if (!auth) {
+        return reply.status(401).send({ error: AUTHENTICATION_REQUIRED_MESSAGE })
+      }
+
+      const user = await authService.finishCurrentAccountContactChange({
+        sessionToken: auth.sessionToken,
+        verificationId: parseVerificationId(request.body.verificationId),
+        secret: request.body.code,
+        metadata: { transport: 'fastify', route: 'contact-email-finish' },
+      })
+
+      return reply.status(200).send({
+        user: {
+          id: user.id,
+          email: user.email ?? null,
+          phone: user.phone ?? null,
+          displayName: user.displayName ?? null,
+        },
+        updatedAt: user.updatedAt.toISOString(),
+      })
+    },
+  )
+
   app.setErrorHandler((error, _request, reply) => {
     if (isFastifyPublicRequestError(error)) {
       reply.status(400).send({ error: REQUEST_CANNOT_BE_COMPLETED_MESSAGE })
@@ -233,6 +319,8 @@ export async function runFastifyAuthExample(): Promise<void> {
           'POST /auth/otp/finish',
           'GET /me',
           'GET /account/security',
+          'POST /account/contact/email/start',
+          'POST /account/contact/email/finish',
         ],
         note: 'OTP codes are printed by the application-owned email sender.',
       },

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -35,10 +35,12 @@ describe('package exports', () => {
     expect(bridges.mapBetterAuthOAuthToAssertion).toBeTypeOf('function')
     expect(core.AuditEventType.SignIn).toBe('auth.sign_in')
     expect(core.AuditEventType.AccountProfileUpdated).toBe('auth.account_profile_updated')
+    expect(core.AuditEventType.AccountContactUpdated).toBe('auth.account_contact_updated')
     expect(core.AuditEventType.VerificationCancelled).toBe('auth.verification_cancelled')
     expect(core.CredentialType.Password).toBe('password')
     expect(core.AuthPolicyAction.ChangePassword).toBe('changePassword')
     expect(core.AuthPolicyAction.UpdateProfile).toBe('updateProfile')
+    expect(core.AuthPolicyAction.UpdateContact).toBe('updateContact')
     expect(core.DefaultAuthService).toBeTypeOf('function')
     expect(core.EMAIL_MAGIC_LINK_PROVIDER_ID).toBe('email-magic-link')
     expect(core.EMAIL_OTP_PROVIDER_ID).toBe('email-otp')
@@ -46,6 +48,7 @@ describe('package exports', () => {
     expect(core.OtpChannel.Phone).toBe('phone')
     expect(core.PASSWORD_PROVIDER_ID).toBe('password')
     expect(core.PHONE_OTP_PROVIDER_ID).toBe('phone-otp')
+    expect(core.VerificationPurpose.ContactChange).toBe('contact-change')
     expect(core.RateLimitAction.ProviderSignIn).toBe('provider:sign-in')
     expect(core.RateLimitAction.OtpResend).toBe('otp:resend')
     expect(core.RateLimitAction.MagicLinkResend).toBe('magic-link:resend')
@@ -106,6 +109,18 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.revokeOtherSessionsByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.unlinkCurrentIdentityByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.updateCurrentAccountProfileByToken).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.startCurrentAccountContactChange).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.resendCurrentAccountContactChange).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.cancelCurrentAccountContactChange).toBeTypeOf(
+      'function',
+    )
+    expect(core.DefaultAuthService.prototype.finishCurrentAccountContactChange).toBeTypeOf(
       'function',
     )
     expect(core.DefaultAuthService.prototype.setCurrentAccountPasswordByToken).toBeTypeOf(
@@ -227,6 +242,10 @@ describe('package exports', () => {
     expect(flowDeclarations).toContain('export interface LinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UnlinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UpdateCurrentAccountProfileByTokenInput')
+    expect(flowDeclarations).toContain('export interface StartCurrentAccountContactChangeInput')
+    expect(flowDeclarations).toContain('export interface ResendCurrentAccountContactChangeInput')
+    expect(flowDeclarations).toContain('export interface CancelCurrentAccountContactChangeInput')
+    expect(flowDeclarations).toContain('export interface FinishCurrentAccountContactChangeInput')
     expect(flowDeclarations).toContain('export interface RevokeOwnedSessionByTokenResult')
     expect(flowDeclarations).toContain('export interface RevokeOtherSessionsByTokenResult')
     expect(serviceDeclarations).toContain(
@@ -282,6 +301,18 @@ describe('package exports', () => {
     )
     expect(serviceDeclarations).toContain(
       'updateCurrentAccountProfileByToken(input: UpdateCurrentAccountProfileByTokenInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'startCurrentAccountContactChange(input: StartCurrentAccountContactChangeInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'resendCurrentAccountContactChange(input: ResendCurrentAccountContactChangeInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'cancelCurrentAccountContactChange(input: CancelCurrentAccountContactChangeInput)',
+    )
+    expect(serviceDeclarations).toContain(
+      'finishCurrentAccountContactChange(input: FinishCurrentAccountContactChangeInput)',
     )
     expect(serviceDeclarations).toContain(
       'setCurrentAccountPasswordByToken(input: SetCurrentAccountPasswordByTokenInput)',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -23,6 +23,12 @@ import {
   updateCurrentAccountProfileByToken,
 } from './current-account-actions.js'
 import {
+  cancelCurrentAccountContactChange,
+  finishCurrentAccountContactChange,
+  resendCurrentAccountContactChange,
+  startCurrentAccountContactChange,
+} from './current-account-contact-change.js'
+import {
   assertCurrentAccountReAuth,
   cancelCurrentAccountOtpReAuth,
   getCurrentAccountReAuthStatus,
@@ -82,6 +88,7 @@ import type {
   AssertCurrentAccountReAuthInput,
   AuthResult,
   AuthService,
+  CancelCurrentAccountContactChangeInput,
   CurrentAccountClosureExportSnapshot,
   CurrentAccountInspectionSnapshot,
   CurrentAccountReAuthAssertion,
@@ -101,6 +108,7 @@ import type {
   CreateSessionResult,
   CreateVerificationInput,
   CreateVerificationResult,
+  FinishCurrentAccountContactChangeInput,
   FinishEmailMagicLinkSignInInput,
   FinishEmailPasswordRecoveryInput,
   FinishOtpChallengeInput,
@@ -127,6 +135,7 @@ import type {
   RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
+  ResendCurrentAccountContactChangeInput,
   ResendCurrentAccountOtpReAuthInput,
   ResendOtpChallengeInput,
   ResolveSessionContextInput,
@@ -138,6 +147,7 @@ import type {
   SetCurrentAccountPasswordByTokenInput,
   SignInInput,
   SignInWithPasswordInput,
+  StartCurrentAccountContactChangeInput,
   StartCurrentAccountOtpReAuthInput,
   StartEmailMagicLinkSignInInput,
   StartEmailMagicLinkSignInResult,
@@ -360,6 +370,30 @@ export class DefaultAuthService implements AuthService {
     input: UpdateCurrentAccountProfileByTokenInput,
   ): Promise<User> {
     return updateCurrentAccountProfileByToken(this.runtime, input)
+  }
+
+  async startCurrentAccountContactChange(
+    input: StartCurrentAccountContactChangeInput,
+  ): Promise<StartOtpChallengeResult> {
+    return startCurrentAccountContactChange(this.runtime, input)
+  }
+
+  async resendCurrentAccountContactChange(
+    input: ResendCurrentAccountContactChangeInput,
+  ): Promise<StartOtpChallengeResult> {
+    return resendCurrentAccountContactChange(this.runtime, input)
+  }
+
+  async cancelCurrentAccountContactChange(
+    input: CancelCurrentAccountContactChangeInput,
+  ): Promise<Verification> {
+    return cancelCurrentAccountContactChange(this.runtime, input)
+  }
+
+  async finishCurrentAccountContactChange(
+    input: FinishCurrentAccountContactChangeInput,
+  ): Promise<User> {
+    return finishCurrentAccountContactChange(this.runtime, input)
   }
 
   async setCurrentAccountPasswordByToken(

--- a/src/application/current-account-contact-change.ts
+++ b/src/application/current-account-contact-change.ts
@@ -1,0 +1,296 @@
+import { optionalProp } from './optional.js'
+import { normalizeOtpTarget, type SupportedOtpChannel } from './otp-delivery.js'
+import {
+  cancelOtpChallenge,
+  enforceOtpFinishRateLimit,
+  findOtpChallengeRecord,
+  resendOtpChallenge,
+  startOtpChallenge,
+} from './otp.js'
+import type { AuthServiceRuntime } from './runtime.js'
+import { resolveSessionContext } from './session-context.js'
+import { audit, ensureReAuth } from './support.js'
+import { consumeVerificationRecord } from './verifications.js'
+import type {
+  CancelCurrentAccountContactChangeInput,
+  FinishCurrentAccountContactChangeInput,
+  OtpChannel as OtpChannelType,
+  ResendCurrentAccountContactChangeInput,
+  SessionId,
+  StartCurrentAccountContactChangeInput,
+  StartOtpChallengeResult,
+  User,
+  UserId,
+  Verification,
+} from '../domain/types.js'
+import {
+  AuditEventType,
+  AuthPolicyAction,
+  OtpChannel,
+  VerificationPurpose,
+} from '../domain/types.js'
+import { UniAuthError, UniAuthErrorCode, invalidInput, isUniAuthError } from '../errors.js'
+
+const CurrentAccountContactField = {
+  Email: 'email',
+  Phone: 'phone',
+} as const
+
+const CURRENT_ACCOUNT_CONTACT_CHANGE_METADATA_KEY = 'currentAccountContactChange'
+
+interface CurrentAccountContactChangeMetadata {
+  readonly userId: string
+  readonly sessionId: string
+  readonly channel: SupportedOtpChannel
+}
+
+export async function startCurrentAccountContactChange(
+  runtime: AuthServiceRuntime,
+  input: StartCurrentAccountContactChangeInput,
+): Promise<StartOtpChallengeResult> {
+  const now = input.now ?? runtime.clock.now()
+  const { session, user } = await resolveSessionContext(runtime, {
+    sessionToken: input.sessionToken,
+    now,
+  })
+
+  await ensureReAuth(runtime, AuthPolicyAction.UpdateContact, user.id, input.reAuthenticatedAt, now)
+  const target = normalizeCurrentAccountContactTarget(runtime, input.channel, input.target)
+
+  rejectUnchangedContact(user, input.channel, target)
+
+  return startOtpChallenge(runtime, {
+    purpose: VerificationPurpose.ContactChange,
+    channel: input.channel,
+    target,
+    ...optionalProp('secret', input.secret),
+    ...optionalProp('ttlSeconds', input.ttlSeconds),
+    now,
+    metadata: buildCurrentAccountContactChangeMetadata(
+      user.id,
+      session.id,
+      input.channel,
+      input.metadata,
+    ),
+  })
+}
+
+export async function resendCurrentAccountContactChange(
+  runtime: AuthServiceRuntime,
+  input: ResendCurrentAccountContactChangeInput,
+): Promise<StartOtpChallengeResult> {
+  const { actor, challenge } = await resolveCurrentAccountOwnedContactChangeChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+
+  return resendOtpChallenge(runtime, {
+    verificationId: challenge.verification.id,
+    ...optionalProp('secret', input.secret),
+    ...optionalProp('ttlSeconds', input.ttlSeconds),
+    now: actor.now,
+    metadata: buildCurrentAccountContactChangeMetadata(
+      actor.userId,
+      actor.sessionId,
+      challenge.channel,
+      input.metadata,
+    ),
+  })
+}
+
+export async function cancelCurrentAccountContactChange(
+  runtime: AuthServiceRuntime,
+  input: CancelCurrentAccountContactChangeInput,
+): Promise<Verification> {
+  const { actor, challenge } = await resolveCurrentAccountOwnedContactChangeChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+
+  return cancelOtpChallenge(runtime, {
+    verificationId: challenge.verification.id,
+    purpose: VerificationPurpose.ContactChange,
+    channel: challenge.channel,
+    now: actor.now,
+    metadata: buildCurrentAccountContactChangeMetadata(
+      actor.userId,
+      actor.sessionId,
+      challenge.channel,
+      input.metadata,
+    ),
+  })
+}
+
+export async function finishCurrentAccountContactChange(
+  runtime: AuthServiceRuntime,
+  input: FinishCurrentAccountContactChangeInput,
+): Promise<User> {
+  const resolved = await resolveCurrentAccountOwnedContactChangeChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+  await enforceOtpFinishRateLimit(runtime, resolved.challenge, resolved.actor.now)
+
+  return runtime.transaction.run(async () => {
+    const { actor, challenge } = await resolveCurrentAccountOwnedContactChangeChallenge(
+      runtime,
+      input.sessionToken,
+      input.verificationId,
+      resolved.actor.now,
+    )
+    const consumed = await consumeVerificationRecord(runtime, {
+      verificationId: challenge.verification.id,
+      secret: input.secret,
+      now: actor.now,
+    })
+    const updated = await runtime.repos.userRepo.update(actor.userId, {
+      [contactFieldFromChannel(challenge.channel)]: consumed.target,
+      updatedAt: actor.now,
+    })
+
+    await audit(runtime, AuditEventType.AccountContactUpdated, actor.now, {
+      userId: actor.userId,
+      sessionId: actor.sessionId,
+      metadata: {
+        verificationId: consumed.id,
+        channel: challenge.channel,
+        changedFields: [contactFieldFromChannel(challenge.channel)],
+        ...optionalProp('requestMetadata', input.metadata),
+      },
+    })
+
+    return updated
+  })
+}
+
+function normalizeCurrentAccountContactTarget(
+  runtime: Pick<AuthServiceRuntime, 'normalizer'>,
+  channel: OtpChannelType,
+  target: string,
+): string {
+  if (channel !== OtpChannel.Email && channel !== OtpChannel.Phone) {
+    throw invalidInput('Current account contact change channel is not supported.')
+  }
+
+  return normalizeOtpTarget(runtime, channel, target)
+}
+
+function rejectUnchangedContact(user: User, channel: OtpChannelType, target: string): void {
+  if (channel === OtpChannel.Email && user.email === target) {
+    throw invalidInput('Current account email already matches the requested target.')
+  }
+
+  if (channel === OtpChannel.Phone && user.phone === target) {
+    throw invalidInput('Current account phone already matches the requested target.')
+  }
+}
+
+function buildCurrentAccountContactChangeMetadata(
+  userId: UserId,
+  sessionId: SessionId,
+  channel: SupportedOtpChannel,
+  requestMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return {
+    [CURRENT_ACCOUNT_CONTACT_CHANGE_METADATA_KEY]: {
+      userId,
+      sessionId,
+      channel,
+    },
+    ...optionalProp('requestMetadata', requestMetadata),
+  }
+}
+
+async function resolveCurrentAccountOwnedContactChangeChallenge(
+  runtime: AuthServiceRuntime,
+  sessionToken: string,
+  verificationId: Verification['id'],
+  now: Date | undefined,
+): Promise<{
+  readonly actor: { readonly now: Date; readonly sessionId: SessionId; readonly userId: UserId }
+  readonly challenge: {
+    readonly verification: Verification
+    readonly channel: SupportedOtpChannel
+  }
+}> {
+  const resolvedNow = now ?? runtime.clock.now()
+  const { session, user } = await resolveSessionContext(runtime, {
+    sessionToken,
+    now: resolvedNow,
+  })
+  const challenge = await getCurrentAccountContactChangeChallenge(runtime, verificationId)
+  const metadata = readCurrentAccountContactChangeMetadata(challenge.verification.metadata)
+
+  if (!metadata || metadata.userId !== user.id || metadata.channel !== challenge.channel) {
+    throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+  }
+
+  return {
+    actor: { now: resolvedNow, sessionId: session.id, userId: user.id },
+    challenge,
+  }
+}
+
+async function getCurrentAccountContactChangeChallenge(
+  runtime: AuthServiceRuntime,
+  verificationId: Verification['id'],
+): Promise<{
+  readonly verification: Verification
+  readonly channel: SupportedOtpChannel
+}> {
+  try {
+    return await findOtpChallengeRecord(runtime, {
+      verificationId,
+      purpose: VerificationPurpose.ContactChange,
+      context: 'current-account contact change',
+    })
+  } catch (error) {
+    if (
+      isUniAuthError(error) &&
+      (error.code === UniAuthErrorCode.VerificationNotFound ||
+        error.code === UniAuthErrorCode.InvalidInput)
+    ) {
+      throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+    }
+
+    throw error
+  }
+}
+
+function readCurrentAccountContactChangeMetadata(
+  metadata: Record<string, unknown> | undefined,
+): CurrentAccountContactChangeMetadata | undefined {
+  const raw = metadata?.[CURRENT_ACCOUNT_CONTACT_CHANGE_METADATA_KEY]
+
+  if (!raw || typeof raw !== 'object') {
+    return undefined
+  }
+
+  const candidate = raw as Partial<CurrentAccountContactChangeMetadata>
+
+  if (
+    typeof candidate.userId !== 'string' ||
+    typeof candidate.sessionId !== 'string' ||
+    (candidate.channel !== OtpChannel.Email && candidate.channel !== OtpChannel.Phone)
+  ) {
+    return undefined
+  }
+
+  return {
+    userId: candidate.userId,
+    sessionId: candidate.sessionId,
+    channel: candidate.channel,
+  }
+}
+
+function contactFieldFromChannel(channel: SupportedOtpChannel): 'email' | 'phone' {
+  return channel === OtpChannel.Email
+    ? CurrentAccountContactField.Email
+    : CurrentAccountContactField.Phone
+}

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -255,7 +255,7 @@ export async function findOtpChallengeRecord(
   return { verification, channel }
 }
 
-async function enforceOtpFinishRateLimit(
+export async function enforceOtpFinishRateLimit(
   runtime: AuthServiceRuntime,
   challenge: { readonly verification: Verification; readonly channel: SupportedOtpChannel },
   now: Date,

--- a/src/domain/audit.ts
+++ b/src/domain/audit.ts
@@ -7,6 +7,7 @@ export const AuditEventType = {
   AccountsMerged: 'auth.accounts_merged',
   AccountClosed: 'auth.account_closed',
   AccountProfileUpdated: 'auth.account_profile_updated',
+  AccountContactUpdated: 'auth.account_contact_updated',
   SessionCreated: 'auth.session_created',
   SessionRevoked: 'auth.session_revoked',
   VerificationCreated: 'auth.verification_created',

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -267,6 +267,41 @@ export interface UpdateCurrentAccountProfileByTokenInput {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface StartCurrentAccountContactChangeInput {
+  readonly sessionToken: string
+  readonly channel: OtpChannel
+  readonly target: string
+  readonly secret?: string
+  readonly ttlSeconds?: number
+  readonly reAuthenticatedAt?: Date
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface ResendCurrentAccountContactChangeInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly secret?: string
+  readonly ttlSeconds?: number
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface CancelCurrentAccountContactChangeInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
+export interface FinishCurrentAccountContactChangeInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly secret: string
+  readonly now?: Date
+  readonly metadata?: Record<string, unknown>
+}
+
 export interface RevokeUserSessionsInput {
   readonly userId: UserId
   readonly exceptSessionId?: SessionId

--- a/src/domain/kinds.ts
+++ b/src/domain/kinds.ts
@@ -11,6 +11,7 @@ export const VerificationPurpose = {
   SignIn: 'sign-in',
   Link: 'link',
   ReAuth: 're-auth',
+  ContactChange: 'contact-change',
   Recovery: 'recovery',
 } as const
 

--- a/src/domain/policy.ts
+++ b/src/domain/policy.ts
@@ -6,6 +6,7 @@ export const AuthPolicyAction = {
   SetPassword: 'setPassword',
   ChangePassword: 'changePassword',
   UpdateProfile: 'updateProfile',
+  UpdateContact: 'updateContact',
   CloseAccount: 'closeAccount',
 } as const
 

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -11,6 +11,7 @@ import type { AuditEvent, AuditEventPage, AuditEventQuery } from './audit.js'
 import type {
   AuthResult,
   AssertCurrentAccountReAuthInput,
+  CancelCurrentAccountContactChangeInput,
   GetCurrentAccountClosureExportSnapshotInput,
   GetCurrentAccountSecuritySnapshotInput,
   GetCurrentAccountReAuthStatusInput,
@@ -23,6 +24,7 @@ import type {
   CreateSessionResult,
   CreateVerificationInput,
   CreateVerificationResult,
+  FinishCurrentAccountContactChangeInput,
   FinishOtpChallengeInput,
   FinishOtpSignInInput,
   GetAccountInspectionSnapshotInput,
@@ -46,11 +48,13 @@ import type {
   RevokeOtherSessionsByTokenResult,
   RevokeUserSessionsInput,
   RevokeUserSessionsResult,
+  ResendCurrentAccountContactChangeInput,
   ResendOtpChallengeInput,
   ResolveSessionContextInput,
   ResolveSessionInput,
   ResolvedSessionContext,
   SignInInput,
+  StartCurrentAccountContactChangeInput,
   StartOtpChallengeInput,
   StartOtpChallengeResult,
   TouchSessionInput,
@@ -148,6 +152,16 @@ export interface AuthService {
     input: CloseCurrentAccountByTokenInput,
   ): Promise<CloseCurrentAccountByTokenResult>
   updateCurrentAccountProfileByToken(input: UpdateCurrentAccountProfileByTokenInput): Promise<User>
+  startCurrentAccountContactChange(
+    input: StartCurrentAccountContactChangeInput,
+  ): Promise<StartOtpChallengeResult>
+  resendCurrentAccountContactChange(
+    input: ResendCurrentAccountContactChangeInput,
+  ): Promise<StartOtpChallengeResult>
+  cancelCurrentAccountContactChange(
+    input: CancelCurrentAccountContactChangeInput,
+  ): Promise<Verification>
+  finishCurrentAccountContactChange(input: FinishCurrentAccountContactChangeInput): Promise<User>
   setCurrentAccountPasswordByToken(
     input: SetCurrentAccountPasswordByTokenInput,
   ): Promise<Credential>

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   AuditEventType,
   AuthPolicyAction,
+  OtpChannel,
   PASSWORD_PROVIDER_ID,
   UniAuthErrorCode,
+  VerificationPurpose,
   addSeconds,
   createDefaultAuthPolicy,
 } from '../../src'
@@ -221,6 +223,314 @@ describe('DefaultAuthService current-account action helpers', () => {
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
     })
+  })
+
+  it('starts, resends, and finishes current-account email changes by trusted session token', async () => {
+    const { service, emailSender } = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.UpdateContact],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-email-change',
+        email: 'old-current-account-email-change@example.com',
+        emailVerified: true,
+        phone: '+15550000003',
+        phoneVerified: true,
+      }),
+      now,
+    })
+    const originalIdentities = await service.getUserIdentities(signedIn.user.id)
+
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: OtpChannel.Email,
+        target: 'new-current-account-email-change@example.com',
+        secret: '111111',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    const first = await service.startCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      channel: OtpChannel.Email,
+      target: ' New-Current-Account-Email-Change@Example.COM ',
+      secret: '111111',
+      reAuthenticatedAt: addSeconds(now, 20),
+      now: addSeconds(now, 20),
+      metadata: { source: 'settings' },
+    })
+    const resent = await service.resendCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      verificationId: first.verificationId,
+      secret: '222222',
+      now: addSeconds(now, 30),
+      metadata: { source: 'settings-resend' },
+    })
+
+    expect(emailSender.listMessages()).toEqual([
+      expect.objectContaining({
+        to: 'new-current-account-email-change@example.com',
+        metadata: expect.objectContaining({
+          purpose: VerificationPurpose.ContactChange,
+          delivery: OtpChannel.Email,
+        }),
+      }),
+      expect.objectContaining({
+        to: 'new-current-account-email-change@example.com',
+        metadata: expect.objectContaining({
+          purpose: VerificationPurpose.ContactChange,
+          delivery: OtpChannel.Email,
+        }),
+      }),
+    ])
+    await expect(
+      service.finishCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        verificationId: first.verificationId,
+        secret: '111111',
+        now: addSeconds(now, 35),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
+    })
+
+    const updated = await service.finishCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      verificationId: resent.verificationId,
+      secret: '222222',
+      now: addSeconds(now, 40),
+      metadata: { source: 'settings-finish' },
+    })
+
+    expect(updated).toMatchObject({
+      id: signedIn.user.id,
+      email: 'new-current-account-email-change@example.com',
+      phone: '+15550000003',
+      updatedAt: addSeconds(now, 40),
+    })
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(originalIdentities)
+    await expect(service.getAuditEvents({ userId: signedIn.user.id })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.AccountContactUpdated,
+          sessionId: signedIn.session.id,
+          metadata: {
+            verificationId: resent.verificationId,
+            channel: OtpChannel.Email,
+            changedFields: ['email'],
+            requestMetadata: { source: 'settings-finish' },
+          },
+        }),
+      ]),
+    )
+  })
+
+  it('keeps current-account contact change ownership neutral and supports cancellation', async () => {
+    const { service } = createInMemoryAuthKit()
+    const alice = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-owner',
+        email: 'current-account-contact-change-owner@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const bob = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-foreign',
+        email: 'current-account-contact-change-foreign@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 1),
+    })
+    const started = await service.startCurrentAccountContactChange({
+      sessionToken: alice.sessionToken,
+      channel: OtpChannel.Phone,
+      target: '+1 (555) 000-0004',
+      secret: '333333',
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.finishCurrentAccountContactChange({
+        sessionToken: bob.sessionToken,
+        verificationId: started.verificationId,
+        secret: '333333',
+        now: addSeconds(now, 6),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await service.cancelCurrentAccountContactChange({
+      sessionToken: alice.sessionToken,
+      verificationId: started.verificationId,
+      now: addSeconds(now, 7),
+      metadata: { source: 'settings-cancel' },
+    })
+    await expect(
+      service.finishCurrentAccountContactChange({
+        sessionToken: alice.sessionToken,
+        verificationId: started.verificationId,
+        secret: '333333',
+        now: addSeconds(now, 8),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
+    })
+  })
+
+  it('rejects invalid current-account contact change inputs before delivery', async () => {
+    const { service, emailSender, smsSender } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-invalid-inputs',
+        email: 'current-account-contact-change-invalid-inputs@example.com',
+        emailVerified: true,
+        phone: '+15550000006',
+        phoneVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: 'push' as OtpChannel,
+        target: 'new@example.com',
+        now: addSeconds(now, 5),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: OtpChannel.Email,
+        target: ' CURRENT-ACCOUNT-CONTACT-CHANGE-INVALID-INPUTS@example.com ',
+        now: addSeconds(now, 6),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: OtpChannel.Phone,
+        target: '+1 (555) 000-0006',
+        now: addSeconds(now, 7),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
+    expect(emailSender.listMessages()).toHaveLength(0)
+    expect(smsSender.listMessages()).toHaveLength(0)
+  })
+
+  it('keeps malformed current-account contact change verification ownership neutral', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-malformed-metadata',
+        email: 'current-account-contact-change-malformed-metadata@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const missingMetadata = await service.startOtpChallenge({
+      purpose: VerificationPurpose.ContactChange,
+      channel: OtpChannel.Email,
+      target: 'missing-metadata@example.com',
+      secret: '444444',
+      now: addSeconds(now, 5),
+    })
+    const invalidMetadata = await service.startOtpChallenge({
+      purpose: VerificationPurpose.ContactChange,
+      channel: OtpChannel.Email,
+      target: 'invalid-metadata@example.com',
+      secret: '555555',
+      now: addSeconds(now, 6),
+      metadata: {
+        currentAccountContactChange: {
+          userId: 1,
+          sessionId: signedIn.session.id,
+          channel: OtpChannel.Email,
+        },
+      },
+    })
+
+    for (const verificationId of [missingMetadata.verificationId, invalidMetadata.verificationId]) {
+      await expect(
+        service.finishCurrentAccountContactChange({
+          sessionToken: signedIn.sessionToken,
+          verificationId,
+          secret: '444444',
+          now: addSeconds(now, 10),
+        }),
+      ).rejects.toMatchObject({
+        code: UniAuthErrorCode.VerificationNotFound,
+      })
+    }
+  })
+
+  it('keeps non-contact verifications and adapter lookup failures on their expected paths', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-wrong-verification',
+        email: 'current-account-contact-change-wrong-verification@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+    const signInChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'current-account-contact-change-wrong-verification@example.com',
+      secret: '666666',
+      now: addSeconds(now, 5),
+    })
+
+    await expect(
+      service.finishCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        verificationId: signInChallenge.verificationId,
+        secret: '666666',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+    await expect(
+      service.cancelCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        verificationId: 'missing-contact-change' as typeof signInChallenge.verificationId,
+        now: addSeconds(now, 11),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    const originalFindById = store.verificationRepo.findById
+    store.verificationRepo.findById = async () => {
+      throw new Error('verification lookup failed')
+    }
+
+    await expect(
+      service.resendCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        verificationId: signInChallenge.verificationId,
+        now: addSeconds(now, 12),
+      }),
+    ).rejects.toThrow('verification lookup failed')
+
+    store.verificationRepo.findById = originalFindById
   })
 
   it('keeps expired and revoked current-account profile update contexts neutral', async () => {
@@ -615,6 +925,7 @@ describe('DefaultAuthService current-account action helpers', () => {
           AuthPolicyAction.Unlink,
           AuthPolicyAction.SetPassword,
           AuthPolicyAction.ChangePassword,
+          AuthPolicyAction.UpdateContact,
         ],
       }),
     })
@@ -649,6 +960,20 @@ describe('DefaultAuthService current-account action helpers', () => {
       reAuthenticatedAt: now,
       metadata: { source: 'current-account-change' },
     })
+    const contactChange = await service.startCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      channel: OtpChannel.Email,
+      target: 'current-account-actions-no-now-new@example.com',
+      secret: '123456',
+      reAuthenticatedAt: now,
+      metadata: { source: 'current-account-contact-start' },
+    })
+    const updatedContact = await service.finishCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      verificationId: contactChange.verificationId,
+      secret: '123456',
+      metadata: { source: 'current-account-contact-finish' },
+    })
 
     await service.unlinkCurrentIdentityByToken({
       sessionToken: signedIn.sessionToken,
@@ -659,6 +984,11 @@ describe('DefaultAuthService current-account action helpers', () => {
 
     expect(created.metadata).toEqual({ source: 'current-account-set' })
     expect(changed.metadata).toEqual({ source: 'current-account-change' })
+    expect(updatedContact).toMatchObject({
+      id: signedIn.user.id,
+      email: 'current-account-actions-no-now-new@example.com',
+      updatedAt: now,
+    })
     await expect(
       service.signInWithPassword({
         email: 'current-account-actions-no-now@example.com',

--- a/test/postgres/current-account-actions.test.ts
+++ b/test/postgres/current-account-actions.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   AuditEventType,
   AuthPolicyAction,
+  OtpChannel,
   SessionStatus,
   UniAuthErrorCode,
+  VerificationPurpose,
   addSeconds,
   createDefaultAuthPolicy,
 } from '../../src'
@@ -230,6 +232,86 @@ describe('Postgres current-account action helpers', () => {
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
     })
+  })
+
+  it('finishes Postgres current-account phone changes by trusted session token', async () => {
+    const { service, smsSender } = await createPostgresTestKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.UpdateContact],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: {
+        provider: 'email',
+        providerUserId: 'pg-current-account-contact-change',
+        email: 'pg-current-account-contact-change@example.com',
+        emailVerified: true,
+      },
+      now,
+    })
+    const originalIdentities = await service.getUserIdentities(signedIn.user.id)
+
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: OtpChannel.Phone,
+        target: '+1 (555) 000-0005',
+        secret: '444444',
+        now: addSeconds(now, 10),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.ReAuthRequired,
+    })
+
+    const started = await service.startCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      channel: OtpChannel.Phone,
+      target: '+1 (555) 000-0005',
+      secret: '444444',
+      reAuthenticatedAt: addSeconds(now, 20),
+      now: addSeconds(now, 20),
+      metadata: { source: 'settings' },
+    })
+
+    expect(smsSender.listMessages()).toEqual([
+      expect.objectContaining({
+        to: '+15550000005',
+        metadata: expect.objectContaining({
+          purpose: VerificationPurpose.ContactChange,
+          delivery: OtpChannel.Phone,
+        }),
+      }),
+    ])
+
+    const updated = await service.finishCurrentAccountContactChange({
+      sessionToken: signedIn.sessionToken,
+      verificationId: started.verificationId,
+      secret: '444444',
+      now: addSeconds(now, 30),
+      metadata: { source: 'settings-finish' },
+    })
+
+    expect(updated).toMatchObject({
+      id: signedIn.user.id,
+      email: 'pg-current-account-contact-change@example.com',
+      phone: '+15550000005',
+      updatedAt: addSeconds(now, 30),
+    })
+    expect(await service.getUserIdentities(signedIn.user.id)).toEqual(originalIdentities)
+    await expect(service.getAuditEvents({ userId: signedIn.user.id })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.AccountContactUpdated,
+          sessionId: signedIn.session.id,
+          metadata: {
+            verificationId: started.verificationId,
+            channel: OtpChannel.Phone,
+            changedFields: ['phone'],
+            requestMetadata: { source: 'settings-finish' },
+          },
+        }),
+      ]),
+    )
   })
 
   it('keeps expired and revoked Postgres current-account profile update contexts neutral', async () => {


### PR DESCRIPTION
## Summary
- add current-account verified contact change flow
- document account security and backend recipes for contact updates
- add examples, smoke coverage, core tests, and postgres coverage

## Verification
- npm run check