### PR TITLE
Fix normalizer and time helper validation

### DIFF
--- a/src/utils/normalization.ts
+++ b/src/utils/normalization.ts
@@ -7,11 +7,13 @@ export type {
 } from '../contracts.js'
 
 export function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase()
+  return requireNormalizerString(email, 'Email must be a string.').trim().toLowerCase()
 }
 
 export function normalizePhone(phone: string): string {
-  return phone.replace(/[\s().-]+/g, '').trim()
+  return requireNormalizerString(phone, 'Phone must be a string.')
+    .replace(/[\s().-]+/g, '')
+    .trim()
 }
 
 export function normalizeTarget(target: string): string {
@@ -22,6 +24,22 @@ export function normalizeTarget(target: string): string {
 }
 
 export function createAuthNormalizer(options: CreateAuthNormalizerOptions = {}): AuthNormalizer {
+  if (!isNormalizerOptions(options)) {
+    throw new Error('Normalizer options must be a plain object.')
+  }
+
+  if (options.normalizeEmail !== undefined && typeof options.normalizeEmail !== 'function') {
+    throw new Error('Email normalizer must be a function.')
+  }
+
+  if (options.normalizePhone !== undefined && typeof options.normalizePhone !== 'function') {
+    throw new Error('Phone normalizer must be a function.')
+  }
+
+  if (options.normalizeTarget !== undefined && typeof options.normalizeTarget !== 'function') {
+    throw new Error('Target normalizer must be a function.')
+  }
+
   const helpers = {
     normalizeEmail: options.normalizeEmail ?? normalizeEmail,
     normalizePhone: options.normalizePhone ?? normalizePhone,
@@ -41,7 +59,7 @@ function defaultNormalizeTarget(
   target: string,
   helpers: Pick<AuthNormalizer, 'normalizeEmail' | 'normalizePhone'>,
 ): string {
-  const trimmed = target.trim()
+  const trimmed = requireNormalizerString(target, 'Target must be a string.').trim()
 
   if (!trimmed) {
     return ''
@@ -60,4 +78,21 @@ function defaultNormalizeTarget(
 
 function isPhoneLikeTarget(target: string): boolean {
   return /[0-9]/u.test(target) && /^[+\d\s().-]+$/u.test(target)
+}
+
+function isNormalizerOptions(value: unknown): value is CreateAuthNormalizerOptions {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function requireNormalizerString(value: string, message: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(message)
+  }
+
+  return value
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -6,6 +6,12 @@ export const systemClock: Clock = {
 }
 
 export function addSeconds(date: Date, seconds: number): Date {
+  assertValidDate(date, 'Date must be valid.')
+
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) {
+    throw invalidInput('Seconds must be a finite number.')
+  }
+
   return new Date(date.getTime() + seconds * 1000)
 }
 

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -67,6 +67,9 @@ describe('public utility coverage', () => {
     expect(normalizeTarget(' +1 (555) 123-4567 ')).toBe('+15551234567')
     expect(normalizeTarget(' opaque-token ')).toBe('opaque-token')
     expect(normalizeTarget('   ')).toBe('')
+    expect(() => normalizeEmail(123 as unknown as string)).toThrow('Email must be a string.')
+    expect(() => normalizePhone(123 as unknown as string)).toThrow('Phone must be a string.')
+    expect(() => normalizeTarget(123 as unknown as string)).toThrow('Target must be a string.')
     expect(compatibilityAuthNormalizer.normalizeEmail(' Alice@Example.COM ')).toBe(
       'alice@example.com',
     )
@@ -86,6 +89,23 @@ describe('public utility coverage', () => {
         normalizePhone: (phone) => phone.replace(/\s+/g, '').trim(),
       }).normalizeTarget(' Alice@Example.COM '),
     ).toBe('ALICE@EXAMPLE.COM')
+    expect(
+      createAuthNormalizer(Object.assign(Object.create(null), {})).normalizeTarget(' A@B '),
+    ).toBe('a@b')
+    expect(() => createAuthNormalizer(null as unknown as object)).toThrow(
+      'Normalizer options must be a plain object.',
+    )
+    expect(() =>
+      createAuthNormalizer({ normalizeEmail: 'email' as unknown as (value: string) => string }),
+    ).toThrow('Email normalizer must be a function.')
+    expect(() =>
+      createAuthNormalizer({ normalizePhone: 'phone' as unknown as (value: string) => string }),
+    ).toThrow('Phone normalizer must be a function.')
+    expect(() =>
+      createAuthNormalizer({
+        normalizeTarget: 'target' as unknown as (value: string) => string,
+      }),
+    ).toThrow('Target normalizer must be a function.')
 
     const generatedSecret = generateSecret(8)
     const generatedOtpSecret = generateOtpSecret()
@@ -168,6 +188,13 @@ describe('public utility coverage', () => {
       'Scrypt maxmem must be a positive integer.',
     )
     expect(addSeconds(now, 5)).toEqual(new Date('2026-01-01T00:00:05.000Z'))
+    expect(() => addSeconds(new Date(Number.NaN), 5)).toThrow('Date must be valid.')
+    expect(() => addSeconds(now, Number.POSITIVE_INFINITY)).toThrow(
+      'Seconds must be a finite number.',
+    )
+    expect(() => addSeconds(now, '5' as unknown as number)).toThrow(
+      'Seconds must be a finite number.',
+    )
     expect(systemClock.now()).toBeInstanceOf(Date)
     expect(() => getUniAuthAttributionNotice({ productName: 123 as unknown as string })).toThrow(
       'Attribution product name must be a string.',


### PR DESCRIPTION
## Summary
- validate public normalizer inputs before string operations
- validate custom normalizer options before storing callbacks
- reject invalid date and seconds values in addSeconds

## Verification
- npm run check

Closes #397
Closes #398