### PR TITLE
Harden current-account and provider input validation

### DIFF
--- a/src/application/current-account-actions.ts
+++ b/src/application/current-account-actions.ts
@@ -246,8 +246,11 @@ function normalizeCurrentAccountProfilePatch(
     throw invalidInput('Current account profile update requires at least one profile field.')
   }
 
-  const displayName =
-    typeof input.displayName === 'string' ? input.displayName.trim() || undefined : undefined
+  if (input.displayName !== undefined && typeof input.displayName !== 'string') {
+    throw invalidInput('Current account display name must be a string.')
+  }
+
+  const displayName = input.displayName?.trim() || undefined
 
   return {
     displayName,

--- a/src/application/otp-delivery.ts
+++ b/src/application/otp-delivery.ts
@@ -23,6 +23,18 @@ export function normalizeOtpTarget(
   channel: OtpChannelType,
   target: string,
 ): string {
+  if (typeof target !== 'string') {
+    if (channel === OtpChannel.Email) {
+      throw invalidInput('Email is required.')
+    }
+
+    if (channel === OtpChannel.Phone) {
+      throw invalidInput('Phone is required.')
+    }
+
+    throw invalidInput('OTP target is required.')
+  }
+
   const trimmed = target.trim()
 
   if (!trimmed) {

--- a/src/application/sign-in/assertion.ts
+++ b/src/application/sign-in/assertion.ts
@@ -42,8 +42,11 @@ export function normalizeAssertion(
   runtime: Pick<AuthServiceRuntime, 'normalizer'>,
   assertion: Partial<ProviderIdentityAssertion>,
 ): ProviderIdentityAssertion {
-  const provider = assertion.provider?.trim() ?? ''
-  const providerUserId = assertion.providerUserId?.trim() ?? ''
+  const provider = normalizeRequiredClaim(assertion.provider, 'Provider is required.')
+  const providerUserId = normalizeRequiredClaim(
+    assertion.providerUserId,
+    'Provider user id is required.',
+  )
 
   if (!provider || !providerUserId) {
     throw invalidInput('Provider and provider user id are required.')
@@ -55,7 +58,7 @@ export function normalizeAssertion(
 
   const email = normalizeOptionalClaim(assertion.email, runtime.normalizer.normalizeEmail)
   const phone = normalizeOptionalClaim(assertion.phone, runtime.normalizer.normalizePhone)
-  const displayName = assertion.displayName?.trim() || undefined
+  const displayName = normalizeOptionalClaim(assertion.displayName, (value) => value)
 
   return {
     provider,
@@ -81,16 +84,28 @@ export function normalizeAssertion(
   }
 }
 
+function normalizeRequiredClaim(value: unknown, message: string): string {
+  if (typeof value !== 'string') {
+    throw invalidInput(message)
+  }
+
+  return value.trim()
+}
+
 function hasControlCharacter(value: string): boolean {
   return /[\u0000-\u001f\u007f]/u.test(value)
 }
 
 function normalizeOptionalClaim(
-  value: string | undefined,
+  value: unknown,
   normalize: (value: string) => string,
 ): string | undefined {
   if (value === undefined) {
     return undefined
+  }
+
+  if (typeof value !== 'string') {
+    throw invalidInput('Provider assertion optional claims must be strings.')
   }
 
   const trimmed = value.trim()

--- a/test/core/current-account-actions.test.ts
+++ b/test/core/current-account-actions.test.ts
@@ -219,6 +219,14 @@ describe('DefaultAuthService current-account action helpers', () => {
     await expect(
       service.updateCurrentAccountProfileByToken({
         sessionToken: signedIn.sessionToken,
+        displayName: 123 as unknown as string,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.updateCurrentAccountProfileByToken({
+        sessionToken: signedIn.sessionToken,
       }),
     ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,

--- a/test/core/otp-and-verifications.test.ts
+++ b/test/core/otp-and-verifications.test.ts
@@ -521,6 +521,16 @@ describe('DefaultAuthService OTP and verification flows', () => {
         })
         .catch((caught: unknown) => caught),
     ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await serviceWithoutSmsSender
+        .startOtpChallenge({
+          purpose: VerificationPurpose.SignIn,
+          channel: OtpChannel.Email,
+          target: 123 as unknown as string,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
 
     const { service, store } = createInMemoryAuthKit()
     const challenge = await service.startOtpChallenge({

--- a/test/otp-options.test.ts
+++ b/test/otp-options.test.ts
@@ -100,9 +100,36 @@ describe('OTP configuration', () => {
         now,
       })
       .catch((caught: unknown) => caught)
+    const nonStringEmailTargetError = await createInMemoryAuthKit()
+      .service.startOtpChallenge({
+        purpose: VerificationPurpose.SignIn,
+        channel: OtpChannel.Email,
+        target: 123 as unknown as string,
+        now,
+      })
+      .catch((caught: unknown) => caught)
+    const nonStringPhoneTargetError = await createInMemoryAuthKit()
+      .service.startOtpChallenge({
+        purpose: VerificationPurpose.SignIn,
+        channel: OtpChannel.Phone,
+        target: 123 as unknown as string,
+        now,
+      })
+      .catch((caught: unknown) => caught)
+    const nonStringUnsupportedTargetError = await createInMemoryAuthKit()
+      .service.startOtpChallenge({
+        purpose: VerificationPurpose.SignIn,
+        channel: 'push' as OtpChannel,
+        target: 123 as unknown as string,
+        now,
+      })
+      .catch((caught: unknown) => caught)
 
     expect(invalidLengthError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(emptyCustomError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringEmailTargetError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringPhoneTargetError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringUnsupportedTargetError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(invalidLength.store.listVerifications()).toHaveLength(0)
     expect(emptyCustom.store.listVerifications()).toHaveLength(0)
   })

--- a/test/provider-policy/provider-resolution-and-validation.test.ts
+++ b/test/provider-policy/provider-resolution-and-validation.test.ts
@@ -58,6 +58,29 @@ describe('provider resolution and assertion validation failures', () => {
     expect(
       await noRegistryService
         .signIn({
+          assertion: {
+            provider: 123,
+            providerUserId: 'user',
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
+          assertion: {
+            provider: 'email',
+            providerUserId: 'user',
+            email: 123,
+          } as unknown as ProviderIdentityAssertion,
+          now,
+        })
+        .catch((caught: unknown) => caught),
+    ).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(
+      await noRegistryService
+        .signIn({
           assertion: assertion({
             provider: 'oauth',
             providerUserId: 'invalid-trust',


### PR DESCRIPTION
## Summary

- Reject non-string current-account displayName values while preserving explicit clearing.
- Reject non-string OTP targets before channel-specific normalization.
- Reject non-string provider assertion required and optional claims with controlled invalid input errors.

## Checks

- npm run check

Closes #372
Closes #373
Closes #374
