### PR TITLE
Validate request metadata across auth flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ const passwordConfirmation = await service.confirmCurrentAccountPasswordByToken(
   currentPassword,
 })
 
+passwordConfirmation.currentSessionId
+passwordConfirmation.reAuthenticatedAt
+
 const reAuthStatus = await service.getCurrentAccountReAuthStatus({
   sessionToken,
   action: AuthPolicyAction.ChangePassword,

--- a/docs/account-security.md
+++ b/docs/account-security.md
@@ -394,6 +394,7 @@ const confirmation = await authService.confirmCurrentAccountPasswordByToken({
   currentPassword: body.currentPassword,
 })
 
+request.auth.currentSessionId = confirmation.currentSessionId
 request.auth.reAuthenticatedAt = confirmation.reAuthenticatedAt
 ```
 

--- a/docs/backend-recipes.md
+++ b/docs/backend-recipes.md
@@ -197,8 +197,8 @@ app.post('/auth/account/reauth/otp/finish', requireSession, async (req, res, nex
 Use `startCurrentAccountOtpReAuth(...)`, `resendCurrentAccountOtpReAuth(...)`, and
 `cancelCurrentAccountOtpReAuth(...)` for the rest of that challenge lifecycle. For password-based
 recent-auth, use `confirmCurrentAccountPasswordByToken(...)` and store the returned
-`reAuthenticatedAt` marker the same way. The framework still owns request validation, browser UI,
-recent-auth marker TTL, cookies, and redirects.
+`currentSessionId` and `reAuthenticatedAt` marker the same way. The framework still owns request
+validation, browser UI, recent-auth marker TTL, cookies, and redirects.
 
 ## Nest
 

--- a/docs/local-auth.md
+++ b/docs/local-auth.md
@@ -181,8 +181,9 @@ const confirmation = await service.confirmCurrentAccountPasswordByToken({
 })
 ```
 
-The application still owns how `confirmation.reAuthenticatedAt` is stored, forwarded, or expired
-before it is passed back into token-based current-account mutation helpers.
+The confirmation includes the trusted `currentSessionId` plus `reAuthenticatedAt`. The application
+still owns how that recent-auth marker is stored, forwarded, or expired before it is passed back
+into token-based current-account mutation helpers.
 
 If the route must actively enforce the same recent-auth policy before app-owned follow-up work,
 keep that on the trusted token boundary too:

--- a/src/application/accounts/link.ts
+++ b/src/application/accounts/link.ts
@@ -1,4 +1,5 @@
 import { optionalProp } from '../optional.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import { AuthPolicyAction } from '../policy.js'
 import type { AuthServiceRuntime } from '../runtime.js'
 import { createIdentityFromAssertion, resolveAssertion } from '../sign-in.js'
@@ -11,6 +12,7 @@ import { UniAuthError, UniAuthErrorCode } from '../../errors.js'
 export async function link(runtime: AuthServiceRuntime, input: LinkInput): Promise<LinkResult> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeLinkMetadata(input.metadata)
     const user = await getActiveUser(runtime, input.userId)
     await ensureReAuth(runtime, AuthPolicyAction.Link, user.id, input.reAuthenticatedAt, now)
 
@@ -51,9 +53,15 @@ export async function link(runtime: AuthServiceRuntime, input: LinkInput): Promi
     await audit(runtime, AuditEventType.IdentityLinked, now, {
       userId: user.id,
       identityId: identity.id,
-      ...optionalProp('metadata', input.metadata),
+      ...optionalProp('metadata', metadata),
     })
 
     return { user, identity, linked: true }
   })
+}
+
+function normalizeLinkMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Link metadata')
 }

--- a/src/application/accounts/merge-support.ts
+++ b/src/application/accounts/merge-support.ts
@@ -1,3 +1,4 @@
+import { normalizeMetadataRecord } from '../metadata.js'
 import { optionalProp } from '../optional.js'
 import { AuthPolicyAction } from '../policy.js'
 import type { AuthServiceRuntime } from '../runtime.js'
@@ -155,13 +156,15 @@ export function createMergeDeniedAudit(input: {
   readonly metadata?: Record<string, unknown> | undefined
   readonly requestMetadata?: Record<string, unknown> | undefined
 }): MergeDeniedAudit {
+  const requestMetadata = normalizeMergeRequestMetadata(input.requestMetadata)
+
   return {
     userId: input.targetUserId,
     metadata: {
       ...input.metadata,
       reason: input.reason,
       sourceUserId: input.sourceUserId,
-      ...optionalProp('requestMetadata', input.requestMetadata),
+      ...optionalProp('requestMetadata', requestMetadata),
     },
   }
 }
