### PR TITLE
Harden secret and OAuth token validation

### DIFF
--- a/src/providers/oauth-oidc/provider.ts
+++ b/src/providers/oauth-oidc/provider.ts
@@ -6,6 +6,8 @@ import { mapOAuthOidcProfileToAssertion } from './profile.js'
 import {
   isRecord,
   normalizeMetadataRecord,
+  normalizeOptionalDate,
+  normalizeOptionalStringArray,
   readFinishPayload,
   readString,
   requireNonBlankString,
@@ -112,7 +114,16 @@ function normalizeTokenSet(tokens: OAuthOidcTokenSet): OAuthOidcTokenSet {
     ...optionalProp('refreshToken', refreshToken),
     ...optionalProp('idToken', idToken),
     ...optionalProp('tokenType', readString(tokenSet.tokenType)),
-    ...optionalProp('expiresAt', tokenSet.expiresAt),
-    ...optionalProp('scopes', tokenSet.scopes),
+    ...optionalProp(
+      'expiresAt',
+      normalizeOptionalDate(tokenSet.expiresAt, 'OAuth/OIDC token expiration time is invalid.'),
+    ),
+    ...optionalProp(
+      'scopes',
+      normalizeOptionalStringArray(
+        tokenSet.scopes,
+        'OAuth/OIDC token scopes must be an array of strings.',
+      ),
+    ),
   }
 }

--- a/src/providers/oauth-oidc/support.ts
+++ b/src/providers/oauth-oidc/support.ts
@@ -17,6 +17,34 @@ export function readString(value: unknown): string | undefined {
   return value.trim() || undefined
 }
 
+export function normalizeOptionalDate(value: unknown, message: string): Date | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw invalidInput(message)
+  }
+
+  return value
+}
+
+export function normalizeOptionalStringArray(
+  value: unknown,
+  message: string,
+): readonly string[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw invalidInput(message)
+  }
+
+  const items = [...new Set(value.map((item) => item.trim()).filter(Boolean))]
+  return items.length > 0 ? items : undefined
+}
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/providers/oauth-oidc/tokens.ts
+++ b/src/providers/oauth-oidc/tokens.ts
@@ -1,6 +1,13 @@
 import { invalidInput } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
