### PR TITLE
Fix date runtime validation

### DIFF
--- a/src/application/support.ts
+++ b/src/application/support.ts
@@ -12,6 +12,7 @@ import type {
 import { AuditEventType, isActiveIdentity, isActiveUser } from '../domain/types.js'
 import { UniAuthError, UniAuthErrorCode, invalidInput, rateLimited } from '../errors.js'
 import type { RateLimitAttempt, RateLimitDecision } from '../contracts.js'
+import { assertValidDate } from '../utils/time.js'
 
 const PolicyDenialReason = {
   ReAuthRequired: 're-auth-required',
@@ -47,6 +48,12 @@ export async function ensureReAuth(
   reAuthenticatedAt: Date | undefined,
   now: Date,
 ): Promise<void> {
+  assertValidDate(now, 'Request time is invalid.')
+
+  if (reAuthenticatedAt !== undefined) {
+    assertValidDate(reAuthenticatedAt, 'Re-authentication time is invalid.')
+  }
+
   const required = await runtime.policy.requiresReAuth({
     action,
     userId,
@@ -101,7 +108,10 @@ function normalizeRateLimitDecisionDetails(
     throw invalidInput('Rate-limit retryAfterSeconds must be a non-negative number.')
   }
 
-  if (decision.resetAt !== undefined && Number.isNaN(decision.resetAt.getTime())) {
+  if (
+    decision.resetAt !== undefined &&
+    (!(decision.resetAt instanceof Date) || Number.isNaN(decision.resetAt.getTime()))
+  ) {
     throw invalidInput('Rate-limit resetAt must be a valid date.')
   }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -9,8 +9,8 @@ export function addSeconds(date: Date, seconds: number): Date {
   return new Date(date.getTime() + seconds * 1000)
 }
 
-export function assertValidDate(date: Date, message: string): void {
-  if (Number.isNaN(date.getTime())) {
+export function assertValidDate(date: unknown, message: string): asserts date is Date {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     throw invalidInput(message)
   }
 }

--- a/test/password.test.ts
+++ b/test/password.test.ts
@@ -238,6 +238,15 @@ describe('password credentials', () => {
         now,
       })
       .catch((caught: unknown) => caught)
+    const invalidReAuthenticatedAtError = await service
+      .setPassword({
+        userId: first.user.id,
+        email: 'alice@example.com',
+        password: 'alice-password',
+        reAuthenticatedAt: 'not-a-date',
+        now,
+      } as unknown as Parameters<typeof service.setPassword>[0])
+      .catch((caught: unknown) => caught)
     await service.setPassword({
       userId: first.user.id,
       email: 'alice@example.com',
@@ -321,6 +330,10 @@ describe('password credentials', () => {
 
     expect(updated.passwordHash).not.toBe('alice-password')
     expect(reAuthError).toMatchObject({ code: UniAuthErrorCode.ReAuthRequired })
+    expect(invalidReAuthenticatedAtError).toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Re-authentication time is invalid.',
+    })
     expect(conflictError).toMatchObject({ code: UniAuthErrorCode.CredentialAlreadyExists })
     expect(emailChangeError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })
     expect(missingHasherError).toMatchObject({ code: UniAuthErrorCode.InvalidInput })

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -197,5 +197,26 @@ describe('rate-limit integration', () => {
       message: 'Rate-limit resetAt must be a valid date.',
     })
     expect(invalidResetAtKit.store.listAuditEvents()).toHaveLength(0)
+
+    const nonDateResetAtLimiter = new InMemoryRateLimiter()
+    nonDateResetAtLimiter.setDecision(
+      {
+        action: RateLimitAction.ProviderSignIn,
+        key: rateLimitKey('email', 'alice'),
+      },
+      { allowed: false, resetAt: 'not-a-date' as unknown as Date },
+    )
+    const nonDateResetAtKit = createInMemoryAuthKit({ rateLimiter: nonDateResetAtLimiter })
+
+    await expect(
+      nonDateResetAtKit.service.signIn({
+        assertion: assertion({ email: 'non-date-reset-at@example.com', emailVerified: true }),
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Rate-limit resetAt must be a valid date.',
+    })
+    expect(nonDateResetAtKit.store.listAuditEvents()).toHaveLength(0)
   })
 })

--- a/test/security-storage.test.ts
+++ b/test/security-storage.test.ts
@@ -174,6 +174,15 @@ describe('security storage regressions', () => {
         code: UniAuthErrorCode.InvalidInput,
         message: 'Session token is required.',
       })
+      await expect(
+        service.createSession({
+          userId: signedIn.user.id,
+          now: 'not-a-date',
+        } as unknown as Parameters<typeof service.createSession>[0]),
+      ).rejects.toMatchObject({
+        code: UniAuthErrorCode.InvalidInput,
+        message: 'Session creation time is invalid.',
+      })
 
       expect(await store.sessionRepo.findByTokenHash(signedIn.sessionToken)).toBeUndefined()
       expect(await store.sessionRepo.findByTokenHash(secondSession.sessionToken)).toBeUndefined()


### PR DESCRIPTION
## Summary
- reject non-Date values in shared date validation
- reject non-Date rate-limit resetAt values
- validate re-auth timestamps before policy checks

## Verification
- npm run check

Closes #384
Closes #385
Closes #386