### PR TITLE
Harden Postgres writes and provider metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,11 @@ identities, and email/phone are optional identity attributes.
 - `getCurrentAccountClosureExportSnapshot`
 - `getCurrentAccountAuditEventPage`
 - `startCurrentAccountOtpReAuth`
+- `resendCurrentAccountOtpReAuth`
+- `cancelCurrentAccountOtpReAuth`
+- `finishCurrentAccountOtpReAuth`
+- `getCurrentAccountReAuthStatus`
+- `assertCurrentAccountReAuth`
 - `linkCurrentIdentityByToken`
 - `revokeCurrentSessionByToken`
 - `revokeOwnedSessionByToken`
@@ -91,13 +96,13 @@ audit page reads, so self-service security routes do not have to mix admin inspe
 manual session ownership resolution. Selected-device revoke, sign-in-method link or unlink, and
 local password setup or change can now stay on that same token-based boundary instead of bouncing
 back to raw `userId` mutation calls after middleware resolution. Recent-auth bootstrapping can now
-stay on the same trusted boundary too: applications can start current-account OTP re-auth by owned
-identity or confirm the current password from `sessionToken`, then persist the resulting
-`reAuthenticatedAt` marker in app-owned session state. The same layer can now also answer or
-enforce whether recent auth is currently required for a specific sensitive current-account action
-before application-owned side effects continue. Resend and cancellation of those current-account
-OTP re-auth challenges can stay on that trusted token boundary as well instead of dropping back to
-generic verification ownership checks in route code. Account closure follows the same shape:
+stay on the same trusted boundary too: applications can start, resend, finish, or cancel
+current-account OTP re-auth by owned identity and `sessionToken`, or confirm the current password
+from `sessionToken`, then persist the resulting `reAuthenticatedAt` marker in app-owned session
+state. The same layer can now also answer or enforce whether recent auth is currently required for
+a specific sensitive current-account action before application-owned side effects continue, without
+dropping back to generic verification ownership checks in route code. Account closure follows the
+same shape:
 the current session token identifies the actor, core disables the current user, revokes active
 local sessions, and leaves cookie clearing, legal retention, and downstream data deletion to the
 application. Pre-closure export snapshots also stay on that boundary: core returns safe local auth

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -171,6 +171,35 @@ Fastify ownership notes:
   action, linking, and recent-auth helpers instead of rebuilding session + user + snapshot
   composition by hand.
 
+## Current-Account Recent Auth
+
+Sensitive self-service routes should keep recent-auth proof on the same trusted `sessionToken`
+boundary as account-security reads and writes. Start and finish OTP re-auth through the
+current-account helpers, then persist the resulting marker in app-owned session state:
+
+```ts
+app.post('/auth/account/reauth/otp/finish', requireSession, async (req, res, next) => {
+  try {
+    const confirmation = await authService.finishCurrentAccountOtpReAuth({
+      sessionToken: req.auth.sessionToken,
+      verificationId: req.body.verificationId,
+      secret: req.body.code,
+    })
+
+    req.auth.reAuthenticatedAt = confirmation.reAuthenticatedAt
+    res.status(204).send()
+  } catch (error) {
+    next(error)
+  }
+})
+```
+
+Use `startCurrentAccountOtpReAuth(...)`, `resendCurrentAccountOtpReAuth(...)`, and
+`cancelCurrentAccountOtpReAuth(...)` for the rest of that challenge lifecycle. For password-based
+recent-auth, use `confirmCurrentAccountPasswordByToken(...)` and store the returned
+`reAuthenticatedAt` marker the same way. The framework still owns request validation, browser UI,
+recent-auth marker TTL, cookies, and redirects.
+
 ## Nest
 
 Use Nest when you want DI, modules, guards, and controller/service separation.

