### PR TITLE
Fix public helper runtime validation

### DIFF
--- a/src/attribution.ts
+++ b/src/attribution.ts
@@ -70,6 +70,14 @@ export const UNIAUTH_ATTRIBUTION = {
 } as const satisfies UniAuthAttributionDetails
 
 export function getUniAuthAttributionNotice(options: UniAuthAttributionNoticeOptions = {}): string {
+  if (!isAttributionOptions(options)) {
+    throw new Error('Attribution notice options must be a plain object.')
+  }
+
+  if (options.productName !== undefined && typeof options.productName !== 'string') {
+    throw new Error('Attribution product name must be a string.')
+  }
+
   const productName = options.productName?.trim()
   const subject = productName ? `${productName} uses` : 'This product uses'
   const parts = [`${subject} ${UNIAUTH_ATTRIBUTION.packageName}.`, UNIAUTH_ATTRIBUTION.copyright]
@@ -83,4 +91,13 @@ export function getUniAuthAttributionNotice(options: UniAuthAttributionNoticeOpt
   }
 
   return parts.join(' ')
+}
+
+function isAttributionOptions(value: unknown): value is UniAuthAttributionNoticeOptions {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -41,10 +41,15 @@ export function generateOtpSecret(length = 6): string {
 }
 
 export function hashSecret(secret: string): string {
+  requireSecretString(secret, 'Secret must be a string.')
   return `${SECRET_HASH_PREFIX}${createHash('sha256').update(secret).digest('hex')}`
 }
 
 export function verifySecret(secret: string, secretHash: string): boolean {
+  if (typeof secret !== 'string' || typeof secretHash !== 'string') {
+    return false
+  }
+
   return verifyPrefixedSecret(secretHash, hashSecret(secret), SECRET_HASH_PREFIX)
 }
 
@@ -80,13 +85,17 @@ export function createScryptSecretHasher(options: ScryptSecretHasherOptions = {}
   return {
     async hash(secret): Promise<string> {
       const salt = randomBytes(saltByteLength)
-      const derived = await deriveScrypt(secret, salt, {
-        cost,
-        blockSize,
-        parallelization,
-        keyLength,
-        maxmem,
-      })
+      const derived = await deriveScrypt(
+        requireSecretString(secret, 'Secret must be a string.'),
+        salt,
+        {
+          cost,
+          blockSize,
+          parallelization,
+          keyLength,
+          maxmem,
+        },
+      )
 
       return [
         SCRYPT_SECRET_HASH_PREFIX.slice(0, -1),
@@ -107,16 +116,32 @@ export function createScryptSecretHasher(options: ScryptSecretHasherOptions = {}
 export const scryptSecretHasher: SecretHasher = createScryptSecretHasher()
 
 export function createHmacSecretHasher(input: { readonly pepper: string }): SecretHasher {
-  if (typeof input.pepper !== 'string' || !input.pepper.trim()) {
+  const candidate = input as unknown
+
+  if (
+    !candidate ||
+    typeof candidate !== 'object' ||
+    Array.isArray(candidate) ||
+    !('pepper' in candidate) ||
+    typeof candidate.pepper !== 'string' ||
+    !candidate.pepper.trim()
+  ) {
     throw new Error('Secret hasher pepper is required.')
   }
 
+  const pepper = candidate.pepper
   const hash = (secret: string): string =>
-    `${HMAC_SECRET_HASH_PREFIX}${createHmac('sha256', input.pepper).update(secret).digest('hex')}`
+    `${HMAC_SECRET_HASH_PREFIX}${createHmac('sha256', pepper)
+      .update(requireSecretString(secret, 'Secret must be a string.'))
+      .digest('hex')}`
 
   return {
     hash,
     verify(secret, secretHash): boolean {
+      if (typeof secret !== 'string' || typeof secretHash !== 'string') {
+        return false
+      }
+
       return verifyPrefixedSecret(secretHash, hash(secret), HMAC_SECRET_HASH_PREFIX)
     },
   }
@@ -138,6 +163,10 @@ function verifyPrefixedSecret(secretHash: string, actualHash: string, prefix: st
 }
 
 async function verifyScryptSecret(secret: string, secretHash: string): Promise<boolean> {
+  if (typeof secret !== 'string' || typeof secretHash !== 'string') {
+    return false
+  }
+
   if (!secretHash.startsWith(SCRYPT_SECRET_HASH_PREFIX)) {
     return false
   }
@@ -222,4 +251,12 @@ function readPositiveInteger(value: number, name: string): number {
   }
 
   return value
+}
+
+function requireSecretString(secret: string, message: string): string {
+  if (typeof secret !== 'string') {
+    throw new Error(message)
+  }
+
+  return secret
 }

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -19,6 +19,7 @@ import {
   createSequentialIdGenerator,
   generateOtpSecret,
   generateSecret,
+  getUniAuthAttributionNotice,
   hashSecret,
   invalidCredentials,
   invalidInput,
@@ -113,12 +114,24 @@ describe('public utility coverage', () => {
     expect(verifySecret('secret', 'plaintext')).toBe(false)
     expect(verifySecret('secret', 'sha256:short')).toBe(false)
     expect(verifySecret('wrong', secretHash)).toBe(false)
+    expect(verifySecret(123 as unknown as string, secretHash)).toBe(false)
+    expect(verifySecret('secret', 123 as unknown as string)).toBe(false)
+    expect(() => hashSecret(123 as unknown as string)).toThrow('Secret must be a string.')
     expect(hmacHash).toMatch(/^hmac-sha256:/)
     expect(await hmacHasher.verify('123456', hmacHash)).toBe(true)
     expect(await hmacHasher.verify('000000', hmacHash)).toBe(false)
     expect(await hmacHasher.verify('123456', secretHash)).toBe(false)
+    expect(await hmacHasher.verify(123 as unknown as string, hmacHash)).toBe(false)
+    expect(() => hmacHasher.hash(123 as unknown as string)).toThrow('Secret must be a string.')
     expect(defaultScryptHash).toMatch(/^scrypt:/)
     expect(await defaultScryptHasher.verify('123456', defaultScryptHash)).toBe(true)
+    await expect(defaultScryptHasher.hash(123 as unknown as string)).rejects.toThrow(
+      'Secret must be a string.',
+    )
+    expect(await defaultScryptHasher.verify(123 as unknown as string, defaultScryptHash)).toBe(
+      false,
+    )
+    expect(await defaultScryptHasher.verify('123456', 123 as unknown as string)).toBe(false)
     expect(scryptHash).toMatch(/^scrypt:/)
     expect(await scryptHasher.verify('123456', scryptHash)).toBe(true)
     expect(await scryptHasher.verify('000000', scryptHash)).toBe(false)
@@ -131,6 +144,9 @@ describe('public utility coverage', () => {
       'Secret hasher pepper is required.',
     )
     expect(() => createHmacSecretHasher({ pepper: '   ' })).toThrow(
+      'Secret hasher pepper is required.',
+    )
+    expect(() => createHmacSecretHasher(undefined as unknown as { pepper: string })).toThrow(
       'Secret hasher pepper is required.',
     )
     expect(() => createScryptSecretHasher({ cost: 15 })).toThrow(
@@ -153,6 +169,15 @@ describe('public utility coverage', () => {
     )
     expect(addSeconds(now, 5)).toEqual(new Date('2026-01-01T00:00:05.000Z'))
     expect(systemClock.now()).toBeInstanceOf(Date)
+    expect(() => getUniAuthAttributionNotice({ productName: 123 as unknown as string })).toThrow(
+      'Attribution product name must be a string.',
+    )
+    expect(() => getUniAuthAttributionNotice(null as unknown as object)).toThrow(
+      'Attribution notice options must be a plain object.',
+    )
+    expect(getUniAuthAttributionNotice(Object.assign(Object.create(null), {}))).toContain(
+      'This product uses',
+    )
 
     const store = new InMemoryAuthStore()
     const runtime = createAuthServiceRuntime({


### PR DESCRIPTION
## Summary
- validate secret helper runtime inputs before crypto/string operations
- return false for malformed secret verifier inputs
- validate attribution notice options before formatting

## Verification
- npm run check

Closes #394
Closes #395