### PR TITLE
Harden verification flows and package checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,7 @@ flowchart TB
 
 Install from GitHub Packages:
 
-```sh
-npm install @alyldas/uniauth
-```
-
-Configure the GitHub Packages registry for the package scope:
+Configure the GitHub Packages registry for the package scope before installing:
 
 ```text
 @alyldas:registry=https://npm.pkg.github.com
@@ -159,6 +155,10 @@ Configure the GitHub Packages registry for the package scope:
 
 GitHub Packages can require authentication for package reads. Use a token with `read:packages` in
 local npm config or CI secrets; do not commit tokens.
+
+```sh
+npm install @alyldas/uniauth
+```
 
 ## Runtime Contract
 
@@ -670,6 +670,9 @@ storage, or framework callback routing.
 
 - `@alyldas/uniauth`: public domain types, service implementation, policy API, ports, errors, and utilities.
 - `@alyldas/uniauth/bridges`: optional Better Auth and Auth.js assertion mapping helpers.
+- `@alyldas/uniauth/providers/messenger`: Telegram Mini App and MAX WebApp provider helpers.
+- `@alyldas/uniauth/providers/oauth-oidc`: SDK-free OAuth/OIDC provider helpers and token
+  persistence helpers.
 - `@alyldas/uniauth/postgres`: reference Postgres repositories, schema helper, and transaction wiring.
 - `@alyldas/uniauth/testing`: in-memory store, provider registry, static provider, in-memory email
   and SMS senders, and test kit.
@@ -773,10 +776,9 @@ The gate runs formatting, ESLint, typecheck, 100% coverage, export smoke tests, 
 package type-resolution checks, dependency audit with `npm audit --audit-level=moderate`, and
 `npm pack --dry-run`.
 
-The release workflow follows the same Release Please model as `theme-mode`: pushes to `main` update
-a release PR, and merging that PR creates the `v*` tag, GitHub release notes, and GitHub Packages
-publish. This repository uses the `RELEASE_PLEASE_TOKEN` secret for release PR automation and
-`GITHUB_TOKEN` for package publishing.
+The release workflow uses Release Please: pushes to `main` update a release PR, and merging that PR
+creates the `v*` tag, GitHub release notes, and GitHub Packages publish. This repository uses the
+`RELEASE_PLEASE_TOKEN` secret for release PR automation and `GITHUB_TOKEN` for package publishing.
 
 Normal feature, fix, refactor, docs, and test commits do not manually change release metadata.
 Release Please owns these files in its release PR:

--- a/examples/fastify-auth/index.ts
+++ b/examples/fastify-auth/index.ts
@@ -8,6 +8,7 @@ import {
   UniAuthErrorCode,
   VerificationPurpose,
   createDefaultAuthPolicy,
+  invalidInput,
   isUniAuthError,
   type Session,
   type User,
@@ -331,7 +332,13 @@ export async function runFastifyAuthExample(): Promise<void> {
 }
 
 function parseVerificationId(value: string): VerificationId {
-  return value.trim() as VerificationId
+  const verificationId = value.trim()
+
+  if (!verificationId) {
+    throw invalidInput('verificationId is required.')
+  }
+
+  return verificationId as VerificationId
 }
 
 function createFastifySessionPreHandler(

--- a/examples/oauth-oidc/index.ts
+++ b/examples/oauth-oidc/index.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { DefaultAuthService } from '@alyldas/uniauth'
+import { DefaultAuthService, invalidInput } from '@alyldas/uniauth'
 import {
   OAuthOidcTokenBindingKind,
   createOAuthOidcTokenRecord,
@@ -22,15 +22,8 @@ import {
 } from '../shared/session-cookie.js'
 
 interface CallbackRequest {
-  readonly query: {
-    readonly code: string
-    readonly state: string
-  }
-  readonly cookies: {
-    readonly oidcState: string
-    readonly oidcCodeVerifier: string
-    readonly oidcRedirectUri: string
-  }
+  readonly query: Record<string, unknown>
+  readonly cookies: Record<string, unknown>
 }
 
 interface SessionCookie {
@@ -175,9 +168,25 @@ const authService = new DefaultAuthService({
   rateLimiter: new InMemoryRateLimiter(),
 })
 
+function readRequiredString(input: Record<string, unknown>, key: string): string {
+  const value = input[key]
+
+  if (typeof value !== 'string') {
+    throw invalidInput(`${key} is required.`)
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    throw invalidInput(`${key} is required.`)
+  }
+
+  return trimmed
+}
+
 function assertStateMatches(expected: string, received: string): void {
   if (expected !== received) {
-    throw new Error('OAuth state mismatch.')
+    throw invalidInput('OAuth state mismatch.')
   }
 }
 
@@ -201,25 +210,33 @@ function clearCookie(name: string): ClearedCookie {
   }
 }
 
-async function finishOidcCallback(request: CallbackRequest): Promise<RedirectResponse> {
+export async function finishOidcCallbackForExample(
+  request: CallbackRequest,
+): Promise<RedirectResponse> {
   // State, PKCE, and redirect URI storage stay application-owned.
-  assertStateMatches(request.cookies.oidcState, request.query.state)
+  const code = readRequiredString(request.query, 'code')
+  const state = readRequiredString(request.query, 'state')
+  const oidcState = readRequiredString(request.cookies, 'oidcState')
+  const oidcCodeVerifier = readRequiredString(request.cookies, 'oidcCodeVerifier')
+  const oidcRedirectUri = readRequiredString(request.cookies, 'oidcRedirectUri')
+
+  assertStateMatches(oidcState, state)
 
   const result = await authService.signIn({
     provider: 'demo-oidc',
     finishInput: {
-      code: request.query.code,
-      state: request.query.state,
+      code,
+      state,
       payload: {
-        redirectUri: request.cookies.oidcRedirectUri,
-        codeVerifier: request.cookies.oidcCodeVerifier,
+        redirectUri: oidcRedirectUri,
+        codeVerifier: oidcCodeVerifier,
       },
     },
   })
   const tokenBinding = tokenStore.rebind(
     {
       kind: OAuthOidcTokenBindingKind.CallbackState,
-      value: request.query.state,
+      value: state,
     },
     {
       kind: OAuthOidcTokenBindingKind.Session,
@@ -248,7 +265,7 @@ async function finishOidcCallback(request: CallbackRequest): Promise<RedirectRes
 export async function runOAuthOidcExample(): Promise<void> {
   assertSessionCookieSealingConfigured()
 
-  const response = await finishOidcCallback({
+  const response = await finishOidcCallbackForExample({
     query: {
       code: 'demo-authorization-code',
       state: 'state-123',

--- a/examples/shared/http.ts
+++ b/examples/shared/http.ts
@@ -9,8 +9,15 @@ export function readBearerToken(header: string | undefined): string | undefined 
     return undefined
   }
 
-  const [scheme, value] = header.split(/\s+/, 2)
-  return scheme?.toLowerCase() === 'bearer' && value?.trim() ? value.trim() : undefined
+  const parts = header.trim().split(/\s+/)
+
+  if (parts.length !== 2) {
+    return undefined
+  }
+
+  const scheme = parts[0]!
+  const value = parts[1]!
+  return scheme.toLowerCase() === 'bearer' && value ? value : undefined
 }
 
 export function readCookieHeaderToken(
@@ -29,7 +36,16 @@ export function readCookieHeaderToken(
     }
 
     const value = rest.join('=').trim()
-    return value ? decodeURIComponent(value) : undefined
+
+    if (!value) {
+      return undefined
+    }
+
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return undefined
+    }
   }
 
   return undefined

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "noEmit": true,
     "paths": {
       "@alyldas/uniauth": ["../src/index.ts"],

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,15 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "ignoreDeprecations": "6.0",
-    "noEmit": true,
-    "paths": {
-      "@alyldas/uniauth": ["../src/index.ts"],
-      "@alyldas/uniauth/providers/messenger": ["../src/providers/messenger.ts"],
-      "@alyldas/uniauth/providers/oauth-oidc": ["../src/providers/oauth-oidc.ts"],
-      "@alyldas/uniauth/testing": ["../src/testing/index.ts"]
-    }
+    "noEmit": true
   },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "check": "npm run audit:deps && npm run format:check && npm run lint && npm run typecheck && npm run coverage && npm run test:exports && npm run lint:package && npm run test:types-package && npm run pack:dry",
     "check:compose": "docker compose run --rm --build check",
     "check:docker": "docker build --target check -t alyldas-uniauth-check .",
-    "coverage": "vitest run test/*.test.ts --coverage",
+    "coverage": "vitest run --dir test --exclude core.test.ts --exclude postgres.test.ts --exclude provider-policy.test.ts --exclude service-edges.test.ts --coverage",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "hooks:install": "node scripts/install-husky.cjs",
@@ -82,7 +82,7 @@
     "pack:dry": "npm pack --dry-run",
     "prepack": "npm run build",
     "prepare": "npm run hooks:install",
-    "test": "vitest run test/*.test.ts",
+    "test": "vitest run --dir test --exclude core.test.ts --exclude postgres.test.ts --exclude provider-policy.test.ts --exclude service-edges.test.ts",
     "test:exports": "npm run build && vitest run smoke/exports.test.ts",
     "test:types-package": "attw --pack . --profile esm-only --quiet",
     "typecheck": "tsc -p tsconfig.typecheck.json && tsc -p examples/tsconfig.json"

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -2,17 +2,50 @@ import { readFile } from 'node:fs/promises'
 import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import packageJson from '../package.json'
+import tsconfigBuild from '../tsconfig.build.json'
+import tsupConfig from '../tsup.config'
 
 interface PackageMetadata {
   readonly name: string
   readonly author: {
     readonly email: string
   }
+  readonly exports: Record<string, { readonly types: string; readonly import: string }>
 }
 
 const packageMetadata = packageJson as PackageMetadata
 
+const expectedEntrypoints = {
+  '.': 'src/index.ts',
+  './bridges': 'src/bridges.ts',
+  './contracts': 'src/contracts.ts',
+  './providers/messenger': 'src/providers/messenger.ts',
+  './providers/oauth-oidc': 'src/providers/oauth-oidc.ts',
+  './postgres': 'src/postgres.ts',
+  './testing': 'src/testing/index.ts',
+} as const
+
 describe('package exports', () => {
+  it('keeps package exports, tsup entries, and declaration entry files aligned', () => {
+    const tsupEntries = tsupConfig.entry as Record<string, string>
+    const tsconfigFiles = new Set(tsconfigBuild.files)
+
+    expect(Object.keys(packageMetadata.exports).sort()).toEqual(
+      Object.keys(expectedEntrypoints).sort(),
+    )
+
+    for (const [exportPath, sourcePath] of Object.entries(expectedEntrypoints)) {
+      const exportTarget = packageMetadata.exports[exportPath]
+      const distEntry = exportTarget.import
+        .replace('./dist/', '')
+        .replace(/\/index\.js$/u, '/index')
+        .replace(/\.js$/u, '')
+
+      expect(tsupEntries[distEntry]).toBe(sourcePath)
+      expect(tsconfigFiles.has(sourcePath)).toBe(true)
+    }
+  })
+
   it('loads the root entry point without mutating process environment', async () => {
     const before = { ...process.env }
 

--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -54,9 +54,9 @@ function normalizeAuditEventQuery(input: AuditEventQuery): NormalizedAuditEventQ
     throw invalidInput('Audit event limit must be a positive integer.')
   }
 
-  if (input.type !== undefined) {
-    const type = input.type.trim()
+  const type = input.type?.trim() as AuditEventQuery['type'] | undefined
 
+  if (input.type !== undefined) {
     if (!type) {
       throw invalidInput('Audit event type is invalid.')
     }
@@ -64,6 +64,7 @@ function normalizeAuditEventQuery(input: AuditEventQuery): NormalizedAuditEventQ
 
   return {
     ...input,
+    ...(type ? { type } : {}),
     ...(before ? { before } : {}),
     ...(after ? { after } : {}),
     limit,

--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -138,25 +138,29 @@ export async function resendEmailMagicLinkSignIn(
   input: ResendEmailMagicLinkSignInInput,
 ): Promise<StartEmailMagicLinkSignInResult> {
   const now = input.now ?? runtime.clock.now()
-  const verification = await findEmailMagicLinkVerification(runtime, input.verificationId)
 
   if (!runtime.emailSender) {
     throw invalidInput('Email sender is required for email magic links.')
   }
+  const emailSender = runtime.emailSender
 
-  await requireVerificationResendAllowed(runtime, verification, {
-    action: RateLimitAction.MagicLinkResend,
-    now,
-  })
-  await enforceRateLimit(runtime, {
-    action: RateLimitAction.MagicLinkResend,
-    key: rateLimitKey(OtpChannel.Email, verification.target),
-    now,
-    metadata: { delivery: OtpChannel.Email, purpose: verification.purpose },
-  })
+  return runtime.transaction.run(async () => {
+    const verification = await findEmailMagicLinkVerification(runtime, input.verificationId, {
+      lock: true,
+    })
 
-  const created = await runtime.transaction.run(async () => {
-    return createVerificationRecord(runtime, {
+    await requireVerificationResendAllowed(runtime, verification, {
+      action: RateLimitAction.MagicLinkResend,
+      now,
+    })
+    await enforceRateLimit(runtime, {
+      action: RateLimitAction.MagicLinkResend,
+      key: rateLimitKey(OtpChannel.Email, verification.target),
+      now,
+      metadata: { delivery: OtpChannel.Email, purpose: verification.purpose },
+    })
+
+    const created = await createVerificationRecord(runtime, {
       purpose: verification.purpose,
       target: verification.target,
       provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
@@ -166,32 +170,32 @@ export async function resendEmailMagicLinkSignIn(
       now,
       ...optionalProp('metadata', mergeVerificationMetadata(verification.metadata, input.metadata)),
     })
-  })
-  const link = await input.createLink({
-    verificationId: created.verification.id,
-    secret: created.secret,
-    email: verification.target,
-    expiresAt: created.verification.expiresAt,
-  })
-
-  await runtime.emailSender.sendEmail({
-    to: verification.target,
-    subject: DEFAULT_EMAIL_MAGIC_LINK_SUBJECT,
-    text: `Sign in using this link: ${link}`,
-    metadata: {
+    const link = await input.createLink({
       verificationId: created.verification.id,
-      purpose: created.verification.purpose,
-      delivery: OtpChannel.Email,
-      provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
-    },
-  })
-  await expireVerificationForResend(runtime, verification.id, now)
+      secret: created.secret,
+      email: verification.target,
+      expiresAt: created.verification.expiresAt,
+    })
 
-  return {
-    verificationId: created.verification.id,
-    expiresAt: created.verification.expiresAt,
-    delivery: OtpChannel.Email,
-  }
+    await emailSender.sendEmail({
+      to: verification.target,
+      subject: DEFAULT_EMAIL_MAGIC_LINK_SUBJECT,
+      text: `Sign in using this link: ${link}`,
+      metadata: {
+        verificationId: created.verification.id,
+        purpose: created.verification.purpose,
+        delivery: OtpChannel.Email,
+        provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
+      },
+    })
+    await expireVerificationForResend(runtime, verification.id, now)
+
+    return {
+      verificationId: created.verification.id,
+      expiresAt: created.verification.expiresAt,
+      delivery: OtpChannel.Email,
+    }
+  })
 }
 
 export async function cancelEmailMagicLinkSignIn(
@@ -209,8 +213,11 @@ export async function cancelEmailMagicLinkSignIn(
 async function findEmailMagicLinkVerification(
   runtime: AuthServiceRuntime,
   verificationId: Verification['id'],
+  options: { readonly lock?: boolean } = {},
 ): Promise<Verification> {
-  const verification = await runtime.repos.verificationRepo.findById(verificationId)
+  const verification = await (options.lock
+    ? runtime.repos.verificationRepo.findByIdForUpdate(verificationId)
+    : runtime.repos.verificationRepo.findById(verificationId))
 
   if (!verification) {
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')

--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -144,7 +144,7 @@ export async function resendEmailMagicLinkSignIn(
   }
   const emailSender = runtime.emailSender
 
-  return runtime.transaction.run(async () => {
+  const { created, verification } = await runtime.transaction.run(async () => {
     const verification = await findEmailMagicLinkVerification(runtime, input.verificationId, {
       lock: true,
     })
@@ -170,32 +170,37 @@ export async function resendEmailMagicLinkSignIn(
       now,
       ...optionalProp('metadata', mergeVerificationMetadata(verification.metadata, input.metadata)),
     })
-    const link = await input.createLink({
-      verificationId: created.verification.id,
-      secret: created.secret,
-      email: verification.target,
-      expiresAt: created.verification.expiresAt,
-    })
-
-    await emailSender.sendEmail({
-      to: verification.target,
-      subject: DEFAULT_EMAIL_MAGIC_LINK_SUBJECT,
-      text: `Sign in using this link: ${link}`,
-      metadata: {
-        verificationId: created.verification.id,
-        purpose: created.verification.purpose,
-        delivery: OtpChannel.Email,
-        provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
-      },
-    })
     await expireVerificationForResend(runtime, verification.id, now)
 
     return {
-      verificationId: created.verification.id,
-      expiresAt: created.verification.expiresAt,
-      delivery: OtpChannel.Email,
+      created,
+      verification,
     }
   })
+  const link = await input.createLink({
+    verificationId: created.verification.id,
+    secret: created.secret,
+    email: verification.target,
+    expiresAt: created.verification.expiresAt,
+  })
+
+  await emailSender.sendEmail({
+    to: verification.target,
+    subject: DEFAULT_EMAIL_MAGIC_LINK_SUBJECT,
+    text: `Sign in using this link: ${link}`,
+    metadata: {
+      verificationId: created.verification.id,
+      purpose: created.verification.purpose,
+      delivery: OtpChannel.Email,
+      provider: EMAIL_MAGIC_LINK_PROVIDER_ID,
+    },
+  })
+
+  return {
+    verificationId: created.verification.id,
+    expiresAt: created.verification.expiresAt,
+    delivery: OtpChannel.Email,
+  }
 }
 
 export async function cancelEmailMagicLinkSignIn(

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -116,33 +116,35 @@ export async function resendOtpChallenge(
   input: ResendOtpChallengeInput,
 ): Promise<StartOtpChallengeResult> {
   const now = input.now ?? runtime.clock.now()
-  const challenge = await findOtpChallengeRecord(runtime, {
-    verificationId: input.verificationId,
-    context: 'OTP resend',
-  })
-  const target = challenge.verification.target
 
-  await requireVerificationResendAllowed(runtime, challenge.verification, {
-    action: RateLimitAction.OtpResend,
-    now,
-  })
-  await enforceRateLimit(runtime, {
-    action: RateLimitAction.OtpResend,
-    key: rateLimitKey(challenge.channel, target),
-    now,
-    metadata: { channel: challenge.channel, purpose: challenge.verification.purpose },
-  })
+  return runtime.transaction.run(async () => {
+    const challenge = await findOtpChallengeRecord(runtime, {
+      verificationId: input.verificationId,
+      context: 'OTP resend',
+      lock: true,
+    })
+    const target = challenge.verification.target
 
-  const delivery = getOtpDelivery(runtime, challenge.channel)
-  const secret = await resolveOtpSecret(runtime, {
-    purpose: challenge.verification.purpose,
-    channel: challenge.channel,
-    target,
-    now,
-    ...optionalProp('secret', input.secret),
-  })
-  const created = await runtime.transaction.run(async () => {
-    return createVerificationRecord(runtime, {
+    await requireVerificationResendAllowed(runtime, challenge.verification, {
+      action: RateLimitAction.OtpResend,
+      now,
+    })
+    await enforceRateLimit(runtime, {
+      action: RateLimitAction.OtpResend,
+      key: rateLimitKey(challenge.channel, target),
+      now,
+      metadata: { channel: challenge.channel, purpose: challenge.verification.purpose },
+    })
+
+    const delivery = getOtpDelivery(runtime, challenge.channel)
+    const secret = await resolveOtpSecret(runtime, {
+      purpose: challenge.verification.purpose,
+      channel: challenge.channel,
+      target,
+      now,
+      ...optionalProp('secret', input.secret),
+    })
+    const created = await createVerificationRecord(runtime, {
       purpose: challenge.verification.purpose,
       target,
       provider: delivery.provider,
@@ -155,16 +157,16 @@ export async function resendOtpChallenge(
         mergeVerificationMetadata(challenge.verification.metadata, input.metadata),
       ),
     })
+
+    await delivery.send(created)
+    await expireVerificationForResend(runtime, challenge.verification.id, now)
+
+    return {
+      verificationId: created.verification.id,
+      expiresAt: created.verification.expiresAt,
+      delivery: challenge.channel,
+    }
   })
-
-  await delivery.send(created)
-  await expireVerificationForResend(runtime, challenge.verification.id, now)
-
-  return {
-    verificationId: created.verification.id,
-    expiresAt: created.verification.expiresAt,
-    delivery: challenge.channel,
-  }
 }
 
 export async function cancelOtpChallenge(
@@ -230,9 +232,12 @@ export async function findOtpChallengeRecord(
     readonly purpose?: VerificationPurpose
     readonly channel?: OtpChannelType
     readonly context: string
+    readonly lock?: boolean
   },
 ): Promise<{ readonly verification: Verification; readonly channel: SupportedOtpChannel }> {
-  const verification = await runtime.repos.verificationRepo.findById(input.verificationId)
+  const verification = await (input.lock
+    ? runtime.repos.verificationRepo.findByIdForUpdate(input.verificationId)
+    : runtime.repos.verificationRepo.findById(input.verificationId))
 
   if (!verification) {
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -117,7 +117,7 @@ export async function resendOtpChallenge(
 ): Promise<StartOtpChallengeResult> {
   const now = input.now ?? runtime.clock.now()
 
-  return runtime.transaction.run(async () => {
+  const { challenge, created, delivery } = await runtime.transaction.run(async () => {
     const challenge = await findOtpChallengeRecord(runtime, {
       verificationId: input.verificationId,
       context: 'OTP resend',
@@ -158,15 +158,22 @@ export async function resendOtpChallenge(
       ),
     })
 
-    await delivery.send(created)
     await expireVerificationForResend(runtime, challenge.verification.id, now)
 
     return {
-      verificationId: created.verification.id,
-      expiresAt: created.verification.expiresAt,
-      delivery: challenge.channel,
+      challenge,
+      created,
+      delivery,
     }
   })
+
+  await delivery.send(created)
+
+  return {
+    verificationId: created.verification.id,
+    expiresAt: created.verification.expiresAt,
+    delivery: challenge.channel,
+  }
 }
 
 export async function cancelOtpChallenge(

--- a/src/application/passwords/recovery.ts
+++ b/src/application/passwords/recovery.ts
@@ -138,7 +138,7 @@ export async function resendEmailPasswordRecovery(
   }
   const emailSender = runtime.emailSender
 
-  return runtime.transaction.run(async () => {
+  const { created, verification } = await runtime.transaction.run(async () => {
     const verification = await findPasswordRecoveryVerification(runtime, input.verificationId, {
       lock: true,
     })
@@ -164,32 +164,37 @@ export async function resendEmailPasswordRecovery(
       now,
       ...optionalProp('metadata', mergeVerificationMetadata(verification.metadata, input.metadata)),
     })
-    const link = await input.createLink({
-      verificationId: created.verification.id,
-      secret: created.secret,
-      email: verification.target,
-      expiresAt: created.verification.expiresAt,
-    })
-
-    await emailSender.sendEmail({
-      to: verification.target,
-      subject: DEFAULT_PASSWORD_RECOVERY_SUBJECT,
-      text: `Reset your password using this link: ${link}`,
-      metadata: {
-        verificationId: created.verification.id,
-        purpose: created.verification.purpose,
-        delivery: OtpChannel.Email,
-        provider: PASSWORD_PROVIDER_ID,
-      },
-    })
     await expireVerificationForResend(runtime, verification.id, now)
 
     return {
-      verificationId: created.verification.id,
-      expiresAt: created.verification.expiresAt,
-      delivery: OtpChannel.Email,
+      created,
+      verification,
     }
   })
+  const link = await input.createLink({
+    verificationId: created.verification.id,
+    secret: created.secret,
+    email: verification.target,
+    expiresAt: created.verification.expiresAt,
+  })
+
+  await emailSender.sendEmail({
+    to: verification.target,
+    subject: DEFAULT_PASSWORD_RECOVERY_SUBJECT,
+    text: `Reset your password using this link: ${link}`,
+    metadata: {
+      verificationId: created.verification.id,
+      purpose: created.verification.purpose,
+      delivery: OtpChannel.Email,
+      provider: PASSWORD_PROVIDER_ID,
+    },
+  })
+
+  return {
+    verificationId: created.verification.id,
+    expiresAt: created.verification.expiresAt,
+    delivery: OtpChannel.Email,
+  }
 }
 
 export async function cancelEmailPasswordRecovery(

--- a/src/application/passwords/recovery.ts
+++ b/src/application/passwords/recovery.ts
@@ -132,25 +132,29 @@ export async function resendEmailPasswordRecovery(
   input: ResendEmailPasswordRecoveryInput,
 ): Promise<StartEmailPasswordRecoveryResult> {
   const now = input.now ?? runtime.clock.now()
-  const verification = await findPasswordRecoveryVerification(runtime, input.verificationId)
 
   if (!runtime.emailSender) {
     throw invalidInput('Email sender is required for password recovery.')
   }
+  const emailSender = runtime.emailSender
 
-  await requireVerificationResendAllowed(runtime, verification, {
-    action: RateLimitAction.PasswordRecoveryResend,
-    now,
-  })
-  await enforceRateLimit(runtime, {
-    action: RateLimitAction.PasswordRecoveryResend,
-    key: rateLimitKey(OtpChannel.Email, verification.target),
-    now,
-    metadata: { delivery: OtpChannel.Email, purpose: verification.purpose },
-  })
+  return runtime.transaction.run(async () => {
+    const verification = await findPasswordRecoveryVerification(runtime, input.verificationId, {
+      lock: true,
+    })
 
-  const created = await runtime.transaction.run(async () => {
-    return createVerificationRecord(runtime, {
+    await requireVerificationResendAllowed(runtime, verification, {
+      action: RateLimitAction.PasswordRecoveryResend,
+      now,
+    })
+    await enforceRateLimit(runtime, {
+      action: RateLimitAction.PasswordRecoveryResend,
+      key: rateLimitKey(OtpChannel.Email, verification.target),
+      now,
+      metadata: { delivery: OtpChannel.Email, purpose: verification.purpose },
+    })
+
+    const created = await createVerificationRecord(runtime, {
       purpose: verification.purpose,
       target: verification.target,
       provider: PASSWORD_PROVIDER_ID,
@@ -160,32 +164,32 @@ export async function resendEmailPasswordRecovery(
       now,
       ...optionalProp('metadata', mergeVerificationMetadata(verification.metadata, input.metadata)),
     })
-  })
-  const link = await input.createLink({
-    verificationId: created.verification.id,
-    secret: created.secret,
-    email: verification.target,
-    expiresAt: created.verification.expiresAt,
-  })
-
-  await runtime.emailSender.sendEmail({
-    to: verification.target,
-    subject: DEFAULT_PASSWORD_RECOVERY_SUBJECT,
-    text: `Reset your password using this link: ${link}`,
-    metadata: {
+    const link = await input.createLink({
       verificationId: created.verification.id,
-      purpose: created.verification.purpose,
-      delivery: OtpChannel.Email,
-      provider: PASSWORD_PROVIDER_ID,
-    },
-  })
-  await expireVerificationForResend(runtime, verification.id, now)
+      secret: created.secret,
+      email: verification.target,
+      expiresAt: created.verification.expiresAt,
+    })
 
-  return {
-    verificationId: created.verification.id,
-    expiresAt: created.verification.expiresAt,
-    delivery: OtpChannel.Email,
-  }
+    await emailSender.sendEmail({
+      to: verification.target,
+      subject: DEFAULT_PASSWORD_RECOVERY_SUBJECT,
+      text: `Reset your password using this link: ${link}`,
+      metadata: {
+        verificationId: created.verification.id,
+        purpose: created.verification.purpose,
+        delivery: OtpChannel.Email,
+        provider: PASSWORD_PROVIDER_ID,
+      },
+    })
+    await expireVerificationForResend(runtime, verification.id, now)
+
+    return {
+      verificationId: created.verification.id,
+      expiresAt: created.verification.expiresAt,
+      delivery: OtpChannel.Email,
+    }
+  })
 }
 
 export async function cancelEmailPasswordRecovery(

--- a/src/application/passwords/shared.ts
+++ b/src/application/passwords/shared.ts
@@ -138,8 +138,11 @@ export async function findUsableCredentialUser(
 export async function findPasswordRecoveryVerification(
   runtime: AuthServiceRuntime,
   verificationId: Verification['id'],
+  options: { readonly lock?: boolean } = {},
 ): Promise<Verification> {
-  const verification = await runtime.repos.verificationRepo.findById(verificationId)
+  const verification = await (options.lock
+    ? runtime.repos.verificationRepo.findByIdForUpdate(verificationId)
+    : runtime.repos.verificationRepo.findById(verificationId))
 
   if (!verification) {
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')

--- a/src/application/runtime-defaults.ts
+++ b/src/application/runtime-defaults.ts
@@ -49,7 +49,8 @@ export function createAuthServiceRuntime(options: DefaultAuthServiceOptions): Au
     ...optionalProp('passwordHasher', options.passwordHasher),
     policy: options.policy ?? defaultAuthPolicy,
     providerRegistry: options.providerRegistry,
-    transaction: options.transaction ?? immediateUnitOfWork,
+    transaction:
+      options.transaction ?? getRepositoryUnitOfWork(options.repos) ?? immediateUnitOfWork,
     idGenerator: options.idGenerator ?? createRandomIdGenerator(),
     normalizer: options.normalizer ?? compatibilityAuthNormalizer,
     secretHasher: options.secretHasher ?? scryptSecretHasher,
@@ -57,4 +58,11 @@ export function createAuthServiceRuntime(options: DefaultAuthServiceOptions): Au
     sessionTtlSeconds: options.sessionTtlSeconds ?? DEFAULT_SESSION_TTL_SECONDS,
     verificationTtlSeconds: options.verificationTtlSeconds ?? DEFAULT_VERIFICATION_TTL_SECONDS,
   }
+}
+
+function getRepositoryUnitOfWork(repos: AuthServiceRepositories): UnitOfWork | undefined {
+  const candidate = repos as Partial<UnitOfWork>
+  return typeof candidate.run === 'function'
+    ? { run: (operation) => candidate.run!(operation) }
+    : undefined
 }

--- a/src/application/sign-in/assertion.ts
+++ b/src/application/sign-in/assertion.ts
@@ -48,6 +48,10 @@ export function normalizeAssertion(
     throw invalidInput('Provider and provider user id are required.')
   }
 
+  if (hasControlCharacter(provider) || hasControlCharacter(providerUserId)) {
+    throw invalidInput('Provider and provider user id cannot contain control characters.')
+  }
+
   const email = normalizeOptionalClaim(assertion.email, runtime.normalizer.normalizeEmail)
   const phone = normalizeOptionalClaim(assertion.phone, runtime.normalizer.normalizePhone)
   const displayName = assertion.displayName?.trim() || undefined
@@ -71,6 +75,10 @@ export function normalizeAssertion(
     ...optionalProp('trust', normalizeProviderTrust(assertion.trust)),
     ...optionalProp('metadata', assertion.metadata),
   }
+}
+
+function hasControlCharacter(value: string): boolean {
+  return /[\u0000-\u001f\u007f]/u.test(value)
 }
 
 function normalizeOptionalClaim(

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -177,7 +177,7 @@ export async function consumeVerificationRecord(
   input: ConsumeVerificationInput,
 ): Promise<Verification> {
   const now = input.now ?? runtime.clock.now()
-  const verification = await runtime.repos.verificationRepo.findById(input.verificationId)
+  const verification = await runtime.repos.verificationRepo.findByIdForUpdate(input.verificationId)
 
   if (!verification) {
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')

--- a/src/ports/rate-limit.ts
+++ b/src/ports/rate-limit.ts
@@ -49,7 +49,7 @@ export interface OtpSecretGeneratorInput {
 export type OtpSecretGenerator = (input: OtpSecretGeneratorInput) => string | Promise<string>
 
 export function rateLimitKey(...parts: readonly string[]): string {
-  return parts.join('\u0000')
+  return JSON.stringify(parts)
 }
 
 export function isRateLimitedErrorDetails(input: unknown): input is RateLimitedErrorDetails {

--- a/src/ports/repositories.ts
+++ b/src/ports/repositories.ts
@@ -97,6 +97,7 @@ export interface CredentialRepo {
 
 export interface VerificationRepo {
   findById(id: VerificationId): Promise<Verification | undefined>
+  findByIdForUpdate(id: VerificationId): Promise<Verification | undefined>
   create(verification: Verification): Promise<Verification>
   update(id: VerificationId, patch: VerificationUpdatePatch): Promise<Verification>
 }

--- a/src/postgres/store/verifications.ts
+++ b/src/postgres/store/verifications.ts
@@ -19,6 +19,17 @@ export function createVerificationRepo(context: PostgresStoreContext): Verificat
         [id],
         mapVerificationRow,
       ),
+    findByIdForUpdate: async (id) =>
+      context.queryOptionalRow<VerificationRow, ReturnType<typeof mapVerificationRow>>(
+        `select
+           id, purpose, target, provider, channel, secret_hash, status, created_at, expires_at,
+           consumed_at, metadata
+         from uniauth_verifications
+         where id = $1
+         for update`,
+        [id],
+        mapVerificationRow,
+      ),
     create: async (verification) =>
       context.queryRequiredRow<VerificationRow, ReturnType<typeof mapVerificationRow>>(
         `insert into uniauth_verifications (

--- a/src/testing/in-memory/store.ts
+++ b/src/testing/in-memory/store.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import {
   AuthIdentityStatus,
   CredentialType,
@@ -51,7 +52,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   private readonly sessions = new Map<Session['id'], Session>()
   private readonly sessionKeys = new Map<string, Session['id']>()
   private readonly auditEvents: AuditEvent[] = []
-  private transactionDepth = 0
+  private readonly transactionScope = new AsyncLocalStorage<boolean>()
+  private transactionQueue: Promise<void> = Promise.resolve()
 
   constructor(private readonly options: InMemoryAuthStoreOptions = {}) {}
 
@@ -201,6 +203,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
   readonly verificationRepo: VerificationRepo = {
     findById: async (id) => this.verifications.get(id),
+    findByIdForUpdate: async (id) => this.verifications.get(id),
     create: async (verification) => {
       this.verifications.set(verification.id, verification)
       return verification
@@ -275,20 +278,27 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   }
 
   async run<T>(operation: () => Promise<T>): Promise<T> {
-    if (this.transactionDepth > 0) {
+    if (this.transactionScope.getStore()) {
       return operation()
     }
 
+    const previousTransaction = this.transactionQueue
+    let releaseTransaction!: () => void
+    this.transactionQueue = new Promise((resolve) => {
+      releaseTransaction = resolve
+    })
+
+    await previousTransaction
+
     const snapshot = this.snapshot()
-    this.transactionDepth += 1
 
     try {
-      return await operation()
+      return await this.transactionScope.run(true, operation)
     } catch (error) {
       this.restore(snapshot)
       throw error
     } finally {
-      this.transactionDepth -= 1
+      releaseTransaction()
     }
   }
 
@@ -317,7 +327,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   }
 
   private identityKey(provider: AuthIdentityProvider, providerUserId: string): string {
-    return `${provider}\u0000${providerUserId}`
+    return compositeKey(provider, providerUserId)
   }
 
   private get normalizer(): AuthNormalizer {
@@ -325,11 +335,11 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
   }
 
   private credentialKey(type: Credential['type'], subject: string): string {
-    return `${type}\u0000${subject}`
+    return compositeKey(type, subject)
   }
 
   private credentialUserKey(type: Credential['type'], userId: User['id']): string {
-    return `${type}\u0000${userId}`
+    return compositeKey(type, userId)
   }
 
   private snapshot(): StoreSnapshot {
@@ -425,6 +435,10 @@ function applyPatch<Entity extends { readonly id: unknown }, Patch extends objec
   }
 
   return updated as Entity
+}
+
+function compositeKey(...parts: readonly string[]): string {
+  return JSON.stringify(parts)
 }
 
 function isOlderThanAuditCursor(

--- a/test/core/current-account-reauth.test.ts
+++ b/test/core/current-account-reauth.test.ts
@@ -348,6 +348,9 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
           findById: async () => {
             throw lookupFailure
           },
+          findByIdForUpdate: async () => {
+            throw lookupFailure
+          },
         },
         sessionRepo: store.sessionRepo,
         auditLogRepo: store.auditLogRepo,

--- a/test/core/otp-and-verifications.test.ts
+++ b/test/core/otp-and-verifications.test.ts
@@ -216,6 +216,40 @@ describe('DefaultAuthService OTP and verification flows', () => {
     expect(generatedFinished.session.expiresAt).toEqual(addSeconds(now, 60))
   })
 
+  it('allows only one concurrent OTP sign-in to consume a verification', async () => {
+    const { service, store } = createInMemoryAuthKit()
+    const started = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'race@example.com',
+      secret: '123456',
+      now,
+    })
+
+    const results = await Promise.allSettled([
+      service.finishOtpSignIn({
+        verificationId: started.verificationId,
+        secret: '123456',
+        channel: OtpChannel.Email,
+        now,
+      }),
+      service.finishOtpSignIn({
+        verificationId: started.verificationId,
+        secret: '123456',
+        channel: OtpChannel.Email,
+        now,
+      }),
+    ])
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(store.listSessions()).toHaveLength(1)
+    expect(store.listVerifications()[0]).toMatchObject({
+      id: started.verificationId,
+      status: VerificationStatus.Consumed,
+    })
+  })
+
   it('keeps a pending OTP verification when app-owned delivery fails', async () => {
     const store = new InMemoryAuthStore()
     const failingEmailSender: EmailSender = {

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -389,6 +389,14 @@ describe('DefaultAuthService read side and sessions', () => {
     expect(continuationWindow.nextAuditCursor).toBeUndefined()
     expect(emptyWindow.auditEvents).toEqual([])
     expect(emptyWindow.nextAuditCursor).toBeUndefined()
+    await expect(
+      service.getAuditEvents({ type: ` ${AuditEventType.SignIn} ` as AuditEventType }),
+    ).resolves.toMatchObject([
+      {
+        type: AuditEventType.SignIn,
+        userId: signedIn.user.id,
+      },
+    ])
   })
 
   it('bulk-revokes active user sessions while optionally keeping one session active', async () => {

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -29,6 +29,8 @@ import {
   systemClock,
   verifySecret,
 } from '../src'
+import { createAuthServiceRuntime } from '../src/application/runtime-defaults.js'
+import { InMemoryAuthStore } from '../src/testing'
 import { assertion, identity, now, user } from './helpers.js'
 
 describe('public utility coverage', () => {
@@ -144,6 +146,20 @@ describe('public utility coverage', () => {
     )
     expect(addSeconds(now, 5)).toEqual(new Date('2026-01-01T00:00:05.000Z'))
     expect(systemClock.now()).toBeInstanceOf(Date)
+
+    const store = new InMemoryAuthStore()
+    const runtime = createAuthServiceRuntime({
+      repos: {
+        userRepo: store.userRepo,
+        identityRepo: store.identityRepo,
+        credentialRepo: store.credentialRepo,
+        verificationRepo: store.verificationRepo,
+        sessionRepo: store.sessionRepo,
+        auditLogRepo: store.auditLogRepo,
+      },
+    })
+
+    await expect(runtime.transaction.run(async () => 'immediate')).resolves.toBe('immediate')
   })
 
   it('covers default policy and error helper branches', () => {

--- a/test/examples.test.ts
+++ b/test/examples.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { UniAuthErrorCode } from '../src'
+import { readBearerToken, readCookieHeaderToken } from '../examples/shared/http.js'
+import { finishOidcCallbackForExample } from '../examples/oauth-oidc/index.js'
+
+describe('example transport helpers', () => {
+  it('rejects ambiguous bearer headers and malformed cookie encoding', () => {
+    expect(readBearerToken('Bearer token')).toBe('token')
+    expect(readBearerToken('Bearer token extra')).toBeUndefined()
+    expect(readBearerToken('Basic token')).toBeUndefined()
+    expect(readCookieHeaderToken('session=%', 'session')).toBeUndefined()
+    expect(readCookieHeaderToken('session=abc%20123', 'session')).toBe('abc 123')
+  })
+
+  it('validates OAuth callback query and cookie values before provider finish', async () => {
+    await expect(
+      finishOidcCallbackForExample({
+        query: {
+          code: 'demo-authorization-code',
+          state: 'state-123',
+        },
+        cookies: {
+          oidcState: 'state-123',
+          oidcCodeVerifier: '   ',
+          oidcRedirectUri: 'https://app.example.test/auth/callback',
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+  })
+})

--- a/test/provider-policy/provider-resolution-and-validation.test.ts
+++ b/test/provider-policy/provider-resolution-and-validation.test.ts
@@ -30,6 +30,14 @@ describe('provider resolution and assertion validation failures', () => {
     expect(
       await noRegistryService
         .signIn({
+          assertion: assertion({ provider: 'oauth', providerUserId: 'user\u0000a' }),
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
           assertion: {
             providerUserId: 'user',
           } as Partial<ProviderIdentityAssertion> as ProviderIdentityAssertion,

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -11,6 +11,10 @@ import { InMemoryRateLimiter, createInMemoryAuthKit } from '../src/testing'
 import { assertion, now, rateLimitKey } from './helpers.js'
 
 describe('rate-limit integration', () => {
+  it('builds unambiguous keys for arbitrary rate-limit parts', () => {
+    expect(rateLimitKey('a', 'b\u0000c')).not.toBe(rateLimitKey('a\u0000b', 'c'))
+  })
+
   it('denies provider sign-in before creating a user, identity, or session', async () => {
     const rateLimiter = new InMemoryRateLimiter()
     rateLimiter.setDecision(

--- a/test/resend-execution.test.ts
+++ b/test/resend-execution.test.ts
@@ -104,6 +104,45 @@ describe('verification resend execution flows', () => {
     expect(signedIn.session.status).toBe(SessionStatus.Active)
   })
 
+  it('allows only one concurrent resend replacement for the same OTP challenge', async () => {
+    const { service, emailSender, store } = createInMemoryAuthKit({
+      verificationResendCooldownSeconds: 0,
+    })
+    const started = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'race@example.com',
+      secret: '111111',
+      now,
+    })
+
+    const results = await Promise.allSettled([
+      service.resendOtpChallenge({
+        verificationId: started.verificationId,
+        secret: '222222',
+        now,
+      }),
+      service.resendOtpChallenge({
+        verificationId: started.verificationId,
+        secret: '333333',
+        now,
+      }),
+    ])
+
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(emailSender.listMessages()).toHaveLength(2)
+    expect(store.listVerifications()).toEqual([
+      expect.objectContaining({
+        id: started.verificationId,
+        expiresAt: now,
+      }),
+      expect.objectContaining({
+        status: VerificationStatus.Pending,
+      }),
+    ])
+  })
+
   it('keeps phone OTP resend behavior aligned with email replacement semantics', async () => {
     const resendNow = addSeconds(now, 61)
     const { service, smsSender } = createInMemoryAuthKit({
@@ -234,9 +273,6 @@ describe('verification resend execution flows', () => {
     expect(store.listVerifications()).toEqual([
       expect.objectContaining({
         id: started.verificationId,
-        status: VerificationStatus.Pending,
-      }),
-      expect.objectContaining({
         status: VerificationStatus.Pending,
       }),
     ])

--- a/test/resend-execution.test.ts
+++ b/test/resend-execution.test.ts
@@ -232,7 +232,7 @@ describe('verification resend execution flows', () => {
     })
   })
 
-  it('keeps the previous OTP verification usable when resend delivery fails before replacement', async () => {
+  it('keeps resend replacement state when OTP delivery fails after storage replacement', async () => {
     const store = new InMemoryAuthStore()
     const messages: Array<{ to: string; text: string }> = []
     let sendAttempts = 0
@@ -274,20 +274,26 @@ describe('verification resend execution flows', () => {
       expect.objectContaining({
         id: started.verificationId,
         status: VerificationStatus.Pending,
+        expiresAt: now,
+      }),
+      expect.objectContaining({
+        status: VerificationStatus.Pending,
       }),
     ])
 
-    const signedIn = await service.finishOtpSignIn({
-      verificationId: started.verificationId,
-      secret: '111111',
-      channel: OtpChannel.Email,
-      now,
+    await expect(
+      service.finishOtpSignIn({
+        verificationId: started.verificationId,
+        secret: '111111',
+        channel: OtpChannel.Email,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
     })
-
-    expect(signedIn.session.status).toBe(SessionStatus.Active)
   })
 
-  it('resends magic links with fresh secrets and leaves the previous link valid when replacement fails early', async () => {
+  it('resends magic links with fresh secrets and keeps replacement state when link creation fails', async () => {
     const { service, emailSender } = createInMemoryAuthKit({
       clock: { now: () => now },
       verificationResendCooldownSeconds: 0,
@@ -355,14 +361,24 @@ describe('verification resend execution flows', () => {
 
     expect(resendError).toBeInstanceOf(Error)
     expect(secondKit.emailSender.listMessages()).toHaveLength(1)
-
-    const fallbackSignIn = await secondKit.service.finishEmailMagicLinkSignIn({
-      verificationId: initial.verificationId,
-      secret: 'magic-1',
-      now,
+    expect(secondKit.store.listVerifications()).toEqual([
+      expect.objectContaining({
+        id: initial.verificationId,
+        expiresAt: now,
+      }),
+      expect.objectContaining({
+        status: VerificationStatus.Pending,
+      }),
+    ])
+    await expect(
+      secondKit.service.finishEmailMagicLinkSignIn({
+        verificationId: initial.verificationId,
+        secret: 'magic-1',
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationExpired,
     })
-
-    expect(fallbackSignIn.session.status).toBe(SessionStatus.Active)
     expect(emailSender.listMessages()).toHaveLength(2)
   })
 

--- a/test/security-storage.test.ts
+++ b/test/security-storage.test.ts
@@ -22,6 +22,7 @@ interface StorageKit {
     }
     readonly verificationRepo: {
       findById(verificationId: VerificationId): Promise<Verification | undefined>
+      findByIdForUpdate(verificationId: VerificationId): Promise<Verification | undefined>
     }
     readonly sessionRepo: {
       findByTokenHash(tokenHash: string): Promise<Session | undefined>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,14 @@
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@alyldas/uniauth": ["src/index.ts"],
+      "@alyldas/uniauth/providers/messenger": ["src/providers/messenger.ts"],
+      "@alyldas/uniauth/providers/oauth-oidc": ["src/providers/oauth-oidc.ts"],
+      "@alyldas/uniauth/testing": ["src/testing/index.ts"]
+    },
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,25 @@
 import { defineConfig } from 'vitest/config'
 import packageJson from './package.json'
 
+const sourceAliases = [
+  {
+    find: '@alyldas/uniauth/providers/messenger',
+    replacement: new URL('./src/providers/messenger.ts', import.meta.url).pathname,
+  },
+  {
+    find: '@alyldas/uniauth/providers/oauth-oidc',
+    replacement: new URL('./src/providers/oauth-oidc.ts', import.meta.url).pathname,
+  },
+  {
+    find: '@alyldas/uniauth/testing',
+    replacement: new URL('./src/testing/index.ts', import.meta.url).pathname,
+  },
+  {
+    find: '@alyldas/uniauth',
+    replacement: new URL('./src/index.ts', import.meta.url).pathname,
+  },
+]
+
 const attributionDefines = {
   __UNIAUTH_PACKAGE_AUTHOR_EMAIL__: JSON.stringify(packageJson.author.email),
   __UNIAUTH_PACKAGE_AUTHOR_NAME__: JSON.stringify(packageJson.author.name),
@@ -11,6 +30,9 @@ const attributionDefines = {
 
 export default defineConfig({
   define: attributionDefines,
+  resolve: {
+    alias: sourceAliases,
+  },
   test: {
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

- make verification consume/resend paths concurrency-safe across Postgres and in-memory stores
- harden rate-limit key composition, provider assertion validation, audit query normalization, and transport-facing examples
- update test/coverage discovery and add package entrypoint alignment smoke coverage
- refresh README install, entrypoint, and release wording

## Validation

- npm run check

Closes #321
Closes #322
Closes #323
Closes #324
Closes #325
Closes #326
Closes #327