### PR TITLE
Validate bridge and OAuth metadata

### DIFF
--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -82,6 +82,9 @@ with it, the helper rejects the input instead of silently picking one.
 If you want a UniAuth provider namespace that differs from the framework provider id, pass
 `providerId`. The original framework id is then kept as `metadata.frameworkProviderId`.
 
+`metadata` must be a reduced plain object with application-owned values. Do not pass raw framework
+account, profile, token, request, or session objects into the bridge helper.
+
 ## Better Auth
 
 Use the bridge helper after your Better Auth integration has already completed provider validation.
@@ -127,6 +130,9 @@ The helper accepts either:
 - `profile.id` from the validated OAuth profile.
 
 If both are present and disagree, the helper rejects the input.
+
+`metadata` follows the same boundary as Auth.js metadata: pass only a plain object with explicit
+application-owned fields, not raw framework or provider SDK objects.
 
 ## Security Notes
 

--- a/docs/oauth-oidc.md
+++ b/docs/oauth-oidc.md
@@ -65,6 +65,10 @@ keep only the local UniAuth session token in UniAuth-facing flows.
 Use `createOAuthOidcTokenRecord(...)` when you want one normalized shape for access, refresh, and
 ID tokens before persisting them. See [Provider token persistence](provider-token-persistence.md).
 