-import { isRecord, normalizeMetadataRecord, readString, requireNonBlankString } from './support.js'
+import {
+  isRecord,
+  normalizeMetadataRecord,
+  normalizeOptionalDate,
+  normalizeOptionalStringArray,
+  readString,
+  requireNonBlankString,
+} from './support.js'
 import type {
   CreateOAuthOidcTokenRecordInput,
   OAuthOidcTokenBinding,
@@ -57,8 +64,14 @@ function normalizeTokenSet(
   const refreshToken = readString(tokens.refreshToken)
   const idToken = readString(tokens.idToken)
   const tokenType = readString(tokens.tokenType)
-  const expiresAt = normalizeExpiresAt(tokens.expiresAt)
-  const scopes = normalizeScopes(tokens.scopes)
+  const expiresAt = normalizeOptionalDate(
+    tokens.expiresAt,
+    'OAuth/OIDC token expiration time is invalid.',
+  )
+  const scopes = normalizeOptionalStringArray(
+    tokens.scopes,
+    'OAuth/OIDC token scopes must be an array of strings.',
+  )
 
   if (!accessToken && !refreshToken && !idToken) {
     throw invalidInput(
@@ -74,31 +87,6 @@ function normalizeTokenSet(
     ...optionalProp('expiresAt', expiresAt),
     ...optionalProp('scopes', scopes),
   }
-}
-
-function normalizeExpiresAt(value: unknown): Date | undefined {
-  if (value === undefined) {
-    return undefined
-  }
-
-  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-    throw invalidInput('OAuth/OIDC token expiration time is invalid.')
-  }
-
-  return value
-}
-
-function normalizeScopes(value: unknown): readonly string[] | undefined {
-  if (value === undefined) {
-    return undefined
-  }
-
-  if (!Array.isArray(value) || value.some((scope) => typeof scope !== 'string')) {
-    throw invalidInput('OAuth/OIDC token scopes must be an array of strings.')
-  }
-
-  const scopes = [...new Set(value.map((scope) => scope.trim()).filter(Boolean))]
-  return scopes.length > 0 ? scopes : undefined
 }
 
 function normalizeMetadata(value: unknown): Record<string, unknown> | undefined {

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -107,7 +107,7 @@ export function createScryptSecretHasher(options: ScryptSecretHasherOptions = {}
 export const scryptSecretHasher: SecretHasher = createScryptSecretHasher()
 
 export function createHmacSecretHasher(input: { readonly pepper: string }): SecretHasher {
-  if (!input.pepper) {
+  if (typeof input.pepper !== 'string' || !input.pepper.trim()) {
     throw new Error('Secret hasher pepper is required.')
   }
 

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -31,11 +31,13 @@ const scryptAsync = promisify(
 )
 
 export function generateSecret(byteLength = 32): string {
-  return randomBytes(byteLength).toString('base64url')
+  return randomBytes(readPositiveInteger(byteLength, 'Secret byte length')).toString('base64url')
 }
 
 export function generateOtpSecret(length = 6): string {
-  return Array.from({ length }, () => randomInt(10).toString()).join('')
+  return Array.from({ length: readPositiveInteger(length, 'OTP secret length') }, () =>
+    randomInt(10).toString(),
+  ).join('')
 }
 
 export function hashSecret(secret: string): string {

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -130,6 +130,9 @@ describe('public utility coverage', () => {
     expect(() => createHmacSecretHasher({ pepper: '' })).toThrow(
       'Secret hasher pepper is required.',
     )
+    expect(() => createHmacSecretHasher({ pepper: '   ' })).toThrow(
+      'Secret hasher pepper is required.',
+    )
     expect(() => createScryptSecretHasher({ cost: 15 })).toThrow(
       'Scrypt cost must be a power of two.',
     )

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -105,6 +105,10 @@ describe('public utility coverage', () => {
 
     expect(generatedSecret).toBeTypeOf('string')
     expect(generatedOtpSecret).toMatch(/^\d{6}$/)
+    expect(() => generateSecret(0)).toThrow('Secret byte length must be a positive integer.')
+    expect(() => generateSecret(1.5)).toThrow('Secret byte length must be a positive integer.')
+    expect(() => generateOtpSecret(0)).toThrow('OTP secret length must be a positive integer.')
+    expect(() => generateOtpSecret(1.5)).toThrow('OTP secret length must be a positive integer.')
     expect(verifySecret('secret', secretHash)).toBe(true)
     expect(verifySecret('secret', 'plaintext')).toBe(false)
     expect(verifySecret('secret', 'sha256:short')).toBe(false)

--- a/test/oauth-oidc.test.ts
+++ b/test/oauth-oidc.test.ts
@@ -419,6 +419,24 @@ describe('OAuth/OIDC provider contract', () => {
         }),
       }).finish({ code: 'code' }),
     )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: new RecordingOAuthOidcClient(
+          { accessToken: 'token', expiresAt: new Date('invalid') },
+          { subject: 'subject' },
+        ),
+      }).finish({ code: 'code' }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: new RecordingOAuthOidcClient(
+          { accessToken: 'token', scopes: ['openid', 42] as unknown as readonly string[] },
+          { subject: 'subject' },
+        ),
+      }).finish({ code: 'code' }),
+    )
 
     await expectInvalid(() =>
       createOAuthOidcProvider({


### PR DESCRIPTION
## Summary

- Validate generated secret and OTP secret lengths before generation.
- Reject whitespace-only HMAC secret hasher peppers.
- Validate OAuth/OIDC exchange token metadata before profile fetch and reuse token metadata normalization.

## Checks

- npm run check

Closes #368
Closes #369
Closes #370