@@ -216,12 +219,20 @@ export function buildMergeAuditMetadata(input: {
   readonly result: MergeResult
   readonly requestMetadata: Record<string, unknown> | undefined
 }): Record<string, unknown> {
+  const requestMetadata = normalizeMergeRequestMetadata(input.requestMetadata)
+
   return {
     decision: input.decision,
     sourceUserId: input.sourceUserId,
     movedIdentityIds: [...input.result.movedIdentityIds],
     movedCredentialIds: [...input.result.movedCredentialIds],
     revokedSessionIds: [...input.result.revokedSessionIds],
-    ...optionalProp('requestMetadata', input.requestMetadata),
+    ...optionalProp('requestMetadata', requestMetadata),
   }
+}
+
+function normalizeMergeRequestMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Merge request metadata')
 }

--- a/src/application/accounts/merge.ts
+++ b/src/application/accounts/merge.ts
@@ -15,6 +15,7 @@ import {
   type MergeState,
 } from './merge-support.js'
 import { audit } from '../support.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import type { MergeAccountsInput, MergeResult } from '../../domain/types.js'
 import { AuditEventType, isActiveUser } from '../../domain/types.js'
 import { UniAuthError, UniAuthErrorCode } from '../../errors.js'
@@ -24,17 +25,13 @@ export async function mergeAccounts(
   input: MergeAccountsInput,
 ): Promise<MergeResult> {
   const now = input.now ?? runtime.clock.now()
+  const metadata = normalizeMergeMetadata(input.metadata)
   let deniedAudit: MergeDeniedAudit | undefined
 
   try {
     return await runtime.transaction.run(async () => {
       const state = await loadMergeState(runtime, input, now)
-      const alreadyMergedResult = await resolveAlreadyMergedResult(
-        runtime,
-        state,
-        now,
-        input.metadata,
-      )
+      const alreadyMergedResult = await resolveAlreadyMergedResult(runtime, state, now, metadata)
 
       if (alreadyMergedResult) {
         return alreadyMergedResult
@@ -67,7 +64,7 @@ export async function mergeAccounts(
           reason: PolicyDenialReason.MergeCredentialConflict,
           targetUserId: state.targetUser.id,
           sourceUserId: state.sourceUser.id,
-          requestMetadata: input.metadata,
+          requestMetadata: metadata,
           metadata: { credentialTypes: conflictingCredentialTypes },
         })
         throw new UniAuthError(
@@ -104,7 +101,7 @@ export async function mergeAccounts(
           decision: 'merged',
           sourceUserId: state.sourceUser.id,
           result,
-          requestMetadata: input.metadata,
+          requestMetadata: metadata,
         }),
       })
 
@@ -117,6 +114,12 @@ export async function mergeAccounts(
 
     throw error
   }
+}
+
+function normalizeMergeMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Merge metadata')
 }
 
 async function resolveAlreadyMergedResult(

--- a/src/application/accounts/unlink.ts
+++ b/src/application/accounts/unlink.ts
@@ -1,4 +1,5 @@
 import { optionalProp } from '../optional.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import { AuthPolicyAction } from '../policy.js'
 import type { AuthServiceRuntime } from '../runtime.js'
 import { listActiveIdentitiesForUser, PolicyDenialReason } from './shared.js'
@@ -10,6 +11,7 @@ import { UniAuthError, UniAuthErrorCode } from '../../errors.js'
 export async function unlink(runtime: AuthServiceRuntime, input: UnlinkInput): Promise<void> {
   await runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizeUnlinkMetadata(input.metadata)
     const user = await getActiveUser(runtime, input.userId)
     await ensureReAuth(runtime, AuthPolicyAction.Unlink, user.id, input.reAuthenticatedAt, now)
 
@@ -49,7 +51,13 @@ export async function unlink(runtime: AuthServiceRuntime, input: UnlinkInput): P
     await audit(runtime, AuditEventType.IdentityUnlinked, now, {
       userId: user.id,
       identityId: identity.id,
-      ...optionalProp('metadata', input.metadata),
+      ...optionalProp('metadata', metadata),
     })
   })
