### PR TITLE
Harden cooldown and rate-limit date validation

### DIFF
--- a/src/application/support.ts
+++ b/src/application/support.ts
@@ -10,8 +10,8 @@ import type {
   UserId,
 } from '../domain/types.js'
 import { AuditEventType, isActiveIdentity, isActiveUser } from '../domain/types.js'
-import { UniAuthError, UniAuthErrorCode, rateLimited } from '../errors.js'
-import type { RateLimitAttempt } from '../contracts.js'
+import { UniAuthError, UniAuthErrorCode, invalidInput, rateLimited } from '../errors.js'
+import type { RateLimitAttempt, RateLimitDecision } from '../contracts.js'
 
 const PolicyDenialReason = {
   ReAuthRequired: 're-auth-required',
@@ -77,20 +77,41 @@ export async function enforceRateLimit(
     return
   }
 
+  const details = normalizeRateLimitDecisionDetails(input.action, decision)
+
   await audit(runtime, AuditEventType.RateLimited, input.now, {
-    metadata: {
-      action: input.action,
-      ...optionalProp('retryAfterSeconds', decision.retryAfterSeconds),
-      ...optionalProp('resetAt', decision.resetAt?.toISOString()),
-    },
+    metadata: details,
   })
 
-  throw rateLimited({
-    action: input.action,
+  throw rateLimited(details)
+}
+
+function normalizeRateLimitDecisionDetails(
+  action: RateLimitAttempt['action'],
+  decision: RateLimitDecision,
+): {
+  readonly action: RateLimitAttempt['action']
+  readonly retryAfterSeconds?: number
+  readonly resetAt?: string
+} {
+  if (
+    decision.retryAfterSeconds !== undefined &&
+    (!Number.isFinite(decision.retryAfterSeconds) || decision.retryAfterSeconds < 0)
+  ) {
+    throw invalidInput('Rate-limit retryAfterSeconds must be a non-negative number.')
+  }
+
+  if (decision.resetAt !== undefined && Number.isNaN(decision.resetAt.getTime())) {
+    throw invalidInput('Rate-limit resetAt must be a valid date.')
+  }
+
+  return {
+    action,
     ...optionalProp('retryAfterSeconds', decision.retryAfterSeconds),
     ...optionalProp('resetAt', decision.resetAt?.toISOString()),
-  })
+  }
 }
+
 export async function audit(
   runtime: AuthServiceRuntime,
   type: AuditEventType,

--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -2,6 +2,7 @@ import type { AuditEvent, AuditEventCursor } from './audit.js'
 import type { AuthIdentity, Credential, Session, User, Verification } from './entities.js'
 import type { ProviderTrustLevel } from './kinds.js'
 import { isExpiredVerification, isUsableVerification } from './rules.js'
+import { invalidInput } from '../errors.js'
 
 export interface AccountSecurityUserView {
   readonly id: User['id']
@@ -220,6 +221,11 @@ export function toVerificationResendWindow(
   const resendAvailableAt = new Date(
     verification.createdAt.getTime() + input.cooldownSeconds * 1000,
   )
+
+  if (Number.isNaN(resendAvailableAt.getTime())) {
+    throw invalidInput('Verification resend cooldown produces an invalid availability time.')
+  }
+
   const cooldownRemainingSeconds = Math.max(
     0,
     Math.ceil((resendAvailableAt.getTime() - input.now.getTime()) / 1000),

--- a/src/providers/messenger/signed-webapp.ts
+++ b/src/providers/messenger/signed-webapp.ts
@@ -133,6 +133,11 @@ function enforceAuthDateMaxAge(input: {
   }
 
   const now = input.now ?? new Date()
+
+  if (Number.isNaN(now.getTime())) {
+    throw invalidSignedWebAppInitData()
+  }
+
   const minTime = now.getTime() - input.maxAgeSeconds * 1000
   const authTime = input.authDate.getTime()
 

--- a/test/messenger.test.ts
+++ b/test/messenger.test.ts
@@ -288,6 +288,14 @@ describe('messenger WebApp providers', () => {
     await expectInvalid(() =>
       validateSignedWebAppInitData({
         initData: signInitData(validFields()),
+        botToken,
+        maxAgeSeconds: 60,
+        now: new Date('invalid'),
+      }),
+    )
+    await expectInvalid(() =>
+      validateSignedWebAppInitData({
+        initData: signInitData(validFields()),
         botToken: '',
       }),
     )

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -152,4 +152,50 @@ describe('rate-limit integration', () => {
       }),
     ])
   })
+
+  it('rejects malformed rate-limit decisions before writing audit metadata', async () => {
+    const invalidRetryAfterLimiter = new InMemoryRateLimiter()
+    invalidRetryAfterLimiter.setDecision(
+      {
+        action: RateLimitAction.ProviderSignIn,
+        key: rateLimitKey('email', 'alice'),
+      },
+      { allowed: false, retryAfterSeconds: -1 },
+    )
+    const invalidRetryAfterKit = createInMemoryAuthKit({
+      rateLimiter: invalidRetryAfterLimiter,
+    })
+
+    await expect(
+      invalidRetryAfterKit.service.signIn({
+        assertion: assertion({ email: 'invalid-retry@example.com', emailVerified: true }),
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Rate-limit retryAfterSeconds must be a non-negative number.',
+    })
+    expect(invalidRetryAfterKit.store.listAuditEvents()).toHaveLength(0)
+
+    const invalidResetAtLimiter = new InMemoryRateLimiter()
+    invalidResetAtLimiter.setDecision(
+      {
+        action: RateLimitAction.ProviderSignIn,
+        key: rateLimitKey('email', 'alice'),
+      },
+      { allowed: false, resetAt: new Date('invalid') },
+    )
+    const invalidResetAtKit = createInMemoryAuthKit({ rateLimiter: invalidResetAtLimiter })
+
+    await expect(
+      invalidResetAtKit.service.signIn({
+        assertion: assertion({ email: 'invalid-reset-at@example.com', emailVerified: true }),
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Rate-limit resetAt must be a valid date.',
+    })
+    expect(invalidResetAtKit.store.listAuditEvents()).toHaveLength(0)
+  })
 })

--- a/test/resend-window.test.ts
+++ b/test/resend-window.test.ts
@@ -150,6 +150,35 @@ describe('verification resend window and rate-limit helpers', () => {
       code: UniAuthErrorCode.InvalidInput,
       message: 'Verification resend cooldown must be a non-negative integer.',
     })
+    await expect(
+      service.getVerificationResendWindow({
+        verificationId: created.verification.id,
+        cooldownSeconds: Number.MAX_VALUE,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification resend cooldown produces an invalid availability time.',
+    })
+    const overflowRuntime = createInMemoryAuthKit({
+      verificationResendCooldownSeconds: Number.MAX_VALUE,
+    })
+    const overflowRuntimeVerification = await overflowRuntime.service.createVerification({
+      purpose: VerificationPurpose.Link,
+      target: 'runtime-overflow-target',
+      secret: 'secret-token',
+      now,
+    })
+
+    await expect(
+      overflowRuntime.service.getVerificationResendWindow({
+        verificationId: overflowRuntimeVerification.verification.id,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification resend cooldown produces an invalid availability time.',
+    })
   })
 
   it('keeps Postgres resend window semantics aligned with in-memory behavior', async () => {


### PR DESCRIPTION
## Summary

- Reject resend cooldown values that produce invalid availability dates.
- Reject invalid signed WebApp max-age reference times.
- Validate rate-limit decision metadata before audit/error serialization.

## Checks

- npm run check

Closes #364
Closes #365
Closes #366
