### PR TITLE
Fix resend window helper validation

### DIFF
--- a/src/domain/views.ts
+++ b/src/domain/views.ts
@@ -218,6 +218,14 @@ export function toVerificationResendWindow(
     readonly cooldownSeconds: number
   },
 ): VerificationResendWindow {
+  assertResendWindowDate(verification.createdAt, 'Verification creation time is invalid.')
+  assertResendWindowDate(verification.expiresAt, 'Verification expiration time is invalid.')
+  assertResendWindowDate(input.now, 'Verification resend window time is invalid.')
+
+  if (!Number.isInteger(input.cooldownSeconds) || input.cooldownSeconds < 0) {
+    throw invalidInput('Verification resend cooldown must be a non-negative integer.')
+  }
+
   const resendAvailableAt = new Date(
     verification.createdAt.getTime() + input.cooldownSeconds * 1000,
   )
@@ -243,5 +251,11 @@ export function toVerificationResendWindow(
     resendAvailableAt,
     cooldownSeconds: input.cooldownSeconds,
     cooldownRemainingSeconds,
+  }
+}
+
+function assertResendWindowDate(value: unknown, message: string): asserts value is Date {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw invalidInput(message)
   }
 }

--- a/test/views.test.ts
+++ b/test/views.test.ts
@@ -251,6 +251,49 @@ describe('safe projection helpers', () => {
     expect(view).not.toHaveProperty('metadata')
   })
 
+  it('rejects invalid verification resend window helper inputs', () => {
+    const verification: Verification = {
+      id: asVerificationId('verification-invalid-window'),
+      purpose: 'sign-in',
+      target: 'alice@example.com',
+      secretHash: 'secret-hash',
+      status: VerificationStatus.Pending,
+      createdAt: now,
+      expiresAt: new Date('2026-01-01T00:10:00.000Z'),
+    }
+
+    expect(() =>
+      toVerificationResendWindow(
+        {
+          ...verification,
+          createdAt: 'not-a-date' as unknown as Date,
+        },
+        { now, cooldownSeconds: 60 },
+      ),
+    ).toThrow('Verification creation time is invalid.')
+    expect(() =>
+      toVerificationResendWindow(
+        {
+          ...verification,
+          expiresAt: 'not-a-date' as unknown as Date,
+        },
+        { now, cooldownSeconds: 60 },
+      ),
+    ).toThrow('Verification expiration time is invalid.')
+    expect(() =>
+      toVerificationResendWindow(verification, {
+        now: 'not-a-date' as unknown as Date,
+        cooldownSeconds: 60,
+      }),
+    ).toThrow('Verification resend window time is invalid.')
+    expect(() =>
+      toVerificationResendWindow(verification, {
+        now,
+        cooldownSeconds: 1.5,
+      }),
+    ).toThrow('Verification resend cooldown must be a non-negative integer.')
+  })
+
   it('maps trusted inspection views without leaking audit metadata', () => {
     const userView = toAccountSecurityUserView(user('user-9'))
     const identityOnlyAuditView = toAuditEventView({


### PR DESCRIPTION
## Summary
- validate verification resend window helper dates
- reject invalid cooldown values before calculating windows
- cover direct helper misuse with regression tests

## Verification
- npm run check

Closes #392