### PR TITLE
Harden current-account metadata and store parity

### DIFF
--- a/src/application/current-account-actions.ts
+++ b/src/application/current-account-actions.ts
@@ -1,4 +1,5 @@
 import { link, unlink } from './accounts.js'
+import { normalizeMetadataRecord } from './metadata.js'
 import { optionalProp } from './optional.js'
 import { changePassword, setPassword } from './passwords.js'
 import type { AuthServiceRuntime } from './runtime.js'
@@ -58,6 +59,7 @@ export async function linkCurrentIdentityByToken(
 ): Promise<LinkResult> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -70,7 +72,7 @@ export async function linkCurrentIdentityByToken(
       ...optionalProp('finishInput', input.finishInput),
       ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
       now,
-      ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...optionalProp('metadata', metadata),
     })
   })
 }
@@ -81,6 +83,7 @@ export async function unlinkCurrentIdentityByToken(
 ): Promise<void> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -91,7 +94,7 @@ export async function unlinkCurrentIdentityByToken(
       identityId: input.identityId,
       ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
       now,
-      ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...optionalProp('metadata', metadata),
     })
   })
 }
@@ -102,6 +105,7 @@ export async function closeCurrentAccountByToken(
 ): Promise<CloseCurrentAccountByTokenResult> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { session, user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -129,7 +133,7 @@ export async function closeCurrentAccountByToken(
       sessionId: session.id,
       metadata: {
         revokedSessionIds: [...revoked.revokedSessionIds],
-        ...optionalProp('requestMetadata', input.metadata),
+        ...optionalProp('requestMetadata', metadata),
       },
     })
 
@@ -147,6 +151,7 @@ export async function updateCurrentAccountProfileByToken(
 ): Promise<User> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { session, user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -168,7 +173,7 @@ export async function updateCurrentAccountProfileByToken(
       sessionId: session.id,
       metadata: {
         changedFields: [CurrentAccountProfileField.DisplayName],
-        ...optionalProp('requestMetadata', input.metadata),
+        ...optionalProp('requestMetadata', metadata),
       },
     })
 
@@ -182,6 +187,7 @@ export async function setCurrentAccountPasswordByToken(
 ): Promise<Credential> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -198,7 +204,7 @@ export async function setCurrentAccountPasswordByToken(
       password: input.password,
       ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
       now,
-      ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...optionalProp('metadata', metadata),
     })
   })
 }
@@ -209,6 +215,7 @@ export async function changeCurrentAccountPasswordByToken(
 ): Promise<Credential> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeCurrentAccountMetadata(input.metadata)
     const { user } = await resolveSessionContext(runtime, {
       sessionToken: input.sessionToken,
       now,
@@ -220,9 +227,15 @@ export async function changeCurrentAccountPasswordByToken(
       newPassword: input.newPassword,
       ...optionalProp('reAuthenticatedAt', input.reAuthenticatedAt),
       now,
-      ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...optionalProp('metadata', metadata),
     })
   })
+}
+
+function normalizeCurrentAccountMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Current-account request metadata')
 }
 
 function normalizeCurrentAccountProfilePatch(

--- a/src/application/current-account-contact-change.ts
+++ b/src/application/current-account-contact-change.ts
@@ -1,4 +1,5 @@
 import { optionalProp } from './optional.js'
+import { normalizeMetadataRecord } from './metadata.js'
 import { normalizeOtpTarget, type SupportedOtpChannel } from './otp-delivery.js'
 import {
   cancelOtpChallenge,
@@ -49,6 +50,7 @@ export async function startCurrentAccountContactChange(
   input: StartCurrentAccountContactChangeInput,
 ): Promise<StartOtpChallengeResult> {
   const now = input.now ?? runtime.clock.now()
+  const metadata = normalizeCurrentAccountContactChangeMetadata(input.metadata)
   const { session, user } = await resolveSessionContext(runtime, {
     sessionToken: input.sessionToken,
     now,
@@ -70,7 +72,7 @@ export async function startCurrentAccountContactChange(
       user.id,
       session.id,
       input.channel,
-      input.metadata,
+      metadata,
     ),
   })
 }
@@ -95,7 +97,7 @@ export async function resendCurrentAccountContactChange(
       actor.userId,
       actor.sessionId,
       challenge.channel,
-      input.metadata,
+      normalizeCurrentAccountContactChangeMetadata(input.metadata),
     ),
   })
 }
