### PR TITLE
Check local Markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,8 +782,8 @@ npm run check
 ```
 
 The gate runs formatting, ESLint, typecheck, 100% coverage, export smoke tests, package lint,
-package type-resolution checks, dependency audit with `npm audit --audit-level=moderate`, and
-`npm pack --dry-run`.
+package type-resolution checks, local Markdown link checks, dependency audit with
+`npm audit --audit-level=moderate`, and `npm pack --dry-run`.
 
 The release workflow uses Release Please: pushes to `main` update a release PR, and merging that PR
 creates the `v*` tag, GitHub release notes, and GitHub Packages publish. This repository uses the

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,8 +30,8 @@ npm run lint
 ## Package Gate
 
 `npm run check` is the local release gate. It runs dependency audit, formatting, ESLint,
-typecheck, 100% coverage, export smoke tests, package lint, package type-resolution checks, and
-`npm pack --dry-run`.
+local Markdown link checks, typecheck, 100% coverage, export smoke tests, package lint, package
+type-resolution checks, and `npm pack --dry-run`.
 
 Use Docker when you want the same package gate inside the pinned Node 22 Alpine image:
 

--- a/package.json
+++ b/package.json
@@ -70,10 +70,11 @@
   "scripts": {
     "audit:deps": "npm audit --audit-level=moderate",
     "build": "tsup && tsc -p tsconfig.build.json",
-    "check": "npm run audit:deps && npm run format:check && npm run lint && npm run typecheck && npm run coverage && npm run test:exports && npm run lint:package && npm run test:types-package && npm run pack:dry",
+    "check": "npm run audit:deps && npm run format:check && npm run docs:links && npm run lint && npm run typecheck && npm run coverage && npm run test:exports && npm run lint:package && npm run test:types-package && npm run pack:dry",
     "check:compose": "docker compose run --rm --build check",
     "check:docker": "docker build --target check -t alyldas-uniauth-check .",
     "coverage": "vitest run --dir test --exclude core.test.ts --exclude postgres.test.ts --exclude provider-policy.test.ts --exclude service-edges.test.ts --coverage",
+    "docs:links": "node scripts/check-md-links.cjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "hooks:install": "node scripts/install-husky.cjs",

--- a/scripts/check-md-links.cjs
+++ b/scripts/check-md-links.cjs
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const { existsSync, readdirSync, readFileSync } = require('node:fs')
+const { dirname, join, resolve } = require('node:path')
+
+const MARKDOWN_LINK_PATTERN = /(?<!!)\[[^\]]+\]\(([^)]+)\)/g
+const MARKDOWN_DIRECTORIES = ['docs', '.github']
+
+const markdownFiles = [
+  ...readdirSync('.').filter((file) => file.endsWith('.md')),
+  ...MARKDOWN_DIRECTORIES.flatMap((directory) => listMarkdownFiles(directory)),
+]
+const brokenLinks = []
+
+for (const file of markdownFiles) {
+  const contents = readFileSync(file, 'utf8')
+
+  for (const match of contents.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const rawTarget = match[1]?.trim()
+    const target = readLocalTarget(rawTarget)
+
+    if (!target) {
+      continue
+    }
+
+    const [pathTarget] = target.split('#')
+
+    if (!pathTarget) {
+      continue
+    }
+
+    const resolvedTarget = resolve(dirname(file), decodeURIComponent(pathTarget))
+
+    if (!existsSync(resolvedTarget)) {
+      brokenLinks.push(`${file}: ${target}`)
+    }
+  }
+}
+
+if (brokenLinks.length > 0) {
+  console.error('Broken local Markdown links found:')
+
+  for (const brokenLink of brokenLinks) {
+    console.error(`- ${brokenLink}`)
+  }
+
+  process.exit(1)
+}
+
+function listMarkdownFiles(directory) {
+  if (!existsSync(directory)) {
+    return []
+  }
+
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return listMarkdownFiles(path)
+    }
+
+    return entry.isFile() && path.endsWith('.md') ? [path] : []
+  })
+}
+
+function readLocalTarget(rawTarget) {
+  if (!rawTarget) {
+    return undefined
+  }
+
+  const target = rawTarget.replace(/^<|>$/g, '').split(/\s+/u)[0]
+
+  if (!target || target.startsWith('#') || /^[a-z][a-z+.-]*:/iu.test(target)) {
+    return undefined
+  }
+
+  return target
+}


### PR DESCRIPTION
## Summary\n- add a dependency-free local Markdown link checker for root docs, docs, and GitHub markdown files\n- run docs:links as part of the package gate\n- document the new package-gate step\n\n## Checks\n- npm run docs:links\n- npm run lint\n- npm run check\n\nCloses #356