### PR TITLE
Validate inspection input containers

### DIFF
--- a/src/application/account-inspection.ts
+++ b/src/application/account-inspection.ts
@@ -6,11 +6,16 @@ import {
   type AccountInspectionSnapshot,
   type GetAccountInspectionSnapshotInput,
 } from '../domain/types.js'
+import { invalidInput } from '../errors.js'
 
 export async function getAccountInspectionSnapshot(
   runtime: AuthServiceRuntime,
   input: GetAccountInspectionSnapshotInput,
 ): Promise<AccountInspectionSnapshot> {
+  if (!isAccountInspectionInput(input)) {
+    throw invalidInput('Account inspection input is required.')
+  }
+
   const account = await getAccountSecuritySnapshot(runtime, input.userId)
   const auditWindow = input.audit
   const auditLimit = auditWindow?.limit ?? input.auditLimit
@@ -26,4 +31,8 @@ export async function getAccountInspectionSnapshot(
     auditEvents: auditPage.events,
     ...(auditPage.nextCursor ? { nextAuditCursor: auditPage.nextCursor } : {}),
   })
+}
+
+function isAccountInspectionInput(value: unknown): value is GetAccountInspectionSnapshotInput {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/src/application/current-account-inspection.ts
+++ b/src/application/current-account-inspection.ts
@@ -11,11 +11,14 @@ import type {
   GetCurrentAccountInspectionSnapshotInput,
 } from '../domain/types.js'
 import { toCurrentAccountInspectionSnapshot } from '../domain/types.js'
+import { invalidInput } from '../errors.js'
 
 export async function getCurrentAccountInspectionSnapshot(
   runtime: AuthServiceRuntime,
   input: GetCurrentAccountInspectionSnapshotInput,
 ): Promise<CurrentAccountInspectionSnapshot> {
+  assertCurrentAccountInspectionInput(input)
+
   const { session, user } = await resolveSessionContext(runtime, input)
   const account = await getAccountSecuritySnapshotForUser(runtime, user)
   const auditWindow = input.audit
@@ -42,6 +45,8 @@ export async function getCurrentAccountClosureExportSnapshot(
   runtime: AuthServiceRuntime,
   input: GetCurrentAccountClosureExportSnapshotInput,
 ): Promise<CurrentAccountClosureExportSnapshot> {
+  assertCurrentAccountInspectionInput(input)
+
   const generatedAt = input.now ?? runtime.clock.now()
   const inspection = await getCurrentAccountInspectionSnapshot(runtime, {
     ...input,
@@ -58,6 +63,8 @@ export async function getCurrentAccountAuditEventPage(
   runtime: AuthServiceRuntime,
   input: GetCurrentAccountAuditEventPageInput,
 ): Promise<AuditEventPage> {
+  assertCurrentAccountInspectionInput(input)
+
   const { user } = await resolveSessionContext(runtime, input)
 
   return getAuditEventPage(runtime, {
@@ -69,4 +76,15 @@ export async function getCurrentAccountAuditEventPage(
     ...(input.after ? { after: input.after } : {}),
     ...(input.limit !== undefined ? { limit: input.limit } : {}),
   })
+}
+
+function assertCurrentAccountInspectionInput(
+  input: unknown,
+): asserts input is
+  | GetCurrentAccountInspectionSnapshotInput
+  | GetCurrentAccountClosureExportSnapshotInput
+  | GetCurrentAccountAuditEventPageInput {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw invalidInput('Current-account inspection input is required.')
+  }
 }

--- a/src/application/session-context.ts
+++ b/src/application/session-context.ts
@@ -3,12 +3,16 @@ import { optionalProp } from './optional.js'
 import { getActiveUser } from './support.js'
 import { resolveSession, touchSession } from './sessions.js'
 import type { ResolveSessionContextInput, ResolvedSessionContext } from '../domain/types.js'
-import { UniAuthError, UniAuthErrorCode, isUniAuthError } from '../errors.js'
+import { UniAuthError, UniAuthErrorCode, invalidInput, isUniAuthError } from '../errors.js'
 
 export async function resolveSessionContext(
   runtime: AuthServiceRuntime,
   input: ResolveSessionContextInput,
 ): Promise<ResolvedSessionContext> {
+  if (!isRecord(input)) {
+    throw invalidInput('Session context input is required.')
+  }
+
   const resolvedSession = await resolveSession(runtime, {
     sessionToken: input.sessionToken,
     ...optionalProp('now', input.now),
@@ -40,4 +44,8 @@ async function getResolvedSessionUser(
 
     throw error
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/test/core/current-account-inspection.test.ts
+++ b/test/core/current-account-inspection.test.ts
@@ -345,6 +345,25 @@ describe('DefaultAuthService current-account inspection helpers', () => {
     const { service, store } = createInMemoryAuthKit()
     const signedIn = await service.signIn({ assertion: assertion(), now })
 
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getCurrentAccountInspectionSnapshot(null),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getCurrentAccountAuditEventPage(123),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getCurrentAccountClosureExportSnapshot([]),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
     await store.userRepo.update(signedIn.user.id, {
       disabledAt: addSeconds(now, 10),
     })

--- a/test/core/read-side-and-sessions.test.ts
+++ b/test/core/read-side-and-sessions.test.ts
@@ -132,6 +132,13 @@ describe('DefaultAuthService read side and sessions', () => {
     const { service, store } = createInMemoryAuthKit()
     const result = await service.signIn({ assertion: assertion(), now })
 
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.resolveSessionContext(null),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
+
     await store.userRepo.update(result.user.id, { disabledAt: addSeconds(now, 10) })
 
     await expect(
@@ -358,6 +365,12 @@ describe('DefaultAuthService read side and sessions', () => {
     expect(
       (await service.getAccountInspectionSnapshot({ userId: signedIn.user.id })).auditEvents,
     ).toHaveLength(3)
+    await expect(
+      // @ts-expect-error runtime validation for untyped callers
+      service.getAccountInspectionSnapshot(null),
+    ).rejects.toMatchObject({
+      code: UniAuthErrorCode.InvalidInput,
+    })
 
     const firstWindow = await service.getAccountInspectionSnapshot({
       userId: signedIn.user.id,


### PR DESCRIPTION
## Summary
- validate session context input containers before reading fields
- validate account inspection input containers before reading audit windows
- validate current-account inspection, export, and audit-page inputs consistently

## Verification
- npm run check

Closes #416
Closes #417
Closes #418