@@ -120,7 +122,7 @@ export async function cancelCurrentAccountContactChange(
       actor.userId,
       actor.sessionId,
       challenge.channel,
-      input.metadata,
+      normalizeCurrentAccountContactChangeMetadata(input.metadata),
     ),
   })
 }
@@ -135,6 +137,7 @@ export async function finishCurrentAccountContactChange(
     input.verificationId,
     input.now,
   )
+  const requestMetadata = normalizeCurrentAccountContactChangeMetadata(input.metadata)
   await enforceOtpFinishRateLimit(runtime, resolved.challenge, resolved.actor.now)
 
   return runtime.transaction.run(async () => {
@@ -161,7 +164,7 @@ export async function finishCurrentAccountContactChange(
         verificationId: consumed.id,
         channel: challenge.channel,
         changedFields: [contactFieldFromChannel(challenge.channel)],
-        ...optionalProp('requestMetadata', input.metadata),
+        ...optionalProp('requestMetadata', requestMetadata),
       },
     })
 
@@ -189,6 +192,12 @@ function rejectUnchangedContact(user: User, channel: OtpChannelType, target: str
   if (channel === OtpChannel.Phone && user.phone === target) {
     throw invalidInput('Current account phone already matches the requested target.')
   }
+}
+
+function normalizeCurrentAccountContactChangeMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Current-account contact change metadata')
 }
 
 function buildCurrentAccountContactChangeMetadata(

--- a/src/application/current-account-re-auth-metadata.ts
+++ b/src/application/current-account-re-auth-metadata.ts
@@ -1,3 +1,4 @@
+import { normalizeMetadataRecord } from './metadata.js'
 import { optionalProp } from './optional.js'
 import { OtpChannel, type SessionId, type UserId } from '../domain/types.js'
 import type { SupportedOtpChannel } from './otp-delivery.js'
@@ -16,13 +17,18 @@ export function buildCurrentAccountOtpReAuthMetadata(
   channel: SupportedOtpChannel,
   requestMetadata: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
+  const normalizedRequestMetadata = normalizeMetadataRecord(
+    requestMetadata,
+    'Current-account OTP re-auth metadata',
+  )
+
   return {
     [CURRENT_ACCOUNT_OTP_RE_AUTH_METADATA_KEY]: {
       userId,
       sessionId,
       channel,
     },
-    ...optionalProp('requestMetadata', requestMetadata),
+    ...optionalProp('requestMetadata', normalizedRequestMetadata),
   }
 }
 

--- a/src/application/current-account-re-auth.ts
+++ b/src/application/current-account-re-auth.ts
@@ -233,6 +233,7 @@ export async function confirmCurrentAccountPasswordByToken(
     await findUsablePasswordIdentity(runtime, credential, credential.subject)
 
     return {
+      currentSessionId: actor.sessionId,
       userId: actor.userId,
       reAuthenticatedAt: actor.now,
     }

--- a/src/application/metadata.ts
+++ b/src/application/metadata.ts
@@ -1,0 +1,25 @@
+import { invalidInput } from '../errors.js'
+
+export function normalizeMetadataRecord(
+  metadata: Record<string, unknown> | undefined,
+  name: string,
+): Record<string, unknown> | undefined {
+  if (metadata === undefined) {
+    return undefined
+  }
+
+  if (!isPlainObject(metadata)) {
+    throw invalidInput(`${name} must be a plain object.`)
+  }
+
+  return metadata
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown
+  return prototype === Object.prototype || prototype === null
+}

--- a/src/application/sign-in/assertion.ts
+++ b/src/application/sign-in/assertion.ts
@@ -1,5 +1,6 @@
 import { optionalProp } from '../optional.js'
 import type { AuthServiceRuntime } from '../runtime.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import {
   ProviderTrustLevel,
   type FinishInput,
@@ -75,7 +76,7 @@ export function normalizeAssertion(
     ...optionalProp('trust', normalizeProviderTrust(assertion.trust)),
     ...optionalProp(
       'metadata',
-      normalizeMetadata(assertion.metadata, 'Provider assertion metadata'),
+      normalizeMetadataRecord(assertion.metadata, 'Provider assertion metadata'),
     ),
   }
 }
@@ -139,30 +140,6 @@ function normalizeProviderTrust(
   return {
     level,
     ...(signals && signals.length > 0 ? { signals: [...new Set(signals)] } : {}),
-    ...optionalProp('metadata', normalizeMetadata(trust.metadata, 'Provider trust metadata')),
+    ...optionalProp('metadata', normalizeMetadataRecord(trust.metadata, 'Provider trust metadata')),
   }
-}
-
-function normalizeMetadata(
-  metadata: Record<string, unknown> | undefined,
-  name: string,
-): Record<string, unknown> | undefined {
-  if (metadata === undefined) {
-    return undefined
-  }
-
-  if (!isPlainObject(metadata)) {
-    throw invalidInput(`${name} must be a plain object.`)
-  }
-
-  return metadata
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return false
-  }
-
-  const prototype = Object.getPrototypeOf(value) as unknown
-  return prototype === Object.prototype || prototype === null
 }

