### PR TITLE
Harden application runtime validation

### DIFF
--- a/src/application/policy.ts
+++ b/src/application/policy.ts
@@ -4,6 +4,7 @@ import {
   type AuthPolicyAction as AuthPolicyActionType,
 } from '../domain/policy.js'
 import type { AuthIdentity, ProviderIdentityAssertion, User, UserId } from '../domain/types.js'
+import { invalidInput } from '../errors.js'
 
 export type MaybePromise<T> = T | Promise<T>
 
@@ -55,10 +56,28 @@ export interface DefaultAuthPolicyOptions {
 }
 
 export function createDefaultAuthPolicy(options: DefaultAuthPolicyOptions = {}): AuthPolicy {
+  if (!isPolicyOptions(options)) {
+    throw invalidInput('Default auth policy options must be a plain object.')
+  }
+
+  if (
+    options.requireReAuthFor !== undefined &&
+    (!Array.isArray(options.requireReAuthFor) ||
+      options.requireReAuthFor.some((action) => typeof action !== 'string' || !action.trim()))
+  ) {
+    throw invalidInput('Default auth policy re-auth actions must be non-blank strings.')
+  }
+
+  const reAuthMaxAgeSeconds = options.reAuthMaxAgeSeconds ?? 15 * 60
+
+  if (!Number.isFinite(reAuthMaxAgeSeconds) || reAuthMaxAgeSeconds < 0) {
+    throw invalidInput('Default auth policy re-auth max age must be a non-negative number.')
+  }
+
   const requireReAuthFor = new Set<AuthPolicyActionType>(
     options.requireReAuthFor ?? [AuthPolicyAction.MergeAccounts, AuthPolicyAction.CloseAccount],
   )
-  const reAuthMaxAgeMs = (options.reAuthMaxAgeSeconds ?? 15 * 60) * 1000
+  const reAuthMaxAgeMs = reAuthMaxAgeSeconds * 1000
 
   return {
     canAutoLink(): boolean {
@@ -74,12 +93,27 @@ export function createDefaultAuthPolicy(options: DefaultAuthPolicyOptions = {}):
       return options.allowMergeAccounts === true
     },
     requiresReAuth(context): boolean {
+      if (!isRecord(context)) {
+        throw invalidInput('Default auth policy re-auth context is required.')
+      }
+
       if (!requireReAuthFor.has(context.action)) {
         return false
       }
 
+      if (!(context.now instanceof Date) || Number.isNaN(context.now.getTime())) {
+        throw invalidInput('Default auth policy re-auth time is invalid.')
+      }
+
       if (!context.reAuthenticatedAt) {
         return true
+      }
+
+      if (
+        !(context.reAuthenticatedAt instanceof Date) ||
+        Number.isNaN(context.reAuthenticatedAt.getTime())
+      ) {
+        throw invalidInput('Default auth policy re-auth timestamp is invalid.')
       }
 
       return context.now.getTime() - context.reAuthenticatedAt.getTime() > reAuthMaxAgeMs
@@ -88,3 +122,16 @@ export function createDefaultAuthPolicy(options: DefaultAuthPolicyOptions = {}):
 }
 
 export const defaultAuthPolicy: AuthPolicy = createDefaultAuthPolicy()
+
+function isPolicyOptions(value: unknown): value is DefaultAuthPolicyOptions {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/application/runtime-defaults.ts
+++ b/src/application/runtime-defaults.ts
@@ -75,7 +75,7 @@ function getRepositoryUnitOfWork(repos: AuthServiceRepositories): UnitOfWork | u
 }
 
 function assertRepositories(repos: unknown): asserts repos is AuthServiceRepositories {
-  if (!isRecord(repos)) {
+  if (!isObject(repos)) {
     throw invalidInput('Auth service repositories are required.')
   }
 
@@ -112,7 +112,7 @@ function assertRepositories(repos: unknown): asserts repos is AuthServiceReposit
 }
 
 function assertRepo(value: unknown, methods: readonly string[], name: string): void {
-  if (!isRecord(value)) {
+  if (!isObject(value)) {
     throw invalidInput(`${name} is required.`)
   }
 
@@ -124,10 +124,18 @@ function assertRepo(value: unknown, methods: readonly string[], name: string): v
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+  if (!isObject(value)) {
     return false
   }
 
   const prototype = Object.getPrototypeOf(value)
   return prototype === Object.prototype || prototype === null
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  return true
 }

--- a/src/application/runtime-defaults.ts
+++ b/src/application/runtime-defaults.ts
@@ -2,6 +2,7 @@ import { optionalProp } from './optional.js'
 import type { AuthPolicy } from './policy.js'
 import { defaultAuthPolicy } from './policy.js'
 import type { AuthServiceRuntime } from './runtime.js'
+import { invalidInput } from '../errors.js'
 import type {
   AuthServiceInfrastructure,
   AuthServiceRepositories,
@@ -36,6 +37,12 @@ export interface DefaultAuthServiceOptions extends AuthServiceInfrastructure {
 }
 
 export function createAuthServiceRuntime(options: DefaultAuthServiceOptions): AuthServiceRuntime {
+  if (!isRecord(options)) {
+    throw invalidInput('Auth service options must be a plain object.')
+  }
+
+  assertRepositories(options.repos)
+
   return {
     repos: options.repos,
     ...optionalProp('emailSender', options.emailSender),
@@ -65,4 +72,62 @@ function getRepositoryUnitOfWork(repos: AuthServiceRepositories): UnitOfWork | u
   return typeof candidate.run === 'function'
     ? { run: (operation) => candidate.run!(operation) }
     : undefined
+}
+
+function assertRepositories(repos: unknown): asserts repos is AuthServiceRepositories {
+  if (!isRecord(repos)) {
+    throw invalidInput('Auth service repositories are required.')
+  }
+
+  assertRepo(repos.userRepo, ['findById', 'create', 'update'], 'User repository')
+  assertRepo(
+    repos.identityRepo,
+    [
+      'findById',
+      'findByProviderUserId',
+      'findByVerifiedEmail',
+      'findByVerifiedPhone',
+      'listByUserId',
+      'create',
+      'update',
+    ],
+    'Identity repository',
+  )
+  assertRepo(
+    repos.credentialRepo,
+    ['findPasswordByEmail', 'findPasswordByUserId', 'listByUserId', 'create', 'update'],
+    'Credential repository',
+  )
+  assertRepo(
+    repos.verificationRepo,
+    ['findById', 'findByIdForUpdate', 'create', 'update'],
+    'Verification repository',
+  )
+  assertRepo(
+    repos.sessionRepo,
+    ['findById', 'findByTokenHash', 'listByUserId', 'create', 'update'],
+    'Session repository',
+  )
+  assertRepo(repos.auditLogRepo, ['append', 'list'], 'Audit log repository')
+}
+
+function assertRepo(value: unknown, methods: readonly string[], name: string): void {
+  if (!isRecord(value)) {
+    throw invalidInput(`${name} is required.`)
+  }
+
+  for (const method of methods) {
+    if (typeof value[method] !== 'function') {
+      throw invalidInput(`${name} ${method} is required.`)
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }

--- a/src/domain/rules.ts
+++ b/src/domain/rules.ts
@@ -1,5 +1,6 @@
 import type { AuthIdentity, Session, User, Verification } from './entities.js'
 import { AuthIdentityStatus, SessionStatus, VerificationStatus } from './kinds.js'
+import { invalidInput } from '../errors.js'
 
 export function isActiveUser(user: Pick<User, 'disabledAt'>): boolean {
   return !user.disabledAt
@@ -17,6 +18,9 @@ export function isActiveSession(
   session: Pick<Session, 'status' | 'expiresAt'>,
   now: Date,
 ): boolean {
+  assertRuleDate(session.expiresAt, 'Session expiration time is invalid.')
+  assertRuleDate(now, 'Session comparison time is invalid.')
+
   return hasActiveSessionStatus(session) && session.expiresAt.getTime() > now.getTime()
 }
 
@@ -28,6 +32,9 @@ export function isExpiredVerification(
   verification: Pick<Verification, 'expiresAt'>,
   now: Date,
 ): boolean {
+  assertRuleDate(verification.expiresAt, 'Verification expiration time is invalid.')
+  assertRuleDate(now, 'Verification comparison time is invalid.')
+
   return verification.expiresAt.getTime() <= now.getTime()
 }
 
@@ -36,4 +43,10 @@ export function isUsableVerification(
   now: Date,
 ): boolean {
   return !isConsumedVerification(verification) && !isExpiredVerification(verification, now)
+}
+
+function assertRuleDate(value: unknown, message: string): asserts value is Date {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw invalidInput(message)
+  }
 }

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -220,6 +220,12 @@ describe('public utility coverage', () => {
     })
 
     await expect(runtime.transaction.run(async () => 'immediate')).resolves.toBe('immediate')
+    await expect(
+      createAuthServiceRuntime({ repos: store }).transaction.run(async () => 'repository'),
+    ).resolves.toBe('repository')
+    expect(
+      createAuthServiceRuntime(Object.assign(Object.create(null), { repos: store })).repos.userRepo,
+    ).toBe(store.userRepo)
     expect(() =>
       createAuthServiceRuntime(null as unknown as Parameters<typeof createAuthServiceRuntime>[0]),
     ).toThrow('Auth service options must be a plain object.')
@@ -240,6 +246,18 @@ describe('public utility coverage', () => {
         } as unknown as Parameters<typeof createAuthServiceRuntime>[0]['repos'],
       }),
     ).toThrow('User repository update is required.')
+    expect(() =>
+      createAuthServiceRuntime({
+        repos: {
+          userRepo: store.userRepo,
+          identityRepo: store.identityRepo,
+          credentialRepo: store.credentialRepo,
+          verificationRepo: store.verificationRepo,
+          sessionRepo: store.sessionRepo,
+          auditLogRepo: null,
+        } as unknown as Parameters<typeof createAuthServiceRuntime>[0]['repos'],
+      }),
+    ).toThrow('Audit log repository is required.')
     expect(() =>
       createAuthService({
         repos: null as unknown as Parameters<typeof createAuthService>[0]['repos'],

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -12,6 +12,7 @@ import {
   asSessionId,
   asUserId,
   asVerificationId,
+  createAuthService,
   createDefaultAuthPolicy,
   createHmacSecretHasher,
   createScryptSecretHasher,
@@ -219,6 +220,31 @@ describe('public utility coverage', () => {
     })
 
     await expect(runtime.transaction.run(async () => 'immediate')).resolves.toBe('immediate')
+    expect(() =>
+      createAuthServiceRuntime(null as unknown as Parameters<typeof createAuthServiceRuntime>[0]),
+    ).toThrow('Auth service options must be a plain object.')
+    expect(() =>
+      createAuthServiceRuntime({
+        repos: null as unknown as Parameters<typeof createAuthServiceRuntime>[0]['repos'],
+      }),
+    ).toThrow('Auth service repositories are required.')
+    expect(() =>
+      createAuthServiceRuntime({
+        repos: {
+          userRepo: { ...store.userRepo, update: undefined },
+          identityRepo: store.identityRepo,
+          credentialRepo: store.credentialRepo,
+          verificationRepo: store.verificationRepo,
+          sessionRepo: store.sessionRepo,
+          auditLogRepo: store.auditLogRepo,
+        } as unknown as Parameters<typeof createAuthServiceRuntime>[0]['repos'],
+      }),
+    ).toThrow('User repository update is required.')
+    expect(() =>
+      createAuthService({
+        repos: null as unknown as Parameters<typeof createAuthService>[0]['repos'],
+      }),
+    ).toThrow('Auth service repositories are required.')
   })
 
   it('covers default policy and error helper branches', () => {

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -312,6 +312,42 @@ describe('public utility coverage', () => {
         targetIdentities: [],
       }),
     ).toBe(true)
+    expect(
+      createDefaultAuthPolicy(Object.assign(Object.create(null), {})).canAutoLink({
+        assertion: assertion(),
+        targetUser: user(),
+        existingIdentities: [],
+      }),
+    ).toBe(false)
+    expect(() => createDefaultAuthPolicy(null as unknown as object)).toThrow(
+      'Default auth policy options must be a plain object.',
+    )
+    expect(() =>
+      createDefaultAuthPolicy({ requireReAuthFor: [''] as unknown as AuthPolicyAction[] }),
+    ).toThrow('Default auth policy re-auth actions must be non-blank strings.')
+    expect(() =>
+      createDefaultAuthPolicy({ reAuthMaxAgeSeconds: Number.POSITIVE_INFINITY }),
+    ).toThrow('Default auth policy re-auth max age must be a non-negative number.')
+    expect(() =>
+      defaultPolicy.requiresReAuth(
+        null as unknown as Parameters<typeof defaultPolicy.requiresReAuth>[0],
+      ),
+    ).toThrow('Default auth policy re-auth context is required.')
+    expect(() =>
+      defaultPolicy.requiresReAuth({
+        action: AuthPolicyAction.MergeAccounts,
+        userId: asUserId('user-1'),
+        now: new Date('invalid'),
+      }),
+    ).toThrow('Default auth policy re-auth time is invalid.')
+    expect(() =>
+      defaultPolicy.requiresReAuth({
+        action: AuthPolicyAction.MergeAccounts,
+        userId: asUserId('user-1'),
+        now,
+        reAuthenticatedAt: new Date('invalid'),
+      }),
+    ).toThrow('Default auth policy re-auth timestamp is invalid.')
 
     const error = new UniAuthError(UniAuthErrorCode.InvalidInput, 'Invalid.', { field: 'email' })
 

--- a/test/domain-rules.test.ts
+++ b/test/domain-rules.test.ts
@@ -44,6 +44,12 @@ describe('domain rules', () => {
     expect(isActiveSession(activeSession, now)).toBe(true)
     expect(isActiveSession({ ...activeSession, expiresAt: now }, now)).toBe(false)
     expect(isActiveSession({ ...activeSession, status: SessionStatus.Revoked }, now)).toBe(false)
+    expect(() =>
+      isActiveSession({ ...activeSession, expiresAt: new Date('invalid') }, now),
+    ).toThrow('Session expiration time is invalid.')
+    expect(() => isActiveSession(activeSession, new Date('invalid'))).toThrow(
+      'Session comparison time is invalid.',
+    )
   })
 
   it('detects consumed and expired verifications', () => {
@@ -65,5 +71,11 @@ describe('domain rules', () => {
     )
     expect(isExpiredVerification({ ...verification, expiresAt: now }, now)).toBe(true)
     expect(isUsableVerification({ ...verification, expiresAt: now }, now)).toBe(false)
+    expect(() =>
+      isExpiredVerification({ ...verification, expiresAt: new Date('invalid') }, now),
+    ).toThrow('Verification expiration time is invalid.')
+    expect(() => isExpiredVerification(verification, new Date('invalid'))).toThrow(
+      'Verification comparison time is invalid.',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- validate default policy options and re-auth date inputs
- validate auth service runtime options and repository method groups
- validate domain rule date inputs before comparisons

## Verification
- npm run check

Closes #408
Closes #409
Closes #410