### PR TITLE
Fix runtime time boundary validation

### DIFF
--- a/src/application/sessions.ts
+++ b/src/application/sessions.ts
@@ -83,6 +83,7 @@ export async function resolveSession(
   input: ResolveSessionInput,
 ): Promise<Session> {
   const now = input.now ?? runtime.clock.now()
+  assertValidDate(now, 'Session resolution time is invalid.')
 
   if (typeof input.sessionToken !== 'string') {
     throw invalidInput('Session token is required.')

--- a/src/application/support.ts
+++ b/src/application/support.ts
@@ -133,6 +133,8 @@ export async function audit(
     readonly metadata?: Record<string, unknown>
   } = {},
 ): Promise<void> {
+  assertValidDate(occurredAt, 'Audit event time is invalid.')
+
   const event: AuditEvent = {
     id: runtime.idGenerator.auditEventId(),
     type,

--- a/src/application/verifications.ts
+++ b/src/application/verifications.ts
@@ -197,6 +197,7 @@ export async function consumeVerificationRecord(
   input: ConsumeVerificationInput,
 ): Promise<Verification> {
   const now = input.now ?? runtime.clock.now()
+  assertValidDate(now, 'Verification consumption time is invalid.')
   const secret = requireVerificationSecret(input.secret)
   const verification = await runtime.repos.verificationRepo.findByIdForUpdate(input.verificationId)
 

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -218,5 +218,26 @@ describe('rate-limit integration', () => {
       message: 'Rate-limit resetAt must be a valid date.',
     })
     expect(nonDateResetAtKit.store.listAuditEvents()).toHaveLength(0)
+
+    const invalidAuditTimeLimiter = new InMemoryRateLimiter()
+    invalidAuditTimeLimiter.setDecision(
+      {
+        action: RateLimitAction.ProviderSignIn,
+        key: rateLimitKey('email', 'alice'),
+      },
+      { allowed: false, retryAfterSeconds: 1 },
+    )
+    const invalidAuditTimeKit = createInMemoryAuthKit({ rateLimiter: invalidAuditTimeLimiter })
+
+    await expect(
+      invalidAuditTimeKit.service.signIn({
+        assertion: assertion({ email: 'invalid-audit-time@example.com', emailVerified: true }),
+        now: 'not-a-date',
+      } as unknown as Parameters<typeof invalidAuditTimeKit.service.signIn>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Audit event time is invalid.',
+    })
+    expect(invalidAuditTimeKit.store.listAuditEvents()).toHaveLength(0)
   })
 })

--- a/test/security-storage.test.ts
+++ b/test/security-storage.test.ts
@@ -175,6 +175,15 @@ describe('security storage regressions', () => {
         message: 'Session token is required.',
       })
       await expect(
+        service.resolveSession({
+          sessionToken: signedIn.sessionToken,
+          now: 'not-a-date',
+        } as unknown as Parameters<typeof service.resolveSession>[0]),
+      ).rejects.toMatchObject({
+        code: UniAuthErrorCode.InvalidInput,
+        message: 'Session resolution time is invalid.',
+      })
+      await expect(
         service.createSession({
           userId: signedIn.user.id,
           now: 'not-a-date',

--- a/test/verification-cancellation.test.ts
+++ b/test/verification-cancellation.test.ts
@@ -38,6 +38,16 @@ describe('verification cancellation flows', () => {
       service.consumeVerification({
         verificationId: created.verification.id,
         secret: '123456',
+        now: 'not-a-date',
+      } as unknown as Parameters<typeof service.consumeVerification>[0]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Verification consumption time is invalid.',
+    })
+    await expect(
+      service.consumeVerification({
+        verificationId: created.verification.id,
+        secret: '123456',
         now,
       }),
     ).rejects.toMatchObject({


### PR DESCRIPTION
## Summary
- validate session resolution timestamps before active-session checks
- validate verification consumption timestamps before expiration checks
- validate audit event timestamps before persistence

## Verification
- npm run check

Closes #388
Closes #389
Closes #390