### PR TITLE
Fix provider runtime input validation

### DIFF
--- a/src/providers/messenger/payload.ts
+++ b/src/providers/messenger/payload.ts
@@ -25,6 +25,10 @@ export function readWebAppInitData(input: FinishInput): string {
 }
 
 export function normalizeMaxWebAppInitData(value: string): string {
+  if (typeof value !== 'string') {
+    throw invalidInput('MAX WebApp init data must be a string.')
+  }
+
   return isMaxWebAppDataContainer(value) ? extractMaxWebAppInitData(value) : value
 }
 

--- a/src/providers/messenger/provider.ts
+++ b/src/providers/messenger/provider.ts
@@ -4,6 +4,7 @@ import type {
   ProviderIdentityAssertion,
 } from '../../domain/types.js'
 import type { AuthProvider, Clock } from '../../contracts.js'
+import { invalidInput } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
 import { MAX_WEBAPP_PROVIDER_ID, TELEGRAM_MINI_APP_PROVIDER_ID } from './constants.js'
 import { normalizeMaxWebAppInitData, readWebAppInitData } from './payload.js'
@@ -11,7 +12,12 @@ import {
   type SignedWebAppInitDataValidationResult,
   validateSignedWebAppInitData,
 } from './signed-webapp.js'
-import { invalidSignedWebAppInitData, isRecord, readString } from './support.js'
+import {
+  invalidSignedWebAppInitData,
+  isRecord,
+  readString,
+  requireNonBlankString,
+} from './support.js'
 
 export interface MessengerWebAppProviderOptions {
   readonly botToken: string
@@ -32,17 +38,21 @@ interface MessengerWebAppUser {
 export function createTelegramMiniAppProvider(
   options: MessengerWebAppProviderOptions,
 ): AuthProvider {
+  const providerOptions = normalizeMessengerWebAppProviderOptions(options)
+
   return createMessengerWebAppProvider({
-    ...options,
-    providerId: options.providerId ?? TELEGRAM_MINI_APP_PROVIDER_ID,
+    ...providerOptions,
+    providerId: providerOptions.providerId ?? TELEGRAM_MINI_APP_PROVIDER_ID,
     resolveInitData: (value) => value,
   })
 }
 
 export function createMaxWebAppProvider(options: MessengerWebAppProviderOptions): AuthProvider {
+  const providerOptions = normalizeMessengerWebAppProviderOptions(options)
+
   return createMessengerWebAppProvider({
-    ...options,
-    providerId: options.providerId ?? MAX_WEBAPP_PROVIDER_ID,
+    ...providerOptions,
+    providerId: providerOptions.providerId ?? MAX_WEBAPP_PROVIDER_ID,
     resolveInitData: normalizeMaxWebAppInitData,
   })
 }
@@ -53,20 +63,47 @@ function createMessengerWebAppProvider(
     readonly resolveInitData: (value: string) => string
   },
 ): AuthProvider {
+  const providerId = requireNonBlankString(options.providerId, 'Messenger provider id is required.')
+  const botToken = requireNonBlankString(options.botToken, 'Bot token is required.')
+
   return {
-    id: options.providerId,
+    id: providerId,
     async finish(input: FinishInput): Promise<ProviderIdentityAssertion> {
       const initData = options.resolveInitData(readWebAppInitData(input))
       const validated = validateSignedWebAppInitData({
         initData,
-        botToken: options.botToken,
+        botToken,
         ...optionalProp('now', options.clock?.now()),
         ...optionalProp('maxAgeSeconds', options.maxAgeSeconds),
       })
 
-      return mapMessengerWebAppAssertion(options.providerId, validated)
+      return mapMessengerWebAppAssertion(providerId, validated)
     },
   }
+}
+
+function normalizeMessengerWebAppProviderOptions(
+  options: MessengerWebAppProviderOptions,
+): MessengerWebAppProviderOptions {
+  if (!isRecord(options)) {
+    throw invalidInput('Messenger provider options are required.')
+  }
+
+  requireNonBlankString(options.botToken, 'Bot token is required.')
+
+  if (options.providerId !== undefined) {
+    requireNonBlankString(options.providerId, 'Messenger provider id is required.')
+  }
+
+  if (options.clock !== undefined && !isClock(options.clock)) {
+    throw invalidInput('Messenger provider clock must provide now().')
+  }
+
+  return options
+}
+
+function isClock(value: unknown): value is Clock {
+  return isRecord(value) && typeof value.now === 'function'
 }
 
 function mapMessengerWebAppAssertion(

--- a/src/providers/oauth-oidc/profile.ts
+++ b/src/providers/oauth-oidc/profile.ts
@@ -1,11 +1,20 @@
 import type { ProviderIdentityAssertion } from '../../domain/types.js'
+import { invalidInput } from '../../errors.js'
 import { optionalProp } from '../../utils/optional.js'
-import { normalizeMetadataRecord, readString, requireNonBlankString } from './support.js'
+import { isRecord, normalizeMetadataRecord, readString, requireNonBlankString } from './support.js'
 import type { OAuthOidcProfileMapperInput } from './types.js'
 
 export function mapOAuthOidcProfileToAssertion(
   input: OAuthOidcProfileMapperInput,
 ): ProviderIdentityAssertion {
+  if (!isRecord(input)) {
+    throw invalidInput('OAuth/OIDC profile mapper input is required.')
+  }
+
+  if (!isRecord(input.profile)) {
+    throw invalidInput('OAuth/OIDC profile is required.')
+  }
+
   const subject = requireNonBlankString(
     input.profile.subject,
     'OAuth/OIDC profile subject is required.',

--- a/src/providers/oauth-oidc/provider.ts
+++ b/src/providers/oauth-oidc/provider.ts
@@ -20,10 +20,31 @@ import type {
 } from './types.js'
 
 export function createOAuthOidcProvider(options: OAuthOidcProviderOptions): AuthProvider {
+  if (!isRecord(options)) {
+    throw invalidInput('OAuth/OIDC provider options are required.')
+  }
+
   const providerId = requireNonBlankString(
     options.providerId,
     'OAuth/OIDC provider id is required.',
   )
+
+  if (!isRecord(options.client)) {
+    throw invalidInput('OAuth/OIDC provider client is required.')
+  }
+
+  if (typeof options.client.exchangeCode !== 'function') {
+    throw invalidInput('OAuth/OIDC provider client exchangeCode is required.')
+  }
+
+  if (typeof options.client.fetchProfile !== 'function') {
+    throw invalidInput('OAuth/OIDC provider client fetchProfile is required.')
+  }
+
+  if (options.mapProfile !== undefined && typeof options.mapProfile !== 'function') {
+    throw invalidInput('OAuth/OIDC profile mapper must be a function.')
+  }
+
   const mapProfile = options.mapProfile ?? mapOAuthOidcProfileToAssertion
 
   return {

--- a/src/providers/oauth-oidc/tokens.ts
+++ b/src/providers/oauth-oidc/tokens.ts
@@ -18,6 +18,10 @@ import type {
 export function createOAuthOidcTokenRecord(
   input: CreateOAuthOidcTokenRecordInput,
 ): OAuthOidcTokenRecord {
+  if (!isRecord(input)) {
+    throw invalidInput('OAuth/OIDC token record input is required.')
+  }
+
   const provider = requireNonBlankString(
     input.provider,
     'OAuth/OIDC token record provider is required.',

--- a/test/messenger.test.ts
+++ b/test/messenger.test.ts
@@ -9,6 +9,7 @@ import {
   createTelegramMiniAppProvider,
   validateSignedWebAppInitData,
 } from '../src'
+import { normalizeMaxWebAppInitData } from '../src/providers/messenger/payload.js'
 import { createInMemoryAuthKit } from '../src/testing'
 import { now } from './helpers.js'
 
@@ -311,6 +312,22 @@ describe('messenger WebApp providers', () => {
   it('rejects missing payloads and malformed WebApp users', async () => {
     const provider = createTelegramMiniAppProvider({ botToken })
 
+    await expectInvalid(() =>
+      createTelegramMiniAppProvider(
+        null as unknown as Parameters<typeof createTelegramMiniAppProvider>[0],
+      ),
+    )
+    await expectInvalid(() => createTelegramMiniAppProvider({ botToken: '' }))
+    await expectInvalid(() => createTelegramMiniAppProvider({ botToken, providerId: '   ' }))
+    await expectInvalid(() =>
+      createTelegramMiniAppProvider({
+        botToken,
+        clock: { now: 'now' } as unknown as NonNullable<
+          Parameters<typeof createTelegramMiniAppProvider>[0]['clock']
+        >,
+      }),
+    )
+    await expectInvalid(() => normalizeMaxWebAppInitData(123 as unknown as string))
     await expectInvalid(() => provider.finish({}))
     await expectInvalid(() => provider.finish({ payload: { other: true } }))
     await expectInvalid(() => provider.finish({ payload: signInitData({}) }))

--- a/test/oauth-oidc.test.ts
+++ b/test/oauth-oidc.test.ts
@@ -391,6 +391,43 @@ describe('OAuth/OIDC provider contract', () => {
 
   it('rejects incomplete OAuth/OIDC inputs', async () => {
     await expectInvalid(() =>
+      createOAuthOidcProvider(null as unknown as Parameters<typeof createOAuthOidcProvider>[0]),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: undefined as unknown as OAuthOidcClient,
+      }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: {
+          exchangeCode: 'exchange' as unknown as OAuthOidcClient['exchangeCode'],
+          fetchProfile: async () => ({ subject: 'subject' }),
+        },
+      }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: {
+          exchangeCode: async () => ({ accessToken: 'token' }),
+          fetchProfile: 'fetch' as unknown as OAuthOidcClient['fetchProfile'],
+        },
+      }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcProvider({
+        providerId: 'oauth',
+        client: new RecordingOAuthOidcClient({ accessToken: 'token' }, { subject: 'subject' }),
+        mapProfile: 'mapper' as unknown as NonNullable<
+          Parameters<typeof createOAuthOidcProvider>[0]['mapProfile']
+        >,
+      }),
+    )
+
+    await expectInvalid(() =>
       createOAuthOidcProvider({
         providerId: '',
         client: new RecordingOAuthOidcClient({ accessToken: 'token' }, { subject: 'subject' }),
@@ -547,6 +584,26 @@ describe('OAuth/OIDC provider contract', () => {
           refreshToken: 'refresh-token',
         },
         metadata: new Date() as unknown as Record<string, unknown>,
+      }),
+    )
+    await expectInvalid(() =>
+      createOAuthOidcTokenRecord(
+        null as unknown as Parameters<typeof createOAuthOidcTokenRecord>[0],
+      ),
+    )
+    await expectInvalid(() =>
+      mapOAuthOidcProfileToAssertion(
+        null as unknown as Parameters<typeof mapOAuthOidcProfileToAssertion>[0],
+      ),
+    )
+    await expectInvalid(() =>
+      mapOAuthOidcProfileToAssertion({
+        provider: 'oauth',
+        profile: null as unknown as OAuthOidcProfile,
+        finishInput: {},
+        exchangeInput: {
+          code: 'code',
+        },
       }),
     )
   })


### PR DESCRIPTION
## Summary
- validate OAuth/OIDC provider, mapper, and token record runtime inputs before property access
- validate messenger provider options and MAX init data before string/object operations
- cover malformed provider boundary inputs in tests

## Verification
- npm run check

Closes #400
Closes #401