### PR TITLE
Align Vitest package aliases

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,14 @@ import packageJson from './package.json'
 
 const sourceAliases = [
   {
+    find: '@alyldas/uniauth/bridges',
+    replacement: new URL('./src/bridges.ts', import.meta.url).pathname,
+  },
+  {
+    find: '@alyldas/uniauth/contracts',
+    replacement: new URL('./src/contracts.ts', import.meta.url).pathname,
+  },
+  {
     find: '@alyldas/uniauth/providers/messenger',
     replacement: new URL('./src/providers/messenger.ts', import.meta.url).pathname,
   },
@@ -13,6 +21,10 @@ const sourceAliases = [
   {
     find: '@alyldas/uniauth/testing',
     replacement: new URL('./src/testing/index.ts', import.meta.url).pathname,
+  },
+  {
+    find: '@alyldas/uniauth/postgres',
+    replacement: new URL('./src/postgres.ts', import.meta.url).pathname,
   },
   {
     find: '@alyldas/uniauth',


### PR DESCRIPTION
## Summary\n- add missing Vitest aliases for public bridges, contracts, and postgres subpaths\n- keep test resolver coverage aligned with package exports and TypeScript paths\n\n## Checks\n- npm run test:exports\n- npm run check\n\nCloses #354