### PR TITLE
Harden runtime input normalization

### DIFF
--- a/src/application/audit-events.ts
+++ b/src/application/audit-events.ts
@@ -45,6 +45,10 @@ export async function getAuditEventPage(
 }
 
 function normalizeAuditEventQuery(input: AuditEventQuery): NormalizedAuditEventQuery {
+  if (!isAuditEventQuery(input)) {
+    throw invalidInput('Audit event query is invalid.')
+  }
+
   const before = input.before ? normalizeAuditEventCursor(input.before) : undefined
   const after = input.after ? normalizeAuditEventCursor(input.after) : undefined
 
@@ -109,4 +113,8 @@ function normalizeAuditEventCursor(input: AuditEventCursor): AuditEventCursor {
     occurredAt,
     id: id as AuditEventCursor['id'],
   }
+}
+
+function isAuditEventQuery(value: unknown): value is AuditEventQuery {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/application/sign-in/assertion.ts
+++ b/src/application/sign-in/assertion.ts
@@ -17,25 +17,41 @@ export async function resolveAssertion(
     readonly finishInput?: FinishInput
   },
 ): Promise<ProviderIdentityAssertion> {
+  if (!(input && typeof input === 'object')) {
+    throw invalidInput('Either assertion or provider finish input is required.')
+  }
+
   if (input.assertion) {
     return normalizeAssertion(runtime, input.assertion)
   }
 
-  if (!input.provider || !input.finishInput) {
+  if (input.provider === undefined || !input.finishInput) {
     throw invalidInput('Either assertion or provider finish input is required.')
   }
+
+  const providerId = normalizeProviderId(input.provider)
 
   if (!runtime.providerRegistry) {
     throw new UniAuthError(UniAuthErrorCode.ProviderNotFound, 'Auth provider was not found.')
   }
 
-  const provider = await runtime.providerRegistry.get(input.provider)
+  const provider = await runtime.providerRegistry.get(providerId)
 
   if (!provider) {
     throw new UniAuthError(UniAuthErrorCode.ProviderNotFound, 'Auth provider was not found.')
   }
 
   return normalizeAssertion(runtime, await provider.finish(input.finishInput))
+}
+
+function normalizeProviderId(value: unknown): string {
+  const provider = normalizeRequiredClaim(value, 'Provider is required.')
+
+  if (!provider || hasControlCharacter(provider)) {
+    throw invalidInput('Provider is required.')
+  }
+
+  return provider
 }
 
 export function normalizeAssertion(

--- a/src/ports/rate-limit.ts
+++ b/src/ports/rate-limit.ts
@@ -15,6 +15,7 @@ export const RateLimitAction = {
 } as const
 
 export type RateLimitAction = (typeof RateLimitAction)[keyof typeof RateLimitAction]
+const RateLimitActions = new Set<string>(Object.values(RateLimitAction))
 
 export interface RateLimitAttempt {
   readonly action: RateLimitAction
@@ -63,7 +64,7 @@ export function isRateLimitedErrorDetails(input: unknown): input is RateLimitedE
 
   const { action, retryAfterSeconds, resetAt } = input as Partial<RateLimitedErrorDetails>
 
-  if (typeof action !== 'string' || !action.trim()) {
+  if (typeof action !== 'string' || !RateLimitActions.has(action)) {
     return false
   }
 

--- a/src/testing/providers.ts
+++ b/src/testing/providers.ts
@@ -7,7 +7,9 @@ export class StaticAuthProvider implements AuthProvider {
   private assertion: ProviderIdentityAssertion
 
   constructor(id: AuthIdentityProvider, assertion: Omit<ProviderIdentityAssertion, 'provider'>) {
-    if (typeof id !== 'string' || !id.trim()) {
+    const providerId = normalizeProviderId(id)
+
+    if (!providerId) {
       throw invalidInput('Static auth provider id is required.')
     }
 
@@ -15,8 +17,8 @@ export class StaticAuthProvider implements AuthProvider {
       throw invalidInput('Static auth provider assertion is required.')
     }
 
-    this.id = id
-    this.assertion = { provider: id, ...assertion }
+    this.id = providerId
+    this.assertion = { provider: providerId, ...assertion }
   }
 
   async finish(): Promise<ProviderIdentityAssertion> {
@@ -37,7 +39,13 @@ export class InMemoryProviderRegistry implements ProviderRegistry {
   private readonly providers = new Map<AuthIdentityProvider, AuthProvider>()
 
   register(provider: AuthProvider): void {
-    if (!isRecord(provider) || typeof provider.id !== 'string' || !provider.id.trim()) {
+    if (!isRecord(provider)) {
+      throw invalidInput('Provider registry provider id is required.')
+    }
+
+    const providerId = normalizeProviderId(provider.id)
+
+    if (!providerId) {
       throw invalidInput('Provider registry provider id is required.')
     }
 
@@ -45,14 +53,28 @@ export class InMemoryProviderRegistry implements ProviderRegistry {
       throw invalidInput('Provider registry provider finish is required.')
     }
 
-    this.providers.set(provider.id, provider)
+    this.providers.set(providerId, provider)
   }
 
   async get(provider: AuthIdentityProvider): Promise<AuthProvider | undefined> {
-    return this.providers.get(provider)
+    const providerId = normalizeProviderId(provider)
+
+    if (!providerId) {
+      throw invalidInput('Provider registry provider id is required.')
+    }
+
+    return this.providers.get(providerId)
   }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeProviderId(value: unknown): AuthIdentityProvider | '' {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return value.trim() as AuthIdentityProvider | ''
 }

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -490,6 +490,18 @@ describe('DefaultAuthService read side and sessions', () => {
       code: UniAuthErrorCode.InvalidInput,
     })
     await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getAuditEvents(null),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getAuditEventPage(123),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
       service.getAuditEvents({
         before: {
           occurredAt: new Date(Number.NaN),

--- a/test/in-memory.test.ts
+++ b/test/in-memory.test.ts
@@ -443,7 +443,7 @@ describe('InMemoryAuthStore', () => {
     expect(await passwordHasher.verify('correct-password', 123 as unknown as string)).toBe(false)
   })
 
-  it('rejects malformed in-memory testing helper inputs', () => {
+  it('rejects malformed in-memory testing helper inputs', async () => {
     expect(() =>
       createInMemoryAuthKit(null as unknown as Parameters<typeof createInMemoryAuthKit>[0]),
     ).toThrow('In-memory auth kit options must be a plain object.')
@@ -479,9 +479,19 @@ describe('InMemoryAuthStore', () => {
     ).toThrow('Provider registry provider id is required.')
     expect(() =>
       registry.register({
+        id: '   ',
+        finish: async () => ({ provider: 'static', providerUserId: 'user-1' }),
+      }),
+    ).toThrow('Provider registry provider id is required.')
+    expect(() =>
+      registry.register({
         id: 'static',
         finish: 'finish' as unknown as Parameters<typeof registry.register>[0]['finish'],
       }),
     ).toThrow('Provider registry provider finish is required.')
+    await expect(registry.get('   ')).rejects.toThrow('Provider registry provider id is required.')
+    await expect(
+      registry.get(123 as unknown as Parameters<typeof registry.get>[0]),
+    ).rejects.toThrow('Provider registry provider id is required.')
   })
 })

--- a/test/provider-policy/provider-resolution-and-validation.test.ts
+++ b/test/provider-policy/provider-resolution-and-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { UniAuthErrorCode, type ProviderIdentityAssertion, createAuthService } from '../../src'
-import { InMemoryAuthStore } from '../../src/testing'
+import { InMemoryAuthStore, StaticAuthProvider, createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from '../helpers.js'
 
 describe('provider resolution and assertion validation failures', () => {
@@ -185,6 +185,47 @@ describe('provider resolution and assertion validation failures', () => {
       identity: {
         metadata: { source: 'assertion' },
       },
+    })
+
+    const { providerRegistry, service } = createInMemoryAuthKit()
+    providerRegistry.register(
+      new StaticAuthProvider(' oidc ', {
+        providerUserId: 'provider-user-1',
+        email: 'person@example.com',
+        emailVerified: true,
+      }),
+    )
+
+    await expect(
+      service.signIn({
+        provider: ' oidc ',
+        finishInput: {},
+        now,
+      }),
+    ).resolves.toMatchObject({
+      identity: {
+        provider: 'oidc',
+        providerUserId: 'provider-user-1',
+      },
+    })
+    await expect(
+      service.signIn({
+        provider: '   ',
+        finishInput: {},
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      service.signIn({
+        // @ts-expect-error runtime validation for untyped callers
+        provider: 123,
+        finishInput: {},
+        now,
+      }),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
     })
   })
 })

--- a/test/provider-policy/provider-resolution-and-validation.test.ts
+++ b/test/provider-policy/provider-resolution-and-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { UniAuthErrorCode, type ProviderIdentityAssertion, createAuthService } from '../../src'
+import { resolveAssertion } from '../../src/application/sign-in/assertion.js'
 import { InMemoryAuthStore, StaticAuthProvider, createInMemoryAuthKit } from '../../src/testing'
 import { assertion, now } from '../helpers.js'
 
@@ -17,6 +18,14 @@ describe('provider resolution and assertion validation failures', () => {
     expect(
       await noRegistryService.signIn({ now }).catch((caught: unknown) => caught),
     ).toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      resolveAssertion(
+        {} as Parameters<typeof resolveAssertion>[0],
+        null as unknown as Parameters<typeof resolveAssertion>[1],
+      ),
+    ).rejects.toMatchObject({
       code: UniAuthErrorCode.InvalidInput,
     })
     expect(

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -6,6 +6,7 @@ import {
   UniAuthErrorCode,
   VerificationPurpose,
   VerificationStatus,
+  isRateLimitedErrorDetails,
 } from '../src'
 import { InMemoryRateLimiter, createInMemoryAuthKit } from '../src/testing'
 import { assertion, now, rateLimitKey } from './helpers.js'
@@ -16,6 +17,19 @@ describe('rate-limit integration', () => {
     expect(() => rateLimitKey('a', 1 as unknown as string)).toThrow(
       'Rate-limit key parts must be strings.',
     )
+  })
+
+  it('recognizes only supported rate-limit error detail actions', () => {
+    expect(isRateLimitedErrorDetails({ action: RateLimitAction.OtpStart })).toBe(true)
+    expect(
+      isRateLimitedErrorDetails({
+        action: RateLimitAction.PasswordSignIn,
+        retryAfterSeconds: 10,
+        resetAt: now.toISOString(),
+      }),
+    ).toBe(true)
+    expect(isRateLimitedErrorDetails({ action: 'custom:action' })).toBe(false)
+    expect(isRateLimitedErrorDetails({ action: ` ${RateLimitAction.OtpStart} ` })).toBe(false)
   })
 
   it('denies provider sign-in before creating a user, identity, or session', async () => {


### PR DESCRIPTION
## Summary
- validate audit event query containers before reading query fields
- normalize provider ids before registry lookup and in testing registry helpers
- restrict rate-limit error details to supported actions

## Verification
- npm run check

Closes #412
Closes #413
Closes #414