### PR TITLE
Harden verification timestamp and secret validation

### DIFF
--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -179,7 +179,10 @@ function resolveSessionExpiresAt(
     throw invalidInput('Session TTL must be a non-negative number of seconds.')
   }
 
-  return addSeconds(input.now, runtime.sessionTtlSeconds)
+  const expiresAt = addSeconds(input.now, runtime.sessionTtlSeconds)
+  assertValidDate(expiresAt, 'Session expiration time is invalid.')
+
+  return expiresAt
 }
 
 async function requireActiveSession(

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -150,7 +150,7 @@ export async function createVerificationRecord(
   runtime: AuthServiceRuntime,
   input: CreateVerificationRecordInput,
 ): Promise<CreateVerificationResult> {
-  const secret = input.secret ?? generateSecret()
+  const secret = resolveVerificationSecret(input.secret)
   const metadata = normalizeVerificationMetadata(input.metadata)
   const trimmedTarget = input.target.trim()
 
@@ -192,6 +192,7 @@ export async function consumeVerificationRecord(
   input: ConsumeVerificationInput,
 ): Promise<Verification> {
   const now = input.now ?? runtime.clock.now()
+  const secret = requireVerificationSecret(input.secret)
   const verification = await runtime.repos.verificationRepo.findByIdForUpdate(input.verificationId)
 
   if (!verification) {
@@ -209,7 +210,7 @@ export async function consumeVerificationRecord(
     throw new UniAuthError(UniAuthErrorCode.VerificationExpired, 'Verification has expired.')
   }
 
-  if (!(await runtime.secretHasher.verify(input.secret, verification.secretHash))) {
+  if (!(await runtime.secretHasher.verify(secret, verification.secretHash))) {
     throw new UniAuthError(
       UniAuthErrorCode.VerificationInvalidSecret,
       'Verification secret is invalid.',
@@ -225,6 +226,22 @@ export async function consumeVerificationRecord(
   })
 
   return consumed
+}
+
+function resolveVerificationSecret(secret: string | undefined): string {
+  if (secret === undefined) {
+    return generateSecret()
+  }
+
+  return requireVerificationSecret(secret)
+}
+
+function requireVerificationSecret(secret: string): string {
+  if (typeof secret !== 'string' || !secret.trim()) {
+    throw invalidInput('Verification secret is required.')
+  }
+
+  return secret
 }
 
 export async function expireVerificationForResend(

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -279,7 +279,10 @@ function resolveVerificationExpiresAt(
     throw invalidInput('Verification TTL must be a non-negative number of seconds.')
   }
 
-  return addSeconds(input.now, ttlSeconds)
+  const expiresAt = addSeconds(input.now, ttlSeconds)
+  assertValidDate(expiresAt, 'Verification expiration time is invalid.')
+
+  return expiresAt
 }
 
 function resolveVerificationResendCooldownSeconds(

--- a/src/providers/messenger/signed-webapp.ts
+++ b/src/providers/messenger/signed-webapp.ts
@@ -110,7 +110,13 @@ function parseAuthDate(value: string | undefined): Date | undefined {
     throw invalidSignedWebAppInitData()
   }
 
-  return new Date(seconds * 1000)
+  const authDate = new Date(seconds * 1000)
+
+  if (Number.isNaN(authDate.getTime())) {
+    throw invalidSignedWebAppInitData()
+  }
+
+  return authDate
 }
 
 function enforceAuthDateMaxAge(input: {

--- a/test/core/otp-and-verifications.test.ts
+++ b/test/core/otp-and-verifications.test.ts
@@ -45,6 +45,14 @@ describe('DefaultAuthService OTP and verification flows', () => {
       code: UniAuthErrorCode.VerificationInvalidSecret,
     })
 
+    await expect(
+      service.consumeVerification({
+        verificationId: created.verification.id,
+        secret: '   ',
+        now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+
     const consumed = await service.consumeVerification({
       verificationId: created.verification.id,
       secret: '123456',
@@ -74,6 +82,16 @@ describe('DefaultAuthService OTP and verification flows', () => {
       .catch((caught: unknown) => caught)
 
     expect(blankTargetError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(store.listVerifications()).toHaveLength(1)
+
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.SignIn,
+        target: 'blank-secret@example.com',
+        secret: '   ',
+        now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(store.listVerifications()).toHaveLength(1)
 
     await expect(

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -571,6 +571,12 @@ describe('DefaultAuthService read side and sessions', () => {
       }),
     ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     await expect(
+      createInMemoryAuthKit({ sessionTtlSeconds: Number.MAX_VALUE }).service.signIn({
+        assertion: assertion(),
+        now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(
       service.touchSession({
         sessionId: signedIn.session.id,
         now: new Date('invalid'),
@@ -600,6 +606,14 @@ describe('DefaultAuthService read side and sessions', () => {
     await expect(
       service.createVerification({
         purpose: VerificationPurpose.SignIn,
+        target: 'overflow@example.com',
+        ttlSeconds: Number.MAX_VALUE,
+        now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.SignIn,
         target: 'invalid-now@example.com',
         now: new Date('invalid'),
       }),
@@ -616,6 +630,15 @@ describe('DefaultAuthService read side and sessions', () => {
       createInMemoryAuthKit({ verificationTtlSeconds: Number.NaN }).service.createVerification({
         purpose: VerificationPurpose.SignIn,
         target: 'runtime-nan@example.com',
+        now,
+      }),
+    ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    await expect(
+      createInMemoryAuthKit({
+        verificationTtlSeconds: Number.MAX_VALUE,
+      }).service.createVerification({
+        purpose: VerificationPurpose.SignIn,
+        target: 'runtime-overflow@example.com',
         now,
       }),
     ).rejects.toMatchObject({ code: UniAuthErrorCode.InvalidInput })

--- a/test/messenger.test.ts
+++ b/test/messenger.test.ts
@@ -257,6 +257,12 @@ describe('messenger WebApp providers', () => {
     )
     await expectInvalid(() =>
       validateSignedWebAppInitData({
+        initData: signInitData(validFields({ auth_date: '8640000000001' })),
+        botToken,
+      }),
+    )
+    await expectInvalid(() =>
+      validateSignedWebAppInitData({
         initData: signInitData({ user: JSON.stringify({ id: 1 }) }),
         botToken,
         maxAgeSeconds: 60,


### PR DESCRIPTION
## Summary

- Reject non-representable signed WebApp auth_date timestamps.
- Reject session and verification TTL values that produce invalid expiration dates.
- Reject blank verification secrets before storage or verification.

## Checks

- npm run check

Closes #360
Closes #361
Closes #362