+}
+
+function normalizeUnlinkMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Unlink metadata')
 }

--- a/src/application/passwords/credentials.ts
+++ b/src/application/passwords/credentials.ts
@@ -1,4 +1,5 @@
 import { optionalProp } from '../optional.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import { AuthPolicyAction } from '../policy.js'
 import type { AuthServiceRuntime } from '../runtime.js'
 import { ensureReAuth, getActiveUser } from '../support.js'
@@ -23,6 +24,7 @@ export async function setPassword(
 ): Promise<Credential> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizePasswordMetadata(input.metadata)
     const user = await getActiveUser(runtime, input.userId)
     await ensureReAuth(runtime, AuthPolicyAction.SetPassword, user.id, input.reAuthenticatedAt, now)
 
@@ -48,7 +50,7 @@ export async function setPassword(
       return runtime.repos.credentialRepo.update(existingForUser.id, {
         passwordHash,
         updatedAt: now,
-        ...optionalProp('metadata', input.metadata),
+        ...optionalProp('metadata', metadata),
       })
     }
 
@@ -60,7 +62,7 @@ export async function setPassword(
       passwordHash,
       createdAt: now,
       updatedAt: now,
-      ...optionalProp('metadata', input.metadata),
+      ...optionalProp('metadata', metadata),
     })
   })
 }
@@ -71,6 +73,7 @@ export async function changePassword(
 ): Promise<Credential> {
   return runtime.transaction.run(async () => {
     const now = input.now ?? runtime.clock.now()
+    const metadata = normalizePasswordMetadata(input.metadata)
     const user = await getActiveUser(runtime, input.userId)
     await ensureReAuth(
       runtime,
@@ -96,7 +99,13 @@ export async function changePassword(
     return runtime.repos.credentialRepo.update(credential.id, {
       passwordHash: await passwordHasher.hash(input.newPassword),
       updatedAt: now,
-      ...optionalProp('metadata', input.metadata),
+      ...optionalProp('metadata', metadata),
     })
   })
+}
+
+function normalizePasswordMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Password metadata')
 }

--- a/src/application/passwords/recovery.ts
+++ b/src/application/passwords/recovery.ts
@@ -1,4 +1,5 @@
 import { optionalProp } from '../optional.js'
+import { normalizeMetadataRecord } from '../metadata.js'
 import type { AuthServiceRuntime } from '../runtime.js'
 import { enforceRateLimit } from '../support.js'
 import {
@@ -96,6 +97,7 @@ export async function finishEmailPasswordRecovery(
   input: FinishEmailPasswordRecoveryInput,
 ): Promise<Credential> {
   const now = input.now ?? runtime.clock.now()
+  const metadata = normalizePasswordRecoveryMetadata(input.metadata)
   assertPassword(input.newPassword)
   const passwordHasher = getPasswordHasher(runtime)
   const verification = await findPasswordRecoveryVerification(runtime, input.verificationId)
@@ -122,7 +124,7 @@ export async function finishEmailPasswordRecovery(
     return runtime.repos.credentialRepo.update(credential.id, {
       passwordHash: await passwordHasher.hash(input.newPassword),
       updatedAt: now,
-      ...optionalProp('metadata', input.metadata),
+      ...optionalProp('metadata', metadata),
     })
   })
 }
@@ -209,4 +211,10 @@ export async function cancelEmailPasswordRecovery(
 
     return cancelVerificationRecord(runtime, verification, now, input.metadata)
   })
+}
+
+function normalizePasswordRecoveryMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Password recovery metadata')
 }

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -1,4 +1,5 @@
 import type { AuthServiceRuntime } from './runtime.js'
