### PR TITLE
Harden session-bound verification flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,12 @@ const resent = await service.resendCurrentAccountOtpReAuth({
   verificationId: challenge.verificationId,
 })
 
+const otpConfirmation = await service.finishCurrentAccountOtpReAuth({
+  sessionToken,
+  verificationId: resent.verificationId,
+  secret: codeFromUserInput,
+})
+
 const passwordConfirmation = await service.confirmCurrentAccountPasswordByToken({
   sessionToken,
   currentPassword,
@@ -445,7 +451,7 @@ const passwordConfirmation = await service.confirmCurrentAccountPasswordByToken(
 const reAuthStatus = await service.getCurrentAccountReAuthStatus({
   sessionToken,
   action: AuthPolicyAction.ChangePassword,
-  reAuthenticatedAt,
+  reAuthenticatedAt: otpConfirmation.reAuthenticatedAt,
 })
 ```
 

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -372,18 +372,17 @@ const challenge = await authService.startCurrentAccountOtpReAuth({
 })
 ```
 
-Then finish the challenge through the existing generic verification consumer and persist the recent
-auth marker in app-owned request or session state:
+Then finish the challenge on the same current-account session boundary and persist the recent-auth
+marker in app-owned request or session state:
 
 ```ts
-const verification = await authService.finishOtpChallenge({
+const confirmation = await authService.finishCurrentAccountOtpReAuth({
+  sessionToken: request.auth.sessionToken,
   verificationId: body.verificationId,
   secret: body.secret,
-  purpose: VerificationPurpose.ReAuth,
-  channel: body.channel,
 })
 
-request.auth.reAuthenticatedAt = verification.consumedAt ?? new Date()
+request.auth.reAuthenticatedAt = confirmation.reAuthenticatedAt
 ```
 
 If the UI prefers password confirmation instead of OTP, keep that proof on the same trusted local

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -49,15 +49,14 @@ const resent = await service.resendCurrentAccountOtpReAuth({
   verificationId: challenge.verificationId,
 })
 
-const verification = await service.finishOtpChallenge({
+const confirmation = await service.finishCurrentAccountOtpReAuth({
+  sessionToken,
   verificationId: resent.verificationId,
   secret: 'code from user input',
-  purpose: VerificationPurpose.ReAuth,
-  channel: OtpChannel.Email,
 })
 ```
 
-The application still owns how `verification.consumedAt` becomes a recent-auth marker in its own
+The application still owns how `confirmation.reAuthenticatedAt` becomes a recent-auth marker in its own
 session, cookie, or server-side request context.
 
 If the user abandons that step instead of finishing it, the route can cancel the current-account

--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -136,6 +136,7 @@ describe('package exports', () => {
     expect(core.DefaultAuthService.prototype.startCurrentAccountOtpReAuth).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.resendCurrentAccountOtpReAuth).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.cancelCurrentAccountOtpReAuth).toBeTypeOf('function')
+    expect(core.DefaultAuthService.prototype.finishCurrentAccountOtpReAuth).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.linkCurrentIdentityByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeCurrentSessionByToken).toBeTypeOf('function')
     expect(core.DefaultAuthService.prototype.revokeOwnedSessionByToken).toBeTypeOf('function')
@@ -272,6 +273,8 @@ describe('package exports', () => {
     expect(flowDeclarations).toContain('export interface StartCurrentAccountOtpReAuthInput')
     expect(flowDeclarations).toContain('export interface ResendCurrentAccountOtpReAuthInput')
     expect(flowDeclarations).toContain('export interface CancelCurrentAccountOtpReAuthInput')
+    expect(flowDeclarations).toContain('export interface FinishCurrentAccountOtpReAuthInput')
+    expect(flowDeclarations).toContain('export interface CurrentAccountOtpReAuthConfirmation')
     expect(flowDeclarations).toContain('export interface LinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UnlinkCurrentIdentityByTokenInput')
     expect(flowDeclarations).toContain('export interface UpdateCurrentAccountProfileByTokenInput')
@@ -289,6 +292,9 @@ describe('package exports', () => {
     )
     expect(serviceDeclarations).toContain(
       'cancelCurrentAccountOtpReAuth(input: CancelCurrentAccountOtpReAuthInput): Promise<Verification>',
+    )
+    expect(serviceDeclarations).toContain(
+      'finishCurrentAccountOtpReAuth(input: FinishCurrentAccountOtpReAuthInput): Promise<CurrentAccountOtpReAuthConfirmation>',
     )
     expect(localAuthDeclarations).toContain(
       'export interface SetCurrentAccountPasswordByTokenInput',

--- a/src/application/auth-service.ts
+++ b/src/application/auth-service.ts
@@ -31,6 +31,7 @@ import {
 import {
   assertCurrentAccountReAuth,
   cancelCurrentAccountOtpReAuth,
+  finishCurrentAccountOtpReAuth,
   getCurrentAccountReAuthStatus,
   confirmCurrentAccountPasswordByToken,
   resendCurrentAccountOtpReAuth,
@@ -91,6 +92,7 @@ import type {
   CancelCurrentAccountContactChangeInput,
   CurrentAccountClosureExportSnapshot,
   CurrentAccountInspectionSnapshot,
+  CurrentAccountOtpReAuthConfirmation,
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
   CurrentAccountSecuritySnapshot,
@@ -109,6 +111,7 @@ import type {
   CreateVerificationInput,
   CreateVerificationResult,
   FinishCurrentAccountContactChangeInput,
+  FinishCurrentAccountOtpReAuthInput,
   FinishEmailMagicLinkSignInInput,
   FinishEmailPasswordRecoveryInput,
   FinishOtpChallengeInput,
@@ -204,6 +207,12 @@ export class DefaultAuthService implements AuthService {
     input: CancelCurrentAccountOtpReAuthInput,
   ): Promise<Verification> {
     return cancelCurrentAccountOtpReAuth(this.runtime, input)
+  }
+
+  async finishCurrentAccountOtpReAuth(
+    input: FinishCurrentAccountOtpReAuthInput,
+  ): Promise<CurrentAccountOtpReAuthConfirmation> {
+    return finishCurrentAccountOtpReAuth(this.runtime, input)
   }
 
   async resendOtpChallenge(input: ResendOtpChallengeInput): Promise<StartOtpChallengeResult> {

--- a/src/application/current-account-contact-change.ts
+++ b/src/application/current-account-contact-change.ts
@@ -231,6 +231,10 @@ async function resolveCurrentAccountOwnedContactChangeChallenge(
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
   }
 
+  if (metadata.sessionId !== session.id) {
+    throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+  }
+
   return {
     actor: { now: resolvedNow, sessionId: session.id, userId: user.id },
     challenge,

--- a/src/application/current-account-re-auth-metadata.ts
+++ b/src/application/current-account-re-auth-metadata.ts
@@ -1,0 +1,53 @@
+import { optionalProp } from './optional.js'
+import { OtpChannel, type SessionId, type UserId } from '../domain/types.js'
+import type { SupportedOtpChannel } from './otp-delivery.js'
+
+const CURRENT_ACCOUNT_OTP_RE_AUTH_METADATA_KEY = 'currentAccountOtpReAuth'
+
+export interface CurrentAccountOtpReAuthMetadata {
+  readonly userId: string
+  readonly sessionId: string
+  readonly channel: SupportedOtpChannel
+}
+
+export function buildCurrentAccountOtpReAuthMetadata(
+  userId: UserId,
+  sessionId: SessionId,
+  channel: SupportedOtpChannel,
+  requestMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return {
+    [CURRENT_ACCOUNT_OTP_RE_AUTH_METADATA_KEY]: {
+      userId,
+      sessionId,
+      channel,
+    },
+    ...optionalProp('requestMetadata', requestMetadata),
+  }
+}
+
+export function readCurrentAccountOtpReAuthMetadata(
+  metadata: Record<string, unknown> | undefined,
+): CurrentAccountOtpReAuthMetadata | undefined {
+  const raw = metadata?.[CURRENT_ACCOUNT_OTP_RE_AUTH_METADATA_KEY]
+
+  if (!raw || typeof raw !== 'object') {
+    return undefined
+  }
+
+  const candidate = raw as Partial<CurrentAccountOtpReAuthMetadata>
+
+  if (
+    typeof candidate.userId !== 'string' ||
+    typeof candidate.sessionId !== 'string' ||
+    (candidate.channel !== OtpChannel.Email && candidate.channel !== OtpChannel.Phone)
+  ) {
+    return undefined
+  }
+
+  return {
+    userId: candidate.userId,
+    sessionId: candidate.sessionId,
+    channel: candidate.channel,
+  }
+}

--- a/src/application/current-account-re-auth.ts
+++ b/src/application/current-account-re-auth.ts
@@ -1,12 +1,18 @@
 import { listActiveIdentitiesForUser } from './accounts/shared.js'
+import {
+  buildCurrentAccountOtpReAuthMetadata,
+  readCurrentAccountOtpReAuthMetadata,
+} from './current-account-re-auth-metadata.js'
 import { optionalProp } from './optional.js'
 import { normalizeOtpTarget, type SupportedOtpChannel } from './otp-delivery.js'
 import {
   cancelOtpChallenge,
+  enforceOtpFinishRateLimit,
   findOtpChallengeRecord,
   resendOtpChallenge,
   startOtpChallenge,
 } from './otp.js'
+import { consumeVerificationRecord } from './verifications.js'
 import {
   getPasswordHasher,
   findUsablePasswordIdentity,
@@ -20,8 +26,10 @@ import type {
   AuthIdentity,
   CancelCurrentAccountOtpReAuthInput,
   ConfirmCurrentAccountPasswordByTokenInput,
+  CurrentAccountOtpReAuthConfirmation,
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
+  FinishCurrentAccountOtpReAuthInput,
   CurrentAccountPasswordReAuthConfirmation,
   GetCurrentAccountReAuthStatusInput,
   OtpChannel as OtpChannelType,
@@ -109,7 +117,12 @@ export async function startCurrentAccountOtpReAuth(
     ...optionalProp('secret', input.secret),
     ...optionalProp('ttlSeconds', input.ttlSeconds),
     now: actor.now,
-    ...(input.metadata ? { metadata: input.metadata } : {}),
+    metadata: buildCurrentAccountOtpReAuthMetadata(
+      actor.userId,
+      actor.sessionId,
+      input.channel,
+      input.metadata,
+    ),
   })
 }
 
@@ -129,7 +142,12 @@ export async function resendCurrentAccountOtpReAuth(
     ...optionalProp('secret', input.secret),
     ...optionalProp('ttlSeconds', input.ttlSeconds),
     now: actor.now,
-    ...(input.metadata ? { metadata: input.metadata } : {}),
+    metadata: buildCurrentAccountOtpReAuthMetadata(
+      actor.userId,
+      actor.sessionId,
+      challenge.channel,
+      input.metadata,
+    ),
   })
 }
 
@@ -149,7 +167,45 @@ export async function cancelCurrentAccountOtpReAuth(
     purpose: VerificationPurpose.ReAuth,
     channel: challenge.channel,
     now: actor.now,
-    ...(input.metadata ? { metadata: input.metadata } : {}),
+    metadata: buildCurrentAccountOtpReAuthMetadata(
+      actor.userId,
+      actor.sessionId,
+      challenge.channel,
+      input.metadata,
+    ),
+  })
+}
+
+export async function finishCurrentAccountOtpReAuth(
+  runtime: AuthServiceRuntime,
+  input: FinishCurrentAccountOtpReAuthInput,
+): Promise<CurrentAccountOtpReAuthConfirmation> {
+  const resolved = await resolveCurrentAccountOwnedOtpReAuthChallenge(
+    runtime,
+    input.sessionToken,
+    input.verificationId,
+    input.now,
+  )
+  await enforceOtpFinishRateLimit(runtime, resolved.challenge, resolved.actor.now)
+
+  return runtime.transaction.run(async () => {
+    const { actor, challenge } = await resolveCurrentAccountOwnedOtpReAuthChallenge(
+      runtime,
+      input.sessionToken,
+      input.verificationId,
+      resolved.actor.now,
+    )
+    await consumeVerificationRecord(runtime, {
+      verificationId: challenge.verification.id,
+      secret: input.secret,
+      now: actor.now,
+    })
+
+    return {
+      currentSessionId: actor.sessionId,
+      userId: actor.userId,
+      reAuthenticatedAt: actor.now,
+    }
   })
 }
 
@@ -231,6 +287,7 @@ async function resolveCurrentAccountOwnedOtpReAuthChallenge(
 }> {
   const actor = await resolveCurrentAccountActor(runtime, sessionToken, now)
   const challenge = await getCurrentAccountOwnedOtpReAuthChallenge(runtime, verificationId)
+  const metadata = readCurrentAccountOtpReAuthMetadata(challenge.verification.metadata)
   const identities = await listActiveIdentitiesForUser(runtime, actor.userId)
   const owned = identities.some((identity) =>
     currentAccountOwnsOtpReAuthTarget(
@@ -241,7 +298,13 @@ async function resolveCurrentAccountOwnedOtpReAuthChallenge(
     ),
   )
 
-  if (!owned) {
+  if (
+    !metadata ||
+    metadata.userId !== actor.userId ||
+    metadata.sessionId !== actor.sessionId ||
+    metadata.channel !== challenge.channel ||
+    !owned
+  ) {
     throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
   }
 

--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -209,7 +209,9 @@ export async function cancelEmailMagicLinkSignIn(
 ): Promise<Verification> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
-    const verification = await findEmailMagicLinkVerification(runtime, input.verificationId)
+    const verification = await findEmailMagicLinkVerification(runtime, input.verificationId, {
+      lock: true,
+    })
 
     return cancelVerificationRecord(runtime, verification, now, input.metadata)
   })

--- a/src/application/otp.ts
+++ b/src/application/otp.ts
@@ -1,4 +1,5 @@
 import type { AuthServiceRuntime } from './runtime.js'
+import { readCurrentAccountOtpReAuthMetadata } from './current-account-re-auth-metadata.js'
 import { getOtpDelivery, normalizeOtpTarget, type SupportedOtpChannel } from './otp-delivery.js'
 import { optionalProp } from './optional.js'
 import { normalizeAssertion, signInWithAssertion } from './sign-in.js'
@@ -93,15 +94,18 @@ export async function finishOtpChallenge(
     context: 'OTP challenge',
   })
 
+  rejectCurrentAccountOtpReAuthChallenge(challenge.verification)
+
   await enforceOtpFinishRateLimit(runtime, challenge, now)
 
   return runtime.transaction.run(async () => {
-    await findOtpChallengeRecord(runtime, {
+    const currentChallenge = await findOtpChallengeRecord(runtime, {
       verificationId: input.verificationId,
       ...optionalProp('purpose', input.purpose),
       ...optionalProp('channel', input.channel),
       context: 'OTP challenge',
     })
+    rejectCurrentAccountOtpReAuthChallenge(currentChallenge.verification)
 
     return consumeVerificationRecord(runtime, {
       verificationId: input.verificationId,
@@ -187,6 +191,7 @@ export async function cancelOtpChallenge(
       ...optionalProp('purpose', input.purpose),
       ...optionalProp('channel', input.channel),
       context: 'OTP cancellation',
+      lock: true,
     })
 
     return cancelVerificationRecord(runtime, challenge.verification, now, input.metadata)
@@ -319,6 +324,15 @@ function otpChannelFromVerification(verification: Verification): SupportedOtpCha
   }
 
   return undefined
+}
+
+function rejectCurrentAccountOtpReAuthChallenge(verification: Verification): void {
+  if (
+    verification.purpose === VerificationPurpose.ReAuth &&
+    readCurrentAccountOtpReAuthMetadata(verification.metadata)
+  ) {
+    throw invalidInput('Current-account OTP re-auth must be finished on the session boundary.')
+  }
 }
 
 function assertionFromOtpVerification(

--- a/src/application/passwords/recovery.ts
+++ b/src/application/passwords/recovery.ts
@@ -203,7 +203,9 @@ export async function cancelEmailPasswordRecovery(
 ): Promise<Verification> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
-    const verification = await findPasswordRecoveryVerification(runtime, input.verificationId)
+    const verification = await findPasswordRecoveryVerification(runtime, input.verificationId, {
+      lock: true,
+    })
 
     return cancelVerificationRecord(runtime, verification, now, input.metadata)
   })

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -58,7 +58,7 @@ export async function cancelVerification(
 ): Promise<Verification> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
-    const verification = await getVerification(runtime, input.verificationId)
+    const verification = await getVerificationForUpdate(runtime, input.verificationId)
 
     return cancelVerificationRecord(runtime, verification, now, input.metadata)
   })
@@ -87,6 +87,19 @@ export async function consumeVerification(
   return runtime.transaction.run(async () => {
     return consumeVerificationRecord(runtime, input)
   })
+}
+
+export async function getVerificationForUpdate(
+  runtime: AuthServiceRuntime,
+  verificationId: Verification['id'],
+): Promise<Verification> {
+  const verification = await runtime.repos.verificationRepo.findByIdForUpdate(verificationId)
+
+  if (!verification) {
+    throw new UniAuthError(UniAuthErrorCode.VerificationNotFound, 'Verification was not found.')
+  }
+
+  return verification
 }
 
 export async function requireVerificationResendAllowed(

--- a/src/domain/flows.ts
+++ b/src/domain/flows.ts
@@ -189,6 +189,19 @@ export interface CancelCurrentAccountOtpReAuthInput {
   readonly metadata?: Record<string, unknown>
 }
 
+export interface FinishCurrentAccountOtpReAuthInput {
+  readonly sessionToken: string
+  readonly verificationId: VerificationId
+  readonly secret: string
+  readonly now?: Date
+}
+
+export interface CurrentAccountOtpReAuthConfirmation {
+  readonly currentSessionId: SessionId
+  readonly userId: UserId
+  readonly reAuthenticatedAt: Date
+}
+
 export interface GetCurrentAccountReAuthStatusInput {
   readonly sessionToken: string
   readonly action: AuthPolicyAction

--- a/src/domain/service.ts
+++ b/src/domain/service.ts
@@ -25,10 +25,12 @@ import type {
   CreateVerificationInput,
   CreateVerificationResult,
   FinishCurrentAccountContactChangeInput,
+  FinishCurrentAccountOtpReAuthInput,
   FinishOtpChallengeInput,
   FinishOtpSignInInput,
   GetAccountInspectionSnapshotInput,
   LinkCurrentIdentityByTokenInput,
+  CurrentAccountOtpReAuthConfirmation,
   CurrentAccountReAuthAssertion,
   CurrentAccountReAuthStatus,
   StartCurrentAccountOtpReAuthInput,
@@ -95,6 +97,9 @@ export interface AuthService {
     input: ResendCurrentAccountOtpReAuthInput,
   ): Promise<StartOtpChallengeResult>
   cancelCurrentAccountOtpReAuth(input: CancelCurrentAccountOtpReAuthInput): Promise<Verification>
+  finishCurrentAccountOtpReAuth(
+    input: FinishCurrentAccountOtpReAuthInput,
+  ): Promise<CurrentAccountOtpReAuthConfirmation>
   resendOtpChallenge(input: ResendOtpChallengeInput): Promise<StartOtpChallengeResult>
   finishOtpChallenge(input: FinishOtpChallengeInput): Promise<Verification>
   finishOtpSignIn(input: FinishOtpSignInInput): Promise<AuthResult>

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -348,6 +348,14 @@ describe('DefaultAuthService current-account action helpers', () => {
       }),
       now: addSeconds(now, 1),
     })
+    const aliceSecondSession = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-contact-change-owner',
+        email: 'current-account-contact-change-owner@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 2),
+    })
     const started = await service.startCurrentAccountContactChange({
       sessionToken: alice.sessionToken,
       channel: OtpChannel.Phone,
@@ -361,6 +369,16 @@ describe('DefaultAuthService current-account action helpers', () => {
         sessionToken: bob.sessionToken,
         verificationId: started.verificationId,
         secret: '333333',
+        now: addSeconds(now, 6),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountContactChange({
+        sessionToken: aliceSecondSession.sessionToken,
+        verificationId: started.verificationId,
         now: addSeconds(now, 6),
       }),
     ).rejects.toMatchObject({

--- a/test/core/current-account-reauth.test.ts
+++ b/test/core/current-account-reauth.test.ts
@@ -55,21 +55,23 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       text: 'Your sign-in code is 654321.',
     })
 
-    const verification = await service.finishOtpChallenge({
+    const confirmation = await service.finishCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
       verificationId: challenge.verificationId,
       secret: '654321',
-      purpose: VerificationPurpose.ReAuth,
-      channel: OtpChannel.Email,
       now: addSeconds(now, 11),
     })
 
-    expect(verification.consumedAt).toEqual(addSeconds(now, 11))
-    const reAuthenticatedAt = verification.consumedAt ?? addSeconds(now, 11)
+    expect(confirmation).toEqual({
+      currentSessionId: signedIn.session.id,
+      userId: signedIn.user.id,
+      reAuthenticatedAt: addSeconds(now, 11),
+    })
 
     await service.unlinkCurrentIdentityByToken({
       sessionToken: signedIn.sessionToken,
       identityId: linked.identity.id,
-      reAuthenticatedAt,
+      reAuthenticatedAt: confirmation.reAuthenticatedAt,
       now: addSeconds(now, 11),
     })
 
@@ -214,9 +216,9 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
           id: resent.verificationId,
           purpose: VerificationPurpose.ReAuth,
           target: 'current-account-reauth-resend@example.com',
-          metadata: {
-            source: 'current-account-reauth-resend',
-          },
+          metadata: expect.objectContaining({
+            requestMetadata: { source: 'current-account-reauth-resend' },
+          }),
         }),
       ]),
     )
@@ -239,18 +241,22 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
           metadata: {
             verificationId: resent.verificationId,
             purpose: VerificationPurpose.ReAuth,
-            source: 'current-account-reauth-cancel',
+            currentAccountOtpReAuth: {
+              userId: signedIn.user.id,
+              sessionId: signedIn.session.id,
+              channel: OtpChannel.Email,
+            },
+            requestMetadata: { source: 'current-account-reauth-cancel' },
           },
         }),
       ]),
     )
 
     await expect(
-      service.finishOtpChallenge({
+      service.finishCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
         verificationId: resent.verificationId,
         secret: '222222',
-        purpose: VerificationPurpose.ReAuth,
-        channel: OtpChannel.Email,
         now: addSeconds(now, 22),
       }),
     ).rejects.toMatchObject({
@@ -276,6 +282,14 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       }),
       now: addSeconds(now, 1),
     })
+    const aliceSecondSession = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-neutral-owner',
+        email: 'current-account-reauth-neutral-owner@example.com',
+        emailVerified: true,
+      }),
+      now: addSeconds(now, 2),
+    })
 
     const ownedChallenge = await service.startCurrentAccountOtpReAuth({
       sessionToken: alice.sessionToken,
@@ -283,6 +297,27 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       channel: OtpChannel.Email,
       secret: '333333',
       now: addSeconds(now, 10),
+    })
+    const missingMetadataChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.ReAuth,
+      channel: OtpChannel.Email,
+      target: 'current-account-reauth-neutral-owner@example.com',
+      secret: '555555',
+      now: addSeconds(now, 11),
+    })
+    const malformedMetadataChallenge = await service.startOtpChallenge({
+      purpose: VerificationPurpose.ReAuth,
+      channel: OtpChannel.Email,
+      target: 'current-account-reauth-neutral-owner@example.com',
+      secret: '666666',
+      now: addSeconds(now, 11),
+      metadata: {
+        currentAccountOtpReAuth: {
+          userId: 1,
+          sessionId: alice.session.id,
+          channel: OtpChannel.Email,
+        },
+      },
     })
     const signInChallenge = await service.startOtpChallenge({
       purpose: VerificationPurpose.SignIn,
@@ -293,7 +328,56 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
     })
 
     await expect(
+      service.finishOtpChallenge({
+        verificationId: ownedChallenge.verificationId,
+        secret: '333333',
+        purpose: VerificationPurpose.ReAuth,
+        channel: OtpChannel.Email,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
+    for (const verificationId of [
+      missingMetadataChallenge.verificationId,
+      malformedMetadataChallenge.verificationId,
+    ]) {
+      await expect(
+        service.finishCurrentAccountOtpReAuth({
+          sessionToken: alice.sessionToken,
+          verificationId,
+          secret: '555555',
+          now: addSeconds(now, 20),
+        }),
+      ).rejects.toMatchObject({
+        code: UniAuthErrorCode.VerificationNotFound,
+      })
+    }
+
+    await expect(
       service.resendCurrentAccountOtpReAuth({
+        sessionToken: aliceSecondSession.sessionToken,
+        verificationId: ownedChallenge.verificationId,
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await expect(
+      service.finishCurrentAccountOtpReAuth({
+        sessionToken: aliceSecondSession.sessionToken,
+        verificationId: ownedChallenge.verificationId,
+        secret: '333333',
+        now: addSeconds(now, 20),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
+    })
+
+    await expect(
+      service.cancelCurrentAccountOtpReAuth({
         sessionToken: bob.sessionToken,
         verificationId: ownedChallenge.verificationId,
         now: addSeconds(now, 20),

--- a/test/postgres/current-account-reauth.test.ts
+++ b/test/postgres/current-account-reauth.test.ts
@@ -50,19 +50,17 @@ describe('Postgres current-account re-auth helpers', () => {
       text: 'Your sign-in code is 654321.',
     })
 
-    const verification = await service.finishOtpChallenge({
+    const confirmation = await service.finishCurrentAccountOtpReAuth({
+      sessionToken: signedIn.sessionToken,
       verificationId: challenge.verificationId,
       secret: '654321',
-      purpose: VerificationPurpose.ReAuth,
-      channel: OtpChannel.Email,
       now: addSeconds(now, 11),
     })
-    const reAuthenticatedAt = verification.consumedAt ?? addSeconds(now, 11)
 
     await service.unlinkCurrentIdentityByToken({
       sessionToken: signedIn.sessionToken,
       identityId: linked.identity.id,
-      reAuthenticatedAt,
+      reAuthenticatedAt: confirmation.reAuthenticatedAt,
       now: addSeconds(now, 11),
     })
 
@@ -124,9 +122,9 @@ describe('Postgres current-account re-auth helpers', () => {
       id: resent.verificationId,
       purpose: VerificationPurpose.ReAuth,
       target: 'pg-current-account-reauth-resend@example.com',
-      metadata: {
-        source: 'pg-current-account-reauth-resend',
-      },
+      metadata: expect.objectContaining({
+        requestMetadata: { source: 'pg-current-account-reauth-resend' },
+      }),
     })
 
     const cancelled = await service.cancelCurrentAccountOtpReAuth({
@@ -147,18 +145,22 @@ describe('Postgres current-account re-auth helpers', () => {
           metadata: {
             verificationId: resent.verificationId,
             purpose: VerificationPurpose.ReAuth,
-            source: 'pg-current-account-reauth-cancel',
+            currentAccountOtpReAuth: {
+              userId: signedIn.user.id,
+              sessionId: signedIn.session.id,
+              channel: OtpChannel.Email,
+            },
+            requestMetadata: { source: 'pg-current-account-reauth-cancel' },
           },
         }),
       ]),
     )
 
     await expect(
-      service.finishOtpChallenge({
+      service.finishCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
         verificationId: resent.verificationId,
         secret: '222222',
-        purpose: VerificationPurpose.ReAuth,
-        channel: OtpChannel.Email,
         now: addSeconds(now, 22),
       }),
     ).rejects.toMatchObject({

--- a/test/verification-cancellation.test.ts
+++ b/test/verification-cancellation.test.ts
@@ -6,6 +6,7 @@ import {
   VerificationPurpose,
   VerificationStatus,
   addSeconds,
+  asVerificationId,
 } from '../src'
 import { createInMemoryAuthKit } from '../src/testing'
 import { now } from './helpers.js'
@@ -219,6 +220,84 @@ describe('verification cancellation flows', () => {
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
+    })
+  })
+
+  it('uses locked verification reads for cancellation helpers', async () => {
+    const { service, store } = createInMemoryAuthKit({
+      clock: { now: () => addSeconds(now, 90) },
+    })
+    const generic = await service.createVerification({
+      purpose: VerificationPurpose.SignIn,
+      target: 'locked-generic@example.com',
+      secret: '111111',
+      now,
+    })
+    const otp = await service.startOtpChallenge({
+      purpose: VerificationPurpose.SignIn,
+      channel: OtpChannel.Email,
+      target: 'locked-otp@example.com',
+      secret: '222222',
+      now,
+    })
+    const magic = await service.startEmailMagicLinkSignIn({
+      email: 'locked-magic@example.com',
+      secret: 'magic-secret',
+      createLink: ({ verificationId, secret }) =>
+        `https://example.com/magic?verificationId=${verificationId}&secret=${secret}`,
+      now,
+    })
+    const recovery = await service.startEmailPasswordRecovery({
+      email: 'locked-recovery@example.com',
+      secret: 'recovery-secret',
+      createLink: ({ verificationId, secret }) =>
+        `https://example.com/recovery?verificationId=${verificationId}&secret=${secret}`,
+      now,
+    })
+    const originalFindById = store.verificationRepo.findById
+    const originalFindByIdForUpdate = store.verificationRepo.findByIdForUpdate
+    let lockedReads = 0
+
+    store.verificationRepo.findById = async () => {
+      throw new Error('unlocked verification read')
+    }
+    store.verificationRepo.findByIdForUpdate = async (id) => {
+      lockedReads += 1
+      return originalFindByIdForUpdate(id)
+    }
+
+    await expect(
+      service.cancelVerification({ verificationId: generic.verification.id }),
+    ).resolves.toMatchObject({ id: generic.verification.id })
+    await expect(
+      service.cancelOtpChallenge({
+        verificationId: otp.verificationId,
+        channel: OtpChannel.Email,
+      }),
+    ).resolves.toMatchObject({ id: otp.verificationId })
+    await expect(
+      service.cancelEmailMagicLinkSignIn({ verificationId: magic.verificationId }),
+    ).resolves.toMatchObject({ id: magic.verificationId })
+    await expect(
+      service.cancelEmailPasswordRecovery({ verificationId: recovery.verificationId }),
+    ).resolves.toMatchObject({ id: recovery.verificationId })
+
+    expect(lockedReads).toBe(4)
+
+    store.verificationRepo.findById = originalFindById
+    store.verificationRepo.findByIdForUpdate = originalFindByIdForUpdate
+  })
+
+  it('returns not found when locked cancellation lookup misses', async () => {
+    const { service } = createInMemoryAuthKit()
+
+    await expect(
+      service.cancelVerification({
+        verificationId: asVerificationId('missing-locked-verification'),
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.VerificationNotFound,
     })
   })
 


### PR DESCRIPTION
## Summary

- Lock verification cancellation lookups before deciding whether a verification is still usable.
- Bind current-account contact-change management to the originating session.
- Add a session-bound current-account OTP re-auth finish flow and block generic OTP finish from consuming those challenges.

## Checks

- npm run check

Closes #329
Closes #330
Closes #331