### PR TITLE
Harden runtime boundaries across adapters and stores

### DIFF
--- a/src/bridges/authjs.ts
+++ b/src/bridges/authjs.ts
@@ -7,6 +7,7 @@ import { invalidInput } from '../errors.js'
 import { optionalProp } from '../utils/optional.js'
 import {
   buildMetadata,
+  isPlainRecord,
   readBooleanLike,
   readString,
   requireMatchingStrings,
@@ -53,6 +54,14 @@ export interface AuthJsOAuthAssertionInput {
 export function mapAuthJsOAuthToAssertion(
   input: AuthJsOAuthAssertionInput,
 ): ProviderIdentityAssertion {
+  if (!isPlainRecord(input as unknown)) {
+    throw invalidInput('Auth.js bridge input is required.')
+  }
+
+  if (!isPlainRecord(input.account as unknown)) {
+    throw invalidInput('Auth.js account is required.')
+  }
+
   const accountType = readString(input.account.type)?.toLowerCase()
 
   if (accountType && !AUTH_JS_OAUTH_ACCOUNT_TYPES.has(accountType)) {

--- a/src/bridges/better-auth.ts
+++ b/src/bridges/better-auth.ts
@@ -5,7 +5,13 @@ import type {
 } from '../domain/types.js'
 import { invalidInput } from '../errors.js'
 import { optionalProp } from '../utils/optional.js'
-import { buildMetadata, readBooleanLike, readString, requireMatchingStrings } from './support.js'
+import {
+  buildMetadata,
+  isPlainRecord,
+  readBooleanLike,
+  readString,
+  requireMatchingStrings,
+} from './support.js'
 
 export interface BetterAuthAccount {
   readonly providerId?: string
@@ -39,6 +45,10 @@ export interface BetterAuthOAuthAssertionInput {
 export function mapBetterAuthOAuthToAssertion(
   input: BetterAuthOAuthAssertionInput,
 ): ProviderIdentityAssertion {
+  if (!isPlainRecord(input as unknown)) {
+    throw invalidInput('Better Auth bridge input is required.')
+  }
+
   const frameworkProviderId = readString(input.account?.providerId)
   const provider = readString(input.providerId) ?? frameworkProviderId
 

--- a/src/bridges/support.ts
+++ b/src/bridges/support.ts
@@ -78,7 +78,7 @@ function requirePlainRecord(value: unknown, message: string): Record<string, unk
   return value
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return false
   }

--- a/src/ports/rate-limit.ts
+++ b/src/ports/rate-limit.ts
@@ -49,6 +49,10 @@ export interface OtpSecretGeneratorInput {
 export type OtpSecretGenerator = (input: OtpSecretGeneratorInput) => string | Promise<string>
 
 export function rateLimitKey(...parts: readonly string[]): string {
+  if (parts.some((part) => typeof part !== 'string')) {
+    throw new Error('Rate-limit key parts must be strings.')
+  }
+
   return JSON.stringify(parts)
 }
 
@@ -71,6 +75,10 @@ export function isRateLimitedErrorDetails(input: unknown): input is RateLimitedE
   }
 
   if (resetAt !== undefined && typeof resetAt !== 'string') {
+    return false
+  }
+
+  if (typeof resetAt === 'string' && Number.isNaN(new Date(resetAt).getTime())) {
     return false
   }
 

--- a/src/postgres/store/shared.ts
+++ b/src/postgres/store/shared.ts
@@ -290,6 +290,10 @@ function isForeignKeyViolation(error: unknown): boolean {
 
 function readDate(value: Date | string): Date {
   if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new Error('Invalid date value returned from Postgres.')
+    }
+
     return value
   }
 
@@ -318,7 +322,14 @@ function readJsonObject(
   }
 
   if (typeof value === 'string') {
-    const parsed = JSON.parse(value) as unknown
+    let parsed: unknown
+
+    try {
+      parsed = JSON.parse(value) as unknown
+    } catch {
+      throw new Error('Expected a JSON object returned from Postgres.')
+    }
+
     return ensureRecord(parsed)
   }
 

--- a/src/testing/in-memory/kit.ts
+++ b/src/testing/in-memory/kit.ts
@@ -4,6 +4,7 @@ import {
   type DefaultAuthServiceOptions,
 } from '../../application/auth-service.js'
 import { optionalProp } from '../../application/optional.js'
+import { invalidInput } from '../../errors.js'
 import type { AuthPolicy } from '../../application/policy.js'
 import type {
   AuthNormalizer,
@@ -60,6 +61,10 @@ interface InMemoryAuthKitResult {
 export function createInMemoryAuthKit(
   options: CreateInMemoryAuthKitOptions = {},
 ): InMemoryAuthKitResult {
+  if (!isOptionsRecord(options)) {
+    throw invalidInput('In-memory auth kit options must be a plain object.')
+  }
+
   const store = new InMemoryAuthStore({
     ...optionalProp('normalizer', options.normalizer),
   })
@@ -100,4 +105,13 @@ export function createInMemoryAuthKit(
     passwordHasher,
     idGenerator,
   }
+}
+
+function isOptionsRecord(value: unknown): value is CreateInMemoryAuthKitOptions {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/src/testing/in-memory/support.ts
+++ b/src/testing/in-memory/support.ts
@@ -44,6 +44,10 @@ export class InMemoryPasswordHasher implements PasswordHasher {
   }
 
   async verify(password: string, passwordHash: string): Promise<boolean> {
+    if (typeof password !== 'string' || typeof passwordHash !== 'string') {
+      return false
+    }
+
     if (!passwordHash.startsWith(TEST_PASSWORD_HASH_PREFIX)) {
       return false
     }

--- a/src/testing/providers.ts
+++ b/src/testing/providers.ts
@@ -1,11 +1,20 @@
 import type { AuthIdentityProvider, ProviderIdentityAssertion } from '../domain/types.js'
 import type { AuthProvider, ProviderRegistry } from '../contracts.js'
+import { invalidInput } from '../errors.js'
 
 export class StaticAuthProvider implements AuthProvider {
   readonly id: AuthIdentityProvider
   private assertion: ProviderIdentityAssertion
 
   constructor(id: AuthIdentityProvider, assertion: Omit<ProviderIdentityAssertion, 'provider'>) {
+    if (typeof id !== 'string' || !id.trim()) {
+      throw invalidInput('Static auth provider id is required.')
+    }
+
+    if (!isRecord(assertion)) {
+      throw invalidInput('Static auth provider assertion is required.')
+    }
+
     this.id = id
     this.assertion = { provider: id, ...assertion }
   }
@@ -16,6 +25,10 @@ export class StaticAuthProvider implements AuthProvider {
 
   /** Replace the next assertion returned by this test provider. */
   setAssertion(assertion: Omit<ProviderIdentityAssertion, 'provider'>): void {
+    if (!isRecord(assertion)) {
+      throw invalidInput('Static auth provider assertion is required.')
+    }
+
     this.assertion = { provider: this.id, ...assertion }
   }
 }
@@ -24,10 +37,22 @@ export class InMemoryProviderRegistry implements ProviderRegistry {
   private readonly providers = new Map<AuthIdentityProvider, AuthProvider>()
 
   register(provider: AuthProvider): void {
+    if (!isRecord(provider) || typeof provider.id !== 'string' || !provider.id.trim()) {
+      throw invalidInput('Provider registry provider id is required.')
+    }
+
+    if (typeof provider.finish !== 'function') {
+      throw invalidInput('Provider registry provider finish is required.')
+    }
+
     this.providers.set(provider.id, provider)
   }
 
   async get(provider: AuthIdentityProvider): Promise<AuthProvider | undefined> {
     return this.providers.get(provider)
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/test/bridges.test.ts
+++ b/test/bridges.test.ts
@@ -74,6 +74,28 @@ describe('auth bridge helpers', () => {
   it('rejects Auth.js non-oauth accounts and mismatched subjects', async () => {
     await expect(
       catchError(() =>
+        mapAuthJsOAuthToAssertion(
+          null as unknown as Parameters<typeof mapAuthJsOAuthToAssertion>[0],
+        ),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Auth.js bridge input is required.',
+    })
+
+    await expect(
+      catchError(() =>
+        mapAuthJsOAuthToAssertion({
+          account: null as unknown as Parameters<typeof mapAuthJsOAuthToAssertion>[0]['account'],
+        }),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Auth.js account is required.',
+    })
+
+    await expect(
+      catchError(() =>
         mapAuthJsOAuthToAssertion({
           account: {
             provider: 'credentials',
@@ -286,6 +308,17 @@ describe('auth bridge helpers', () => {
   })
 
   it('rejects Better Auth inputs without a stable provider id or with conflicting subjects', async () => {
+    await expect(
+      catchError(() =>
+        mapBetterAuthOAuthToAssertion(
+          null as unknown as Parameters<typeof mapBetterAuthOAuthToAssertion>[0],
+        ),
+      ),
+    ).resolves.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+      message: 'Better Auth bridge input is required.',
+    })
+
     await expect(
       catchError(() =>
         mapBetterAuthOAuthToAssertion({

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -19,7 +19,13 @@ import {
   type Session,
   type Verification,
 } from '../src'
-import { InMemoryAuthStore, InMemoryPasswordHasher } from '../src/testing'
+import {
+  createInMemoryAuthKit,
+  InMemoryAuthStore,
+  InMemoryPasswordHasher,
+  InMemoryProviderRegistry,
+  StaticAuthProvider,
+} from '../src/testing'
 import { identity, now, user } from './helpers.js'
 
 describe('InMemoryAuthStore', () => {
@@ -433,5 +439,43 @@ describe('InMemoryAuthStore', () => {
     expect(await passwordHasher.verify('correct-password', 'sha256:not-a-password-hash')).toBe(
       false,
     )
+    expect(await passwordHasher.verify(123 as unknown as string, passwordHash)).toBe(false)
+    expect(await passwordHasher.verify('correct-password', 123 as unknown as string)).toBe(false)
+  })
+
+  it('rejects malformed in-memory testing helper inputs', () => {
+    expect(() =>
+      createInMemoryAuthKit(null as unknown as Parameters<typeof createInMemoryAuthKit>[0]),
+    ).toThrow('In-memory auth kit options must be a plain object.')
+
+    expect(
+      () =>
+        new StaticAuthProvider('', {
+          providerUserId: 'user-1',
+        }),
+    ).toThrow('Static auth provider id is required.')
+    expect(
+      () =>
+        new StaticAuthProvider(
+          'static',
+          null as unknown as ConstructorParameters<typeof StaticAuthProvider>[1],
+        ),
+    ).toThrow('Static auth provider assertion is required.')
+
+    const provider = new StaticAuthProvider('static', { providerUserId: 'user-1' })
+    expect(() =>
+      provider.setAssertion(null as unknown as Parameters<typeof provider.setAssertion>[0]),
+    ).toThrow('Static auth provider assertion is required.')
+
+    const registry = new InMemoryProviderRegistry()
+    expect(() =>
+      registry.register(null as unknown as Parameters<typeof registry.register>[0]),
+    ).toThrow('Provider registry provider id is required.')
+    expect(() =>
+      registry.register({
+        id: 'static',
+        finish: 'finish' as unknown as Parameters<typeof registry.register>[0]['finish'],
+      }),
+    ).toThrow('Provider registry provider finish is required.')
   })
 })

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -447,6 +447,12 @@ describe('InMemoryAuthStore', () => {
     expect(() =>
       createInMemoryAuthKit(null as unknown as Parameters<typeof createInMemoryAuthKit>[0]),
     ).toThrow('In-memory auth kit options must be a plain object.')
+    expect(() =>
+      createInMemoryAuthKit([] as unknown as Parameters<typeof createInMemoryAuthKit>[0]),
+    ).toThrow('In-memory auth kit options must be a plain object.')
+    expect(createInMemoryAuthKit(Object.assign(Object.create(null), {})).store).toBeInstanceOf(
+      InMemoryAuthStore,
+    )
 
     expect(
       () =>

--- a/test/postgres-store.test.ts
+++ b/test/postgres-store.test.ts
@@ -522,6 +522,16 @@ describe('PostgresAuthStore unit coverage', () => {
       ]),
       result([
         userRow({
+          created_at: new Date('invalid'),
+        }),
+      ]),
+      result([
+        userRow({
+          metadata: '{',
+        }),
+      ]),
+      result([
+        userRow({
           metadata: '[]',
         }),
       ]),
@@ -552,6 +562,12 @@ describe('PostgresAuthStore unit coverage', () => {
     ).rejects.toThrow('Expected a database row to be returned.')
     await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
       'Invalid date value returned from Postgres.',
+    )
+    await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
+      'Invalid date value returned from Postgres.',
+    )
+    await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
+      'Expected a JSON object returned from Postgres.',
     )
     await expect(store.userRepo.findById(asUserId('user-1'))).rejects.toThrow(
       'Expected a JSON object returned from Postgres.',

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -13,6 +13,9 @@ import { assertion, now, rateLimitKey } from './helpers.js'
 describe('rate-limit integration', () => {
   it('builds unambiguous keys for arbitrary rate-limit parts', () => {
     expect(rateLimitKey('a', 'b\u0000c')).not.toBe(rateLimitKey('a\u0000b', 'c'))
+    expect(() => rateLimitKey('a', 1 as unknown as string)).toThrow(
+      'Rate-limit key parts must be strings.',
+    )
   })
 
   it('denies provider sign-in before creating a user, identity, or session', async () => {

--- a/test/resend-window.test.ts
+++ b/test/resend-window.test.ts
@@ -254,6 +254,12 @@ describe('verification resend window and rate-limit helpers', () => {
     expect(
       isRateLimitedErrorDetails({
         action: RateLimitAction.OtpStart,
+        resetAt: 'not-a-date',
+      }),
+    ).toBe(false)
+    expect(
+      isRateLimitedErrorDetails({
+        action: RateLimitAction.OtpStart,
         retryAfterSeconds: 15,
         resetAt: now.toISOString(),
       }),


### PR DESCRIPTION
## Summary
- validate auth bridge and rate-limit helper runtime inputs before low-level operations
- validate public in-memory testing helpers and fail closed for malformed password verification inputs
- normalize Postgres mapper errors for invalid dates and malformed JSON payloads

## Verification
- npm run check

Closes #403
Closes #404
Closes #405
Closes #406