--- a/src/application/sign-in/assertion.ts
+++ b/src/application/sign-in/assertion.ts
@@ -73,7 +73,10 @@ export function normalizeAssertion(
       : {}),
     ...optionalProp('displayName', displayName),
     ...optionalProp('trust', normalizeProviderTrust(assertion.trust)),
-    ...optionalProp('metadata', assertion.metadata),
+    ...optionalProp(
+      'metadata',
+      normalizeMetadata(assertion.metadata, 'Provider assertion metadata'),
+    ),
   }
 }
 
@@ -136,6 +139,30 @@ function normalizeProviderTrust(
   return {
     level,
     ...(signals && signals.length > 0 ? { signals: [...new Set(signals)] } : {}),
-    ...optionalProp('metadata', trust.metadata),
+    ...optionalProp('metadata', normalizeMetadata(trust.metadata, 'Provider trust metadata')),
   }
+}
+
+function normalizeMetadata(
+  metadata: Record<string, unknown> | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  if (metadata === undefined) {
+    return undefined
+  }
+
+  if (!isPlainObject(metadata)) {
+    throw invalidInput(`${name} must be a plain object.`)
+  }
+
+  return metadata
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown
+  return prototype === Object.prototype || prototype === null
 }

--- a/src/postgres/store/sessions.ts
+++ b/src/postgres/store/sessions.ts
@@ -2,6 +2,7 @@ import { UniAuthError, UniAuthErrorCode } from '../../errors.js'
 import type { SessionRepo } from '../../contracts.js'
 import {
   buildUpdateQuery,
+  mapSessionWriteError,
   mapSessionRow,
   type PostgresStoreContext,
   type SessionRow,
@@ -40,28 +41,33 @@ export function createSessionRepo(context: PostgresStoreContext): SessionRepo {
         [userId],
         mapSessionRow,
       ),
-    create: async (session) =>
-      context.queryRequiredRow<SessionRow, ReturnType<typeof mapSessionRow>>(
-        `insert into uniauth_sessions (
-           id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
-           metadata
-         ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-         returning
-           id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
-           metadata`,
-        [
-          session.id,
-          session.userId,
-          session.tokenHash,
-          session.status,
-          session.createdAt,
-          session.expiresAt,
-          session.revokedAt ?? null,
-          session.lastSeenAt ?? null,
-          session.metadata ?? null,
-        ],
-        mapSessionRow,
-      ),
+    create: async (session) => {
+      try {
+        return await context.queryRequiredRow<SessionRow, ReturnType<typeof mapSessionRow>>(
+          `insert into uniauth_sessions (
+             id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
+             metadata
+           ) values ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           returning
+             id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
+             metadata`,
+          [
+            session.id,
+            session.userId,
+            session.tokenHash,
+            session.status,
+            session.createdAt,
+            session.expiresAt,
+            session.revokedAt ?? null,
+            session.lastSeenAt ?? null,
+            session.metadata ?? null,
+          ],
+          mapSessionRow,
+        )
+      } catch (error) {
+        throw mapSessionWriteError(error)
+      }
+    },
     update: async (id, patch) => {
       const existing = await repo.findById(id)
 
@@ -83,16 +89,20 @@ export function createSessionRepo(context: PostgresStoreContext): SessionRepo {
         return existing
       }
 
-      return context.queryRequiredRow<SessionRow, ReturnType<typeof mapSessionRow>>(
-        `update uniauth_sessions
-         set ${update.setClause}
-         where id = $${update.values.length + 1}
-         returning
-           id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
-           metadata`,
-        [...update.values, id],
-        mapSessionRow,
-      )
+      try {
+        return await context.queryRequiredRow<SessionRow, ReturnType<typeof mapSessionRow>>(
+          `update uniauth_sessions
+           set ${update.setClause}
+           where id = $${update.values.length + 1}
+           returning
+             id, user_id, token_hash, status, created_at, expires_at, revoked_at, last_seen_at,
+             metadata`,
+          [...update.values, id],
+          mapSessionRow,
+        )
+      } catch (error) {
+        throw mapSessionWriteError(error)
+      }
     },
   }
 