--- a/src/domain/local-auth.ts
+++ b/src/domain/local-auth.ts
@@ -1,4 +1,4 @@
-import type { UserId, VerificationId } from './ids.js'
+import type { SessionId, UserId, VerificationId } from './ids.js'
 import type { OtpChannel } from './kinds.js'
 
 export interface EmailMagicLink {
@@ -55,6 +55,7 @@ export interface SignInWithPasswordInput {
 }
 
 export interface CurrentAccountPasswordReAuthConfirmation {
+  readonly currentSessionId: SessionId
   readonly userId: UserId
   readonly reAuthenticatedAt: Date
 }

--- a/src/testing/in-memory/store.ts
+++ b/src/testing/in-memory/store.ts
@@ -103,6 +103,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
     listByUserId: async (userId) =>
       [...this.identities.values()].filter((identity) => identity.userId === userId),
     create: async (identity) => {
+      this.assertUserExists(identity.userId)
       const key = this.identityKey(identity.provider, identity.providerUserId)
 
       if (this.identityKeys.has(key)) {
@@ -121,6 +122,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       }
 
       const updated = applyPatch(existing, patch)
+      this.assertUserExists(updated.userId)
       const oldKey = this.identityKey(existing.provider, existing.providerUserId)
       const newKey = this.identityKey(updated.provider, updated.providerUserId)
       const existingIdentityId = this.identityKeys.get(newKey)
@@ -152,6 +154,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
     listByUserId: async (userId) =>
       [...this.credentials.values()].filter((credential) => credential.userId === userId),
     create: async (credential) => {
+      this.assertUserExists(credential.userId)
       const key = this.credentialKey(credential.type, credential.subject)
       const userKey = this.credentialUserKey(credential.type, credential.userId)
 
@@ -175,6 +178,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       }
 
       const updated = applyPatch(existing, patch)
+      this.assertUserExists(updated.userId)
       const oldKey = this.credentialKey(existing.type, existing.subject)
       const newKey = this.credentialKey(updated.type, updated.subject)
       const oldUserKey = this.credentialUserKey(existing.type, existing.userId)
@@ -230,6 +234,8 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
     listByUserId: async (userId) =>
       [...this.sessions.values()].filter((session) => session.userId === userId),
     create: async (session) => {
+      this.assertUserExists(session.userId)
+
       if (this.sessionKeys.has(session.tokenHash)) {
         throw new UniAuthError(UniAuthErrorCode.InvalidInput, 'Session token already exists.')
       }
@@ -246,6 +252,7 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
       }
 
       const updated = applyPatch(existing, patch)
+      this.assertUserExists(updated.userId)
       const existingSessionId = this.sessionKeys.get(updated.tokenHash)
 
       if (updated.tokenHash !== existing.tokenHash && existingSessionId) {
@@ -324,6 +331,12 @@ export class InMemoryAuthStore implements AuthServiceRepositories, UnitOfWork {
 
   listAuditEvents(): readonly AuditEvent[] {
     return [...this.auditEvents]
+  }
+
+  private assertUserExists(userId: User['id']): void {
+    if (!this.users.has(userId)) {
+      throw new UniAuthError(UniAuthErrorCode.UserNotFound, 'User was not found.')
+    }
   }
 
   private identityKey(provider: AuthIdentityProvider, providerUserId: string): string {

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -1018,6 +1018,91 @@ describe('DefaultAuthService current-account action helpers', () => {
     })
   })
 
+  it('rejects non-plain current-account request metadata and accepts null-prototype metadata', async () => {
+    const { service, store } = createInMemoryAuthKit({
+      policy: createDefaultAuthPolicy({
+        requireReAuthFor: [AuthPolicyAction.UpdateProfile],
+      }),
+    })
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-request-metadata',
+        email: 'current-account-request-metadata@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
+        displayName: 'Alice',
+        reAuthenticatedAt: now,
+        metadata: ['not-a-record'],
+        now: addSeconds(now, 1),
+      } as unknown as Parameters<typeof service.updateCurrentAccountProfileByToken>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.closeCurrentAccountByToken({
+        sessionToken: signedIn.sessionToken,
+        reAuthenticatedAt: now,
+        metadata: null,
+        now: addSeconds(now, 2),
+      } as unknown as Parameters<typeof service.closeCurrentAccountByToken>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.setCurrentAccountPasswordByToken({
+        sessionToken: signedIn.sessionToken,
+        password: 'first-password',
+        reAuthenticatedAt: now,
+        metadata: 'not-a-record',
+        now: addSeconds(now, 3),
+      } as unknown as Parameters<typeof service.setCurrentAccountPasswordByToken>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.startCurrentAccountContactChange({
+        sessionToken: signedIn.sessionToken,
+        channel: OtpChannel.Email,
+        target: 'current-account-request-metadata-new@example.com',
+        reAuthenticatedAt: now,
+        metadata: ['not-a-record'],
+        now: addSeconds(now, 4),
+      } as unknown as Parameters<typeof service.startCurrentAccountContactChange>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
+    const nullPrototypeMetadata = Object.assign(Object.create(null) as Record<string, unknown>, {
+      source: 'settings',
+    })
+
+    await service.updateCurrentAccountProfileByToken({
+      sessionToken: signedIn.sessionToken,
+      displayName: 'Alice',
+      reAuthenticatedAt: now,
+      metadata: nullPrototypeMetadata,
+      now: addSeconds(now, 5),
+    })
+
+    expect(store.listAuditEvents()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: AuditEventType.AccountProfileUpdated,
+          metadata: {
+            changedFields: ['displayName'],
+            requestMetadata: { source: 'settings' },
+          },
+        }),
+      ]),
+    )
+  })
+
   it('keeps stale disabled-user current-account action helpers neutral', async () => {
     const { service, store } = createInMemoryAuthKit()
     const signedIn = await service.signIn({

--- a/test/core/current-account-reauth.test.ts
+++ b/test/core/current-account-reauth.test.ts
@@ -484,6 +484,7 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
     })
 
     expect(confirmation).toEqual({
+      currentSessionId: signedIn.session.id,
       userId: signedIn.user.id,
       reAuthenticatedAt: addSeconds(now, 20),
     })
@@ -616,6 +617,30 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
       }),
     ).resolves.toMatchObject({
       subject: 'current-account-recent-auth-status@example.com',
+    })
+  })
+
+  it('rejects non-plain current-account OTP re-auth request metadata', async () => {
+    const { service } = createInMemoryAuthKit()
+    const signedIn = await service.signIn({
+      assertion: assertion({
+        providerUserId: 'current-account-reauth-request-metadata',
+        email: 'current-account-reauth-request-metadata@example.com',
+        emailVerified: true,
+      }),
+      now,
+    })
+
+    await expect(
+      service.startCurrentAccountOtpReAuth({
+        sessionToken: signedIn.sessionToken,
+        identityId: signedIn.identity.id,
+        channel: OtpChannel.Email,
+        metadata: ['not-a-record'],
+        now: addSeconds(now, 1),
+      } as unknown as Parameters<typeof service.startCurrentAccountOtpReAuth>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
     })
   })
 
