### PR TITLE
ci: переведены workflows на self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, vm1082285, ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, vm1082285, ci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, vm1082285, ci]
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:


### PR DESCRIPTION
Переведены CI, CodeQL и Release Please workflows на self-hosted runners vm1082285.