### PR TITLE
Fix runtime string input validation

### DIFF
--- a/src/application/magic-link.ts
+++ b/src/application/magic-link.ts
@@ -33,6 +33,11 @@ export async function startEmailMagicLinkSignIn(
   input: StartEmailMagicLinkSignInInput,
 ): Promise<StartEmailMagicLinkSignInResult> {
   const now = input.now ?? runtime.clock.now()
+
+  if (typeof input.email !== 'string') {
+    throw invalidInput('Email is required.')
+  }
+
   const trimmedEmail = input.email.trim()
 
   if (!trimmedEmail) {

--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -83,6 +83,11 @@ export async function resolveSession(
   input: ResolveSessionInput,
 ): Promise<Session> {
   const now = input.now ?? runtime.clock.now()
+
+  if (typeof input.sessionToken !== 'string') {
+    throw invalidInput('Session token is required.')
+  }
+
   const sessionToken = input.sessionToken.trim()
 
   if (!sessionToken) {

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -152,6 +152,11 @@ export async function createVerificationRecord(
 ): Promise<CreateVerificationResult> {
   const secret = resolveVerificationSecret(input.secret)
   const metadata = normalizeVerificationMetadata(input.metadata)
+
+  if (typeof input.target !== 'string') {
+    throw invalidInput('Verification target is required.')
+  }
+
   const trimmedTarget = input.target.trim()
 
   if (!trimmedTarget) {

--- a/test/magic-link.test.ts
+++ b/test/magic-link.test.ts
@@ -173,6 +173,13 @@ describe('email magic link sign-in', () => {
         now,
       })
       .catch((caught: unknown) => caught)
+    const nonStringEmailError = await service
+      .startEmailMagicLinkSignIn({
+        email: 123,
+        createLink: () => 'https://app.example.test/auth/magic',
+        now,
+      } as unknown as Parameters<typeof service.startEmailMagicLinkSignIn>[0])
+      .catch((caught: unknown) => caught)
     const missingSenderError = await defaultService
       .startEmailMagicLinkSignIn({
         email: 'alice@example.com',
@@ -203,6 +210,7 @@ describe('email magic link sign-in', () => {
       .catch((caught: unknown) => caught)
 
     expect(blankEmailError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringEmailError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(missingSenderError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(missingVerificationError).toMatchObject({
       code: UniAuthErrorCode.VerificationNotFound,

--- a/test/normalization.test.ts
+++ b/test/normalization.test.ts
@@ -176,6 +176,16 @@ describe('shared normalization boundary', () => {
       code: UniAuthErrorCode.InvalidInput,
       message: 'Verification target is required.',
     })
+    await expect(
+      service.createVerification({
+        purpose: VerificationPurpose.Link,
+        target: 123,
+        now,
+      } as unknown as Parameters<typeof service.createVerification>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification target is required.',
+    })
 
     expect(store.listVerifications()).toHaveLength(0)
     expect(emailSender.listMessages()).toHaveLength(0)

--- a/test/security-storage.test.ts
+++ b/test/security-storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  UniAuthErrorCode,
   VerificationPurpose,
   VerificationStatus,
   addSeconds,
@@ -163,6 +164,15 @@ describe('security storage regressions', () => {
         }),
       ).resolves.toMatchObject({
         id: secondSession.session.id,
+      })
+      await expect(
+        service.resolveSession({
+          sessionToken: 123,
+          now,
+        } as unknown as Parameters<typeof service.resolveSession>[0]),
+      ).rejects.toMatchObject({
+        code: UniAuthErrorCode.InvalidInput,
+        message: 'Session token is required.',
       })
 
       expect(await store.sessionRepo.findByTokenHash(signedIn.sessionToken)).toBeUndefined()


### PR DESCRIPTION
## Summary
- reject non-string verification targets before trimming
- reject non-string magic-link emails before trimming
- reject non-string session tokens before hashing

## Verification
- npm run check

Closes #376
Closes #377
Closes #378