### PR TITLE
Harden package export boundary checks

### DIFF
--- a/smoke/exports.test.ts
+++ b/smoke/exports.test.ts
@@ -212,14 +212,22 @@ describe('package exports', () => {
     expect(testing.StaticAuthProvider).toBeTypeOf('function')
   })
 
-  it('loads provider family package subpaths through self-reference exports', async () => {
-    const messengerProviders = await import(`${packageMetadata.name}/providers/messenger`)
-    const oauthOidcProviders = await import(`${packageMetadata.name}/providers/oauth-oidc`)
+  it('loads every public package subpath through self-reference exports', async () => {
+    for (const exportPath of Object.keys(expectedEntrypoints)) {
+      const importPath =
+        exportPath === '.' ? packageMetadata.name : `${packageMetadata.name}${exportPath.slice(1)}`
+      const result = spawnSync(
+        process.execPath,
+        ['--input-type=module', '--eval', `await import(${JSON.stringify(importPath)})`],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+        },
+      )
 
-    expect(messengerProviders.MAX_WEBAPP_PROVIDER_ID).toBe('max-webapp')
-    expect(messengerProviders.createMaxWebAppProvider).toBeTypeOf('function')
-    expect(oauthOidcProviders.createOAuthOidcProvider).toBeTypeOf('function')
-    expect(oauthOidcProviders.createOAuthOidcTokenRecord).toBeTypeOf('function')
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(0)
+    }
   })
 
   it('keeps testing package declarations aligned with the stable public surface', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,11 @@
     "ignoreDeprecations": "6.0",
     "paths": {
       "@alyldas/uniauth": ["src/index.ts"],
+      "@alyldas/uniauth/bridges": ["src/bridges.ts"],
+      "@alyldas/uniauth/contracts": ["src/contracts.ts"],
       "@alyldas/uniauth/providers/messenger": ["src/providers/messenger.ts"],
       "@alyldas/uniauth/providers/oauth-oidc": ["src/providers/oauth-oidc.ts"],
+      "@alyldas/uniauth/postgres": ["src/postgres.ts"],
       "@alyldas/uniauth/testing": ["src/testing/index.ts"]
     },
     "strict": true,


### PR DESCRIPTION
## Summary\n- cover every public package subpath through Node self-reference smoke imports\n- align local TypeScript path aliases with the public package export table\n\n## Checks\n- npm run test:exports\n- npm run check\n\nCloses #348\nCloses #349