+Callback, profile, and token-record `metadata` values must be reduced plain objects. Keep raw SDK
+responses, framework request objects, provider profiles, and token payloads in application-owned
+code, then pass only the fields UniAuth should retain or forward.
+
 ## Registration
 
 ```ts

--- a/src/bridges/support.ts
+++ b/src/bridges/support.ts
@@ -54,11 +54,13 @@ export function buildMetadata(
   const metadata: Record<string, unknown> = {}
 
   for (const record of records) {
-    if (!record) {
+    if (record === undefined) {
       continue
     }
 
-    for (const [key, value] of Object.entries(record)) {
+    const normalizedRecord = requirePlainRecord(record, 'Bridge metadata must be a plain object.')
+
+    for (const [key, value] of Object.entries(normalizedRecord)) {
       if (value !== undefined) {
         metadata[key] = value
       }
@@ -66,4 +68,21 @@ export function buildMetadata(
   }
 
   return Object.keys(metadata).length > 0 ? metadata : undefined
+}
+
+function requirePlainRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!isPlainRecord(value)) {
+    throw invalidInput(message)
+  }
+
+  return value
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/src/providers/oauth-oidc/profile.ts
+++ b/src/providers/oauth-oidc/profile.ts
@@ -1,6 +1,6 @@
 import type { ProviderIdentityAssertion } from '../../domain/types.js'
 import { optionalProp } from '../../utils/optional.js'
-import { readString, requireNonBlankString } from './support.js'
+import { normalizeMetadataRecord, readString, requireNonBlankString } from './support.js'
 import type { OAuthOidcProfileMapperInput } from './types.js'
 
 export function mapOAuthOidcProfileToAssertion(
@@ -27,12 +27,16 @@ export function mapOAuthOidcProfileToAssertion(
 function buildOAuthOidcAssertionMetadata(
   profile: OAuthOidcProfileMapperInput['profile'],
 ): Record<string, unknown> | undefined {
+  const profileMetadata = normalizeMetadataRecord(
+    profile.metadata,
+    'OAuth/OIDC profile metadata must be a plain object.',
+  )
   const metadata = {
     ...optionalProp('issuer', readString(profile.issuer)),
     ...optionalProp('preferredUsername', readString(profile.preferredUsername)),
     ...optionalProp('pictureUrl', readString(profile.pictureUrl)),
     ...optionalProp('locale', readString(profile.locale)),
-    ...profile.metadata,
+    ...profileMetadata,
   }
 
   return Object.keys(metadata).length > 0 ? metadata : undefined

--- a/src/providers/oauth-oidc/provider.ts
+++ b/src/providers/oauth-oidc/provider.ts
@@ -3,7 +3,13 @@ import type { AuthProvider } from '../../contracts.js'
 import { invalidInput } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
 import { mapOAuthOidcProfileToAssertion } from './profile.js'
-import { isRecord, readFinishPayload, readString, requireNonBlankString } from './support.js'
+import {
+  isRecord,
+  normalizeMetadataRecord,
+  readFinishPayload,
+  readString,
+  requireNonBlankString,
+} from './support.js'
 import type {
   OAuthOidcAuthorizationCodeExchangeInput,
   OAuthOidcFetchProfileInput,
@@ -48,7 +54,7 @@ function readAuthorizationCodeExchangeInput(
   }
 
   const state = readString(input.state) ?? readString(payload.state)
-  const metadata = isMetadata(payload.metadata) ? payload.metadata : input.metadata
+  const metadata = readAuthorizationCodeMetadata(input, payload)
 
   return {
     code,
@@ -57,6 +63,23 @@ function readAuthorizationCodeExchangeInput(
     ...optionalProp('codeVerifier', readString(payload.codeVerifier)),
     ...optionalProp('metadata', metadata),
   }
+}
+
+function readAuthorizationCodeMetadata(
+  input: FinishInput,
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (Object.prototype.hasOwnProperty.call(payload, 'metadata')) {
+    return normalizeMetadataRecord(
+      payload.metadata,
+      'OAuth/OIDC finish metadata must be a plain object.',
+    )
+  }
+
+  return normalizeMetadataRecord(
+    input.metadata,
+    'OAuth/OIDC finish metadata must be a plain object.',
+  )
 }
 
 function readFetchProfileInput(
@@ -92,8 +115,4 @@ function normalizeTokenSet(tokens: OAuthOidcTokenSet): OAuthOidcTokenSet {
     ...optionalProp('expiresAt', tokenSet.expiresAt),
     ...optionalProp('scopes', tokenSet.scopes),
   }
-}
-
-function isMetadata(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/providers/oauth-oidc/support.ts
+++ b/src/providers/oauth-oidc/support.ts
@@ -24,3 +24,27 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 export function readFinishPayload(input: FinishInput): Record<string, unknown> {
   return isRecord(input.payload) ? input.payload : {}
 }
+
+export function normalizeMetadataRecord(
+  value: unknown,
+  message: string,
+): Record<string, unknown> | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!isPlainRecord(value)) {
+    throw invalidInput(message)
+  }
+
+  return value
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/src/providers/oauth-oidc/tokens.ts
+++ b/src/providers/oauth-oidc/tokens.ts
@@ -1,6 +1,6 @@
 import { invalidInput } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
-import { isRecord, readString, requireNonBlankString } from './support.js'
+import { isRecord, normalizeMetadataRecord, readString, requireNonBlankString } from './support.js'
 import type {
   CreateOAuthOidcTokenRecordInput,
   OAuthOidcTokenBinding,
@@ -102,13 +102,10 @@ function normalizeScopes(value: unknown): readonly string[] | undefined {
 }
 
 function normalizeMetadata(value: unknown): Record<string, unknown> | undefined {
-  if (value === undefined) {
-    return undefined
-  }
+  const metadata = normalizeMetadataRecord(
+    value,
+    'OAuth/OIDC token record metadata must be a plain object.',
+  )
 
-  if (!isRecord(value)) {
-    throw invalidInput('OAuth/OIDC token record metadata must be a plain object.')
-  }
-
-  return { ...value }
+  return metadata ? { ...metadata } : undefined
 }

--- a/test/bridges.test.ts
+++ b/test/bridges.test.ts
@@ -169,6 +169,56 @@ describe('auth bridge helpers', () => {
     })
   })
 
+  it('rejects Auth.js metadata that is not a plain object', async () => {
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: {
+            provider: 'google',
+            providerAccountId: 'user-1',
+          },
+          metadata: ['tenant-1'] as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Bridge metadata must be a plain object.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: {
+            provider: 'google',
+            providerAccountId: 'user-1',
+          },
+          metadata: new Date() as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Bridge metadata must be a plain object.',
+    })
+  })
+
+  it('accepts Auth.js metadata records without an object prototype', () => {
+    const metadata = Object.assign(Object.create(null) as Record<string, unknown>, {
+      tenantId: 'tenant-1',
+    })
+
+    expect(
+      mapAuthJsOAuthToAssertion({
+        account: {
+          provider: 'google',
+          providerAccountId: 'user-1',
+        },
+        metadata,
+      }).metadata,
+    ).toEqual({
+      tenantId: 'tenant-1',
+    })
+  })
+
   it('maps Better Auth account or profile data without copying account tokens', () => {
     const assertion = mapBetterAuthOAuthToAssertion({
       providerId: 'discord-app',
@@ -292,6 +342,23 @@ describe('auth bridge helpers', () => {
     ).toEqual({
       provider: 'google',
       providerUserId: 'google-user-2',
+    })
+  })
+
+  it('rejects Better Auth metadata that is not a plain object', async () => {
+    await expect(
+      catchError(() =>
+        mapBetterAuthOAuthToAssertion({
+          account: {
+            providerId: 'google',
+            accountId: 'user-1',
+          },
+          metadata: ['tenant-1'] as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Bridge metadata must be a plain object.',
     })
   })
 

--- a/test/oauth-oidc.test.ts
+++ b/test/oauth-oidc.test.ts
@@ -191,7 +191,6 @@ describe('OAuth/OIDC provider contract', () => {
         code: ' payload-code ',
         redirectUri: '   ',
         codeVerifier: '   ',
-        metadata: 'not-metadata',
       },
     })
 
@@ -200,6 +199,49 @@ describe('OAuth/OIDC provider contract', () => {
       metadata: {
         requestId: 'fallback-request',
       },
+    })
+  })
+
+  it('rejects malformed OAuth/OIDC finish metadata instead of falling back', async () => {
+    const client = new RecordingOAuthOidcClient(
+      { accessToken: 'token' },
+      {
+        subject: 'metadata-user',
+      },
+    )
+    const provider = createOAuthOidcProvider({
+      providerId: 'metadata-provider',
+      client,
+    })
+
+    await expect(
+      catchError(() =>
+        provider.finish({
+          code: 'code',
+          metadata: {
+            requestId: 'fallback-request',
+          },
+          payload: {
+            metadata: 'not-metadata',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'OAuth/OIDC finish metadata must be a plain object.',
+    })
+    expect(client.exchangeInput).toBeUndefined()
+
+    await expect(
+      catchError(() =>
+        provider.finish({
+          code: 'code',
+          metadata: new Date() as unknown as Record<string, unknown>,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'OAuth/OIDC finish metadata must be a plain object.',
     })
   })
 
@@ -259,7 +301,32 @@ describe('OAuth/OIDC provider contract', () => {
     })
   })
 
+  it('rejects OAuth/OIDC profile metadata that is not a plain object', async () => {
+    await expect(
+      catchError(() =>
+        mapOAuthOidcProfileToAssertion({
+          provider: 'direct',
+          profile: {
+            subject: 'direct-subject',
+            metadata: ['tenant-1'] as unknown as Record<string, unknown>,
+          },
+          finishInput: {},
+          exchangeInput: {
+            code: 'code',
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'OAuth/OIDC profile metadata must be a plain object.',
+    })
+  })
+
   it('creates normalized token records for application-owned persistence', () => {
+    const metadata = Object.assign(Object.create(null) as Record<string, unknown>, {
+      tenantId: 'tenant-1',
+    })
+
     expect(
       createOAuthOidcTokenRecord({
         provider: ' example-oauth ',
@@ -276,9 +343,7 @@ describe('OAuth/OIDC provider contract', () => {
           expiresAt: now,
           scopes: ['openid', ' email ', 'openid', '   '],
         },
-        metadata: {
-          tenantId: 'tenant-1',
-        },
+        metadata,
       }),
     ).toEqual({
       provider: 'example-oauth',
@@ -450,6 +515,20 @@ describe('OAuth/OIDC provider contract', () => {
           refreshToken: 'refresh-token',
         },
         metadata: 'not-an-object' as unknown as Record<string, unknown>,
+      }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcTokenRecord({
+        provider: 'oauth',
+        providerUserId: 'subject',
+        binding: {
+          kind: OAuthOidcTokenBindingKind.User,
+          value: 'user-1',
+        },
+        tokens: {
+          refreshToken: 'refresh-token',
+        },
+        metadata: new Date() as unknown as Record<string, unknown>,
       }),
     )
   })


### PR DESCRIPTION
## Summary\n- reject non-plain bridge metadata before merging it into assertion metadata\n- validate OAuth/OIDC finish, profile, and token-record metadata at public boundaries\n- document the reduced plain-object metadata contract for bridge and OAuth integrations\n\n## Checks\n- npx vitest run test/bridges.test.ts test/oauth-oidc.test.ts\n- npm run check\n\nCloses #345\nCloses #346