### PR TITLE
Fix additional runtime input validation

### DIFF
--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -54,17 +54,28 @@ function normalizeAuditEventQuery(input: AuditEventQuery): NormalizedAuditEventQ
     throw invalidInput('Audit event limit must be a positive integer.')
   }
 
-  const type = input.type?.trim() as AuditEventQuery['type'] | undefined
-
   if (input.type !== undefined) {
+    if (typeof input.type !== 'string') {
+      throw invalidInput('Audit event type is invalid.')
+    }
+
+    const type = input.type.trim() as AuditEventQuery['type']
+
     if (!type) {
       throw invalidInput('Audit event type is invalid.')
+    }
+
+    return {
+      ...input,
+      type,
+      ...(before ? { before } : {}),
+      ...(after ? { after } : {}),
+      limit,
     }
   }
 
   return {
     ...input,
-    ...(type ? { type } : {}),
     ...(before ? { before } : {}),
     ...(after ? { after } : {}),
     limit,

--- a/src/application/passwords/shared.ts
+++ b/src/application/passwords/shared.ts
@@ -24,6 +24,10 @@ export function normalizePasswordEmail(
   runtime: Pick<AuthServiceRuntime, 'normalizer'>,
   email: string,
 ): string {
+  if (typeof email !== 'string') {
+    throw invalidInput('Email is required.')
+  }
+
   const trimmed = email.trim()
 
   if (!trimmed) {
@@ -40,7 +44,7 @@ export function normalizePasswordEmail(
 }
 
 export function assertPassword(password: string): void {
-  if (!password) {
+  if (typeof password !== 'string' || !password) {
     throw invalidInput('Password is required.')
   }
 }

--- a/src/application/passwords/sign-in.ts
+++ b/src/application/passwords/sign-in.ts
@@ -13,7 +13,6 @@ import { invalidCredentials } from '../../errors.js'
 import { RateLimitAction, rateLimitKey } from '../../ports.js'
 import {
   PasswordAuditMode,
-  assertPassword,
   findPasswordCredentialByEmail,
   findUsableCredentialUser,
   findUsablePasswordIdentity,
@@ -27,7 +26,10 @@ export async function signInWithPassword(
 ): Promise<AuthResult> {
   const now = input.now ?? runtime.clock.now()
   const email = normalizePasswordEmail(runtime, input.email)
-  assertPassword(input.password)
+  if (typeof input.password !== 'string' || !input.password) {
+    throw invalidCredentials()
+  }
+
   const passwordHasher = getPasswordHasher(runtime)
 
   await enforceRateLimit(runtime, {

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -286,12 +286,37 @@ describe('password credentials', () => {
         now,
       })
       .catch((caught: unknown) => caught)
+    const nonStringEmailError = await service
+      .setPassword({
+        userId: first.user.id,
+        email: 123,
+        password: 'password',
+        reAuthenticatedAt: now,
+        now,
+      } as unknown as Parameters<typeof service.setPassword>[0])
+      .catch((caught: unknown) => caught)
     const blankPasswordError = await service
       .signInWithPassword({
         email: 'alice@example.com',
         password: '',
         now,
       })
+      .catch((caught: unknown) => caught)
+    const nonStringSetupPasswordError = await service
+      .setPassword({
+        userId: first.user.id,
+        email: 'alice@example.com',
+        password: 123,
+        reAuthenticatedAt: now,
+        now,
+      } as unknown as Parameters<typeof service.setPassword>[0])
+      .catch((caught: unknown) => caught)
+    const nonStringSignInPasswordError = await service
+      .signInWithPassword({
+        email: 'alice@example.com',
+        password: 123,
+        now,
+      } as unknown as Parameters<typeof service.signInWithPassword>[0])
       .catch((caught: unknown) => caught)
 
     expect(updated.passwordHash).not.toBe('alice-password')
@@ -300,7 +325,12 @@ describe('password credentials', () => {
     expect(emailChangeError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(missingHasherError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(blankEmailError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
-    expect(blankPasswordError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringEmailError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(blankPasswordError).toMatchObject({ code: UniAuthErrorCode.InvalidCredentials })
+    expect(nonStringSetupPasswordError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
+    expect(nonStringSignInPasswordError).toMatchObject({
+      code: UniAuthErrorCode.InvalidCredentials,
+    })
   })
 
   it('starts and finishes password recovery with consume-once verification semantics', async () => {

--- a/test/verification-cancellation.test.ts
+++ b/test/verification-cancellation.test.ts
@@ -332,6 +332,14 @@ describe('verification cancellation flows', () => {
       type: AuditEventType.VerificationCancelled,
     })
 
+    await expect(
+      service.getAuditEvents({
+        type: 123,
+      } as unknown as Parameters<typeof service.getAuditEvents>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Audit event type is invalid.',
+    })
     expect(cancelled.expiresAt).toEqual(now)
     expect(auditEvents).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- reject non-string audit event types before trimming
- reject non-string password emails before normalization
- reject non-string password values before hashing or verification

## Verification
- npm run check

Closes #380
Closes #381
Closes #382