@@ -808,6 +833,7 @@ describe('DefaultAuthService current-account re-auth helpers', () => {
         currentPassword: 'first-password',
       }),
     ).resolves.toEqual({
+      currentSessionId: signedIn.session.id,
       userId: signedIn.user.id,
       reAuthenticatedAt: runtimeNow,
     })

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -88,6 +88,20 @@ describe('InMemoryAuthStore', () => {
     })
     expect(
       await store.identityRepo
+        .create(
+          identity({
+            id: asIdentityId('identity-missing-user'),
+            userId: asUserId('missing-user'),
+            provider: 'missing-user',
+            providerUserId: 'missing-user',
+          }),
+        )
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
+    expect(
+      await store.identityRepo
         .update(secondIdentity.id, {
           provider: emailIdentity.provider,
           providerUserId: emailIdentity.providerUserId,
@@ -100,6 +114,13 @@ describe('InMemoryAuthStore', () => {
         .catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.IdentityNotFound,
+    })
+    expect(
+      await store.identityRepo
+        .update(secondIdentity.id, { userId: asUserId('missing-user') })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
     })
     expect(
       await store.identityRepo.update(secondIdentity.id, { providerUserId: 'oauth-alice-2' }),
@@ -152,6 +173,18 @@ describe('InMemoryAuthStore', () => {
     ).toMatchObject({
       code: UniAuthErrorCode.CredentialAlreadyExists,
     })
+    expect(
+      await store.credentialRepo
+        .create({
+          ...sameUserCredential,
+          id: asCredentialId('credential-missing-user'),
+          userId: asUserId('missing-user'),
+          subject: 'missing-user@example.com',
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
     expect(await store.credentialRepo.create(secondCredential)).toBe(secondCredential)
     const updatedPasswordHash = await passwordHasher.hash('new')
     expect(
@@ -179,6 +212,13 @@ describe('InMemoryAuthStore', () => {
         .catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.CredentialNotFound,
+    })
+    expect(
+      await store.credentialRepo
+        .update(credential.id, { userId: asUserId('missing-user') })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
     })
 
     const verification: Verification = {
@@ -229,6 +269,18 @@ describe('InMemoryAuthStore', () => {
     ).toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
     })
+    expect(
+      await store.sessionRepo
+        .create({
+          ...session,
+          id: asSessionId('session-missing-user'),
+          userId: asUserId('missing-user'),
+          tokenHash: hashSecret('missing-user-session-token'),
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
+    })
     const otherSession: Session = {
       ...session,
       id: asSessionId('session-2'),
@@ -252,6 +304,13 @@ describe('InMemoryAuthStore', () => {
       await store.sessionRepo.update(asSessionId('missing'), {}).catch((caught: unknown) => caught),
     ).toMatchObject({
       code: UniAuthErrorCode.SessionNotFound,
+    })
+    expect(
+      await store.sessionRepo
+        .update(session.id, { userId: asUserId('missing-user') })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({
+      code: UniAuthErrorCode.UserNotFound,
     })
 
     await store.auditLogRepo.append({

--- a/test/postgres/current-account-reauth.test.ts
+++ b/test/postgres/current-account-reauth.test.ts
@@ -256,6 +256,7 @@ describe('Postgres current-account re-auth helpers', () => {
     })
 
     expect(confirmation).toEqual({
+      currentSessionId: signedIn.session.id,
       userId: signedIn.user.id,
       reAuthenticatedAt: addSeconds(now, 20),
     })

--- a/test/service-edges/sign-in-and-session-edge-cases.test.ts
+++ b/test/service-edges/sign-in-and-session-edge-cases.test.ts
@@ -9,6 +9,8 @@ import {
   asUserId,
   asVerificationId,
   createDefaultAuthPolicy,
+  type AuthIdentity,
+  type IdentityId,
 } from '../../src'
 import { InMemoryAuthStore, createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from '../helpers.js'
@@ -342,7 +344,7 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
       createdAt: now,
       updatedAt: now,
     })
-    await malformedKit.store.identityRepo.create({
+    const orphanedIdentity: AuthIdentity = {
       id: asIdentityId('missing-user-identity'),
       userId: asUserId('missing-user'),
       provider: 'email',
@@ -352,7 +354,16 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
       status: AuthIdentityStatus.Active,
       createdAt: now,
       updatedAt: now,
-    })
+    }
+    const malformedStoreInternals = malformedKit.store as unknown as {
+      readonly identities: Map<AuthIdentity['id'], AuthIdentity>
+      readonly identityKeys: Map<string, IdentityId>
+    }
+    malformedStoreInternals.identities.set(orphanedIdentity.id, orphanedIdentity)
+    malformedStoreInternals.identityKeys.set(
+      JSON.stringify([orphanedIdentity.provider, orphanedIdentity.providerUserId]),
+      orphanedIdentity.id,
+    )
 
     const inactiveEmailTarget = await malformedKit.service.signIn({
       assertion: assertion({


### PR DESCRIPTION
## Summary
- normalize provider and current-account request metadata through a shared plain-object guard
- include currentSessionId in password re-auth confirmations for session-bound parity
- reject orphaned user-owned records in the in-memory store to match Postgres constraints

## Checks
- npx vitest run test/service-edges/sign-in-and-session-edge-cases.test.ts --testNamePattern "covers disabled and malformed auto-link candidates" --reporter verbose
- npm run check

Closes #338
Closes #339
Closes #340