### PR TITLE
Strengthen Markdown link checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,8 +782,8 @@ npm run check
 ```
 
 The gate runs formatting, ESLint, typecheck, 100% coverage, export smoke tests, package lint,
-package type-resolution checks, local Markdown link checks, dependency audit with
-`npm audit --audit-level=moderate`, and `npm pack --dry-run`.
+package type-resolution checks, local Markdown file, anchor, and image link checks, dependency
+audit with `npm audit --audit-level=moderate`, and `npm pack --dry-run`.
 
 The release workflow uses Release Please: pushes to `main` update a release PR, and merging that PR
 creates the `v*` tag, GitHub release notes, and GitHub Packages publish. This repository uses the

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,8 +30,8 @@ npm run lint
 ## Package Gate
 
 `npm run check` is the local release gate. It runs dependency audit, formatting, ESLint,
-local Markdown link checks, typecheck, 100% coverage, export smoke tests, package lint, package
-type-resolution checks, and `npm pack --dry-run`.
+local Markdown file, anchor, and image link checks, typecheck, 100% coverage, export smoke tests,
+package lint, package type-resolution checks, and `npm pack --dry-run`.
 
 Use Docker when you want the same package gate inside the pinned Node 22 Alpine image:
 

--- a/scripts/check-md-links.cjs
+++ b/scripts/check-md-links.cjs
@@ -2,7 +2,9 @@
 const { existsSync, readdirSync, readFileSync } = require('node:fs')
 const { dirname, join, resolve } = require('node:path')
 
-const MARKDOWN_LINK_PATTERN = /(?<!!)\[[^\]]+\]\(([^)]+)\)/g
+const MARKDOWN_LINK_PATTERN = /!?\[[^\]]*\]\(([^)]+)\)/g
+const HEADING_PATTERN = /^(#{1,6})\s+(.+)$/gm
+const HTML_ANCHOR_PATTERN = /<a\s+(?:[^>]*\s+)?(?:id|name)=["']([^"']+)["'][^>]*>/giu
 const MARKDOWN_DIRECTORIES = ['docs', '.github']
 
 const markdownFiles = [
@@ -10,6 +12,7 @@ const markdownFiles = [
   ...MARKDOWN_DIRECTORIES.flatMap((directory) => listMarkdownFiles(directory)),
 ]
 const brokenLinks = []
+const anchorCache = new Map()
 
 for (const file of markdownFiles) {
   const contents = readFileSync(file, 'utf8')
@@ -22,7 +25,7 @@ for (const file of markdownFiles) {
       continue
     }
 
-    const [pathTarget] = target.split('#')
+    const [pathTarget, anchorTarget] = target.split('#')
 
     if (!pathTarget) {
       continue
@@ -32,6 +35,16 @@ for (const file of markdownFiles) {
 
     if (!existsSync(resolvedTarget)) {
       brokenLinks.push(`${file}: ${target}`)
+      continue
+    }
+
+    if (anchorTarget && resolvedTarget.endsWith('.md')) {
+      const anchors = readMarkdownAnchors(resolvedTarget)
+      const decodedAnchor = decodeURIComponent(anchorTarget)
+
+      if (!anchors.has(decodedAnchor)) {
+        brokenLinks.push(`${file}: ${target}`)
+      }
     }
   }
 }
@@ -74,4 +87,45 @@ function readLocalTarget(rawTarget) {
   }
 
   return target
+}
+
+function readMarkdownAnchors(file) {
+  const cachedAnchors = anchorCache.get(file)
+
+  if (cachedAnchors) {
+    return cachedAnchors
+  }
+
+  const contents = readFileSync(file, 'utf8')
+  const anchors = new Set()
+
+  for (const match of contents.matchAll(HEADING_PATTERN)) {
+    const heading = match[2]
+
+    if (heading) {
+      anchors.add(toGitHubHeadingAnchor(heading))
+    }
+  }
+
+  for (const match of contents.matchAll(HTML_ANCHOR_PATTERN)) {
+    const anchor = match[1]
+
+    if (anchor) {
+      anchors.add(anchor)
+    }
+  }
+
+  anchorCache.set(file, anchors)
+  return anchors
+}
+
+function toGitHubHeadingAnchor(heading) {
+  return heading
+    .trim()
+    .replace(/<[^>]+>/gu, '')
+    .replace(/`([^`]+)`/gu, '$1')
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/gu, '-')
 }


### PR DESCRIPTION
## Summary\n- validate local Markdown anchors and image links in the docs link gate\n- keep local file checks for README, docs, and GitHub markdown files\n- document that the package gate covers local Markdown files, anchors, and images\n\n## Checks\n- npm run docs:links\n- npm run lint\n- npm run test:exports\n- npm run check\n\nCloses #358