+import { normalizeMetadataRecord } from './metadata.js'
 import { optionalProp } from './optional.js'
 import { audit, getActiveUser } from './support.js'
 import type {
@@ -131,6 +132,7 @@ export async function createSessionRecord(
   input: CreateSessionInput & { readonly now: Date },
 ): Promise<CreateSessionResult> {
   const sessionToken = generateSecret()
+  const metadata = normalizeSessionMetadata(input.metadata)
   const expiresAt = resolveSessionExpiresAt(runtime, input)
   const session: Session = {
     id: runtime.idGenerator.sessionId(),
@@ -139,7 +141,7 @@ export async function createSessionRecord(
     status: SessionStatus.Active,
     createdAt: input.now,
     expiresAt,
-    ...optionalProp('metadata', input.metadata),
+    ...optionalProp('metadata', metadata),
   }
 
   const created = await runtime.repos.sessionRepo.create(session)
@@ -149,6 +151,12 @@ export async function createSessionRecord(
   })
 
   return { session: created, sessionToken }
+}
+
+function normalizeSessionMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Session metadata')
 }
 
 function resolveSessionExpiresAt(

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -1,4 +1,5 @@
 import type { AuthServiceRuntime } from './runtime.js'
+import { normalizeMetadataRecord } from './metadata.js'
 import { optionalProp } from './optional.js'
 import { audit } from './support.js'
 import {
@@ -150,6 +151,7 @@ export async function createVerificationRecord(
   input: CreateVerificationRecordInput,
 ): Promise<CreateVerificationResult> {
   const secret = input.secret ?? generateSecret()
+  const metadata = normalizeVerificationMetadata(input.metadata)
   const trimmedTarget = input.target.trim()
 
   if (!trimmedTarget) {
@@ -174,7 +176,7 @@ export async function createVerificationRecord(
     status: VerificationStatus.Pending,
     createdAt: input.now,
     expiresAt,
-    ...optionalProp('metadata', input.metadata),
+    ...optionalProp('metadata', metadata),
   }
 
   const created = await runtime.repos.verificationRepo.create(verification)
@@ -244,6 +246,7 @@ export async function cancelVerificationRecord(
   metadata?: Record<string, unknown>,
 ): Promise<Verification> {
   assertValidDate(now, 'Verification cancellation time is invalid.')
+  const cancellationMetadata = normalizeVerificationMetadata(metadata)
 
   if (!isUsableVerification(verification, now)) {
     return verification
@@ -257,7 +260,7 @@ export async function cancelVerificationRecord(
     metadata: {
       verificationId: cancelled.id,
       purpose: cancelled.purpose,
-      ...(metadata ?? {}),
+      ...(cancellationMetadata ?? {}),
     },
   })
 
@@ -296,12 +299,21 @@ export function mergeVerificationMetadata(
   current: Record<string, unknown> | undefined,
   next: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
-  if (!current && !next) {
+  const currentMetadata = normalizeVerificationMetadata(current)
+  const nextMetadata = normalizeVerificationMetadata(next)
+
+  if (!currentMetadata && !nextMetadata) {
     return undefined
   }
 
   return {
-    ...(current ?? {}),
-    ...(next ?? {}),
+    ...(currentMetadata ?? {}),
+    ...(nextMetadata ?? {}),
   }
+}
+
+function normalizeVerificationMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return normalizeMetadataRecord(metadata, 'Verification metadata')
 }

--- a/test/core/otp-and-verifications.test.ts
+++ b/test/core/otp-and-verifications.test.ts
@@ -75,6 +75,35 @@ describe('DefaultAuthService OTP and verification flows', () => {
 
     expect(blankTargetError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(store.listVerifications()).toHaveLength(1)
+
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.SignIn,
+        target: 'metadata-array@example.com',
+        secret: '123456',
+        metadata: ['not-a-record'],
+        now,
+      } as unknown as Parameters<typeof service.createVerification>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
+    const nullPrototypeMetadata = Object.assign(Object.create(null) as Record<string, unknown>, {
+      requestId: 'req-null-prototype',
+    })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.SignIn,
+        target: 'metadata-record@example.com',
+        secret: '123456',
+        metadata: nullPrototypeMetadata,
+        now,
+      }),
+    ).resolves.toMatchObject({
+      verification: {
+        metadata: { requestId: 'req-null-prototype' },
+      },
+    })
   })
 
   it('uses a configured secret hasher for verification storage', async () => {

--- a/test/service-edges/sign-in-and-session-edge-cases.test.ts
+++ b/test/service-edges/sign-in-and-session-edge-cases.test.ts
@@ -12,7 +12,7 @@ import {
   type AuthIdentity,
   type IdentityId,
 } from '../../src'
-import { InMemoryAuthStore, createInMemoryAuthKit } from '../../src/testing'
+import { InMemoryAuthStore, InMemoryPasswordHasher, createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from '../helpers.js'
 
 describe('DefaultAuthService sign-in and session edge cases', () => {
@@ -53,7 +53,10 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
 
   it('covers uncommon sign-in, session, link, unlink, and read-side branches', async () => {
     const defaultStore = new InMemoryAuthStore()
-    const defaultService = new DefaultAuthService({ repos: defaultStore })
+    const defaultService = new DefaultAuthService({
+      repos: defaultStore,
+      passwordHasher: new InMemoryPasswordHasher(),
+    })
     const first = await defaultService.signIn({
       assertion: assertion({
         provider: '  email  ',
@@ -131,6 +134,30 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
     expect(
       await defaultService.resolveSession({ sessionToken: explicitSession.sessionToken, now }),
     ).toBe(explicitSession.session)
+    await expect(
+      defaultService.createSession({
+        userId: first.user.id,
+        metadata: ['not-a-record'],
+        now,
+      } as unknown as Parameters<typeof defaultService.createSession>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    const nullPrototypeSessionMetadata = Object.assign(
+      Object.create(null) as Record<string, unknown>,
+      { mode: 'manual' },
+    )
+    await expect(
+      defaultService.createSession({
+        userId: first.user.id,
+        metadata: nullPrototypeSessionMetadata,
+        now,
+      }),
+    ).resolves.toMatchObject({
+      session: {
+        metadata: { mode: 'manual' },
+      },
+    })
     expect(
       await defaultService.touchSession({
         sessionId: explicitSession.session.id,
@@ -172,6 +199,19 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
         })
         .then((result) => result.linked),
     ).toBe(false)
+    await expect(
+      defaultService.link({
+        userId: first.user.id,
+        assertion: assertion({
+          provider: 'invalid-metadata-link',
+          providerUserId: 'invalid-metadata-link',
+        }),
+        metadata: ['not-a-record'],
+        now,
+      } as unknown as Parameters<typeof defaultService.link>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
 
     const linked = await defaultService.link({
       userId: first.user.id,
@@ -203,6 +243,16 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
       identityId: linked.identity.id,
       metadata: { action: 'unlink' },
       now,
+    })
+    await expect(
+      defaultService.unlink({
+        userId: first.user.id,
+        identityId: first.identity.id,
+        metadata: 'not-a-record',
+        now,
+      } as unknown as Parameters<typeof defaultService.unlink>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
     })
     expect(
       await defaultService
@@ -238,6 +288,45 @@ describe('DefaultAuthService sign-in and session edge cases', () => {
         })
         .catch((caught: unknown) => caught),
     ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(
+      defaultService.mergeAccounts({
+        sourceUserId: second.user.id,
+        targetUserId: first.user.id,
+        metadata: ['not-a-record'],
+        now,
+      } as unknown as Parameters<typeof defaultService.mergeAccounts>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      defaultService.setPassword({
+        userId: first.user.id,
+        email: 'alice@example.com',
+        password: 'first-password',
+        metadata: ['not-a-record'],
+        now,
+      } as unknown as Parameters<typeof defaultService.setPassword>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await defaultService.setPassword({
+      userId: first.user.id,
+      email: 'alice@example.com',
+      password: 'first-password',
+      metadata: { mode: 'set' },
+      now,
+    })
+    await expect(
+      defaultService.changePassword({
+        userId: first.user.id,
+        currentPassword: 'first-password',
+        newPassword: 'second-password',
+        metadata: null,
+        now,
+      } as unknown as Parameters<typeof defaultService.changePassword>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
 
     await defaultStore.userRepo.update(second.user.id, { disabledAt: now })
     expect(

--- a/test/verification-cancellation.test.ts
+++ b/test/verification-cancellation.test.ts
@@ -55,6 +55,15 @@ describe('verification cancellation flows', () => {
         }),
       ]),
     )
+    await expect(
+      service.cancelVerification({
+        verificationId: created.verification.id,
+        metadata: ['not-a-record'],
+        now: addSeconds(now, 1),
+      } as unknown as Parameters<typeof service.cancelVerification>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
   })
 
   it('keeps cancellation idempotent for consumed and already expired verifications', async () => {


### PR DESCRIPTION
## Summary
- validate public request metadata before it is persisted or merged into audit/verification/session/credential records
- preserve null-prototype plain records while rejecting arrays, null, and primitives at runtime
- document currentSessionId on password re-auth confirmations

## Checks
- npx vitest run test/service-edges/sign-in-and-session-edge-cases.test.ts test/core/otp-and-verifications.test.ts test/verification-cancellation.test.ts test/password.test.ts test/magic-link.test.ts test/resend-execution.test.ts
- npm run check

Closes #342
Closes #343