--- a/src/postgres/store/shared.ts
+++ b/src/postgres/store/shared.ts
@@ -25,6 +25,7 @@ import { UniAuthError, UniAuthErrorCode } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
 
 const UniqueViolationCode = '23505'
+const ForeignKeyViolationCode = '23503'
 
 export interface UserRow {
   readonly id: string
@@ -240,6 +241,10 @@ export function buildUpdateQuery<Patch extends object, Key extends Extract<keyof
 }
 
 export function mapIdentityWriteError(error: unknown): Error {
+  if (isForeignKeyViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+  }
+
   if (isUniqueViolation(error)) {
     return new UniAuthError(UniAuthErrorCode.IdentityAlreadyLinked, 'Identity cannot be linked.')
   }
@@ -248,8 +253,24 @@ export function mapIdentityWriteError(error: unknown): Error {
 }
 
 export function mapCredentialWriteError(error: unknown): Error {
+  if (isForeignKeyViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+  }
+
   if (isUniqueViolation(error)) {
     return new UniAuthError(UniAuthErrorCode.CredentialAlreadyExists, 'Credential already exists.')
+  }
+
+  return toError(error)
+}
+
+export function mapSessionWriteError(error: unknown): Error {
+  if (isForeignKeyViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+  }
+
+  if (isUniqueViolation(error)) {
+    return new UniAuthError(UniAuthErrorCode.InvalidInput, 'Session token already exists.')
   }
 
   return toError(error)
@@ -258,6 +279,12 @@ export function mapCredentialWriteError(error: unknown): Error {
 function isUniqueViolation(error: unknown): boolean {
   return typeof error === 'object' && error !== null && 'code' in error
     ? (error as { code?: unknown }).code === UniqueViolationCode
+    : false
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? (error as { code?: unknown }).code === ForeignKeyViolationCode
     : false
 }
 

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -367,15 +367,23 @@ describe('PostgresAuthStore unit coverage', () => {
   it('maps write failures into domain and generic errors', async () => {
     const identityWriteError = new Error('identity write failed')
     const credentialWriteError = new Error('credential write failed')
+    const sessionWriteError = new Error('session write failed')
     const harness = createStubPool([
       failure({ code: '23505' }),
+      failure({ code: '23503' }),
       failure('identity-unknown'),
       result([identityRow()]),
       failure(identityWriteError),
       failure({ code: '23505' }),
+      failure({ code: '23503' }),
       failure('credential-unknown'),
       result([credentialRow()]),
       failure(credentialWriteError),
+      failure({ code: '23505' }),
+      failure({ code: '23503' }),
+      failure('session-unknown'),
+      result([sessionRow()]),
+      failure(sessionWriteError),
     ])
     const store = createPostgresAuthStore({ pool: harness.pool })
 
@@ -391,6 +399,19 @@ describe('PostgresAuthStore unit coverage', () => {
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.IdentityAlreadyLinked,
+    })
+    await expect(
+      store.identityRepo.create({
+        id: asIdentityId('identity-create-fk'),
+        userId: asUserId('missing-user'),
+        provider: 'oidc',
+        providerUserId: 'provider-user-create-fk',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
     })
     await expect(
       store.identityRepo.create({
@@ -424,6 +445,19 @@ describe('PostgresAuthStore unit coverage', () => {
     })
     await expect(
       store.credentialRepo.create({
+        id: asCredentialId('credential-create-fk'),
+        userId: asUserId('missing-user'),
+        type: 'password',
+        subject: 'missing-user@example.com',
+        passwordHash: 'hash',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    await expect(
+      store.credentialRepo.create({
         id: asCredentialId('credential-create-2'),
         userId: asUserId('user-1'),
         type: 'password',
@@ -436,6 +470,44 @@ describe('PostgresAuthStore unit coverage', () => {
     await expect(
       store.credentialRepo.update(asCredentialId('credential-1'), { passwordHash: 'new-hash' }),
     ).rejects.toBe(credentialWriteError)
+
+    await expect(
+      store.sessionRepo.create({
+        id: asSessionId('session-create-1'),
+        userId: asUserId('user-1'),
+        tokenHash: 'duplicate-token-hash',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      store.sessionRepo.create({
+        id: asSessionId('session-create-fk'),
+        userId: asUserId('missing-user'),
+        tokenHash: 'missing-user-token-hash',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    await expect(
+      store.sessionRepo.create({
+        id: asSessionId('session-create-2'),
+        userId: asUserId('user-1'),
+        tokenHash: 'unknown-error-token-hash',
+        status: 'active',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        expiresAt: new Date('2026-02-01T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('Unknown Postgres error.')
+    await expect(
+      store.sessionRepo.update(asSessionId('session-1'), { tokenHash: 'new-token-hash' }),
+    ).rejects.toBe(sessionWriteError)
 
     expect(harness.remainingSteps).toBe(0)
   })

--- a/test/postgres/persistence-and-merge.test.ts
+++ b/test/postgres/persistence-and-merge.test.ts
@@ -49,10 +49,12 @@ describe('Postgres reference persistence repository coverage and merge', () => {
     }
 
     await store.credentialRepo.create(credential)
+    const sessionTokenHash = hashSecret('pg-session-token')
+
     await store.sessionRepo.create({
       id: createSequentialIdGenerator('pg-session').sessionId(),
       userId: createdUser.id,
-      tokenHash: hashSecret('pg-session-token'),
+      tokenHash: sessionTokenHash,
       status: 'active',
       createdAt: now,
       expiresAt: new Date('2026-01-31T00:00:00.000Z'),
@@ -119,6 +121,18 @@ describe('Postgres reference persistence repository coverage and merge', () => {
         })
         .catch((caught: unknown) => caught),
     ).toMatchObject({ code: UniAuthErrorCode.CredentialAlreadyExists })
+    expect(
+      await store.sessionRepo
+        .create({
+          id: asSessionId('pg-session-duplicate'),
+          userId: createdUser.id,
+          tokenHash: sessionTokenHash,
+          status: SessionStatus.Active,
+          createdAt: now,
+          expiresAt: new Date('2026-01-31T00:00:00.000Z'),
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
   })
 
   it('runs core auth flows on top of the Postgres store', async () => {

--- a/test/provider-policy/provider-resolution-and-validation.test.ts
+++ b/test/provider-policy/provider-resolution-and-validation.test.ts
@@ -113,5 +113,55 @@ describe('provider resolution and assertion validation failures', () => {
         })
         .catch((caught: unknown) => caught),
     ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'oauth',
+            providerUserId: 'invalid-assertion-metadata',
+            metadata: ['not-a-record'],
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'oauth',
+            providerUserId: 'invalid-trust-metadata',
+            trust: {
+              level: 'trusted',
+              metadata: ['not-a-record'],
+            },
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+
+    const nullPrototypeMetadata = Object.assign(Object.create(null) as Record<string, unknown>, {
+      source: 'provider',
+    })
+
+    await expect(
+      noRegistryService.signIn({
+        assertion: assertion({
+          provider: 'oauth',
+          providerUserId: 'plain-metadata',
+          metadata: { source: 'assertion' },
+          trust: {
+            level: 'trusted',
+            metadata: nullPrototypeMetadata,
+          },
+        }),
+        now,
+      }),
+    ).resolves.toMatchObject({
+      identity: {
+        metadata: { source: 'assertion' },
+      },
+    })
   })
 })


### PR DESCRIPTION
## Summary
- map Postgres session write failures and foreign-key violations to stable domain errors
- reject non-object provider assertion and trust metadata before materialization
- refresh recent-auth backend docs for the current-account OTP finish boundary

## Checks
- npm run check

Closes #333
Closes #334